### PR TITLE
AK-15710 Convert resource Id from int to string

### DIFF
--- a/alkira/resource_alkira_connector_aws_vpc.go
+++ b/alkira/resource_alkira_connector_aws_vpc.go
@@ -2,7 +2,6 @@ package alkira
 
 import (
 	"log"
-	"strconv"
 
 	"github.com/alkiranet/alkira-client-go/alkira"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -38,10 +37,6 @@ func resourceAlkiraConnectorAwsVpc() *schema.Resource {
 				Description: "ID of credential managed by Credential Manager.",
 				Type:        schema.TypeString,
 				Required:    true,
-			},
-			"connector_id": {
-				Type:     schema.TypeInt,
-				Computed: true,
 			},
 			"cxp": {
 				Description: "The CXP where the connector should be provisioned.",
@@ -176,8 +171,7 @@ func resourceConnectorAwsVpcCreate(d *schema.ResourceData, m interface{}) error 
 		return err
 	}
 
-	d.SetId(strconv.Itoa(id))
-	d.Set("connector_id", id)
+	d.SetId(id)
 	return resourceConnectorAwsVpcRead(d, m)
 }
 
@@ -193,7 +187,7 @@ func resourceConnectorAwsVpcDelete(d *schema.ResourceData, m interface{}) error 
 	client := m.(*alkira.AlkiraClient)
 
 	log.Printf("[INFO] Deleting Connector (AWS-VPC) %s", d.Id())
-	err := client.DeleteConnectorAwsVpc(d.Get("connector_id").(int))
+	err := client.DeleteConnectorAwsVpc(d.Id())
 
 	if err != nil {
 		return err

--- a/alkira/resource_alkira_credential_aws_vpc.go
+++ b/alkira/resource_alkira_credential_aws_vpc.go
@@ -33,34 +33,34 @@ func resourceAlkiraCredentialAwsVpc() *schema.Resource {
 				Description: "The name of the credential",
 			},
 			"aws_access_key": &schema.Schema{
-				Type:        schema.TypeString,
-				Optional:    true,
+				Type:     schema.TypeString,
+				Optional: true,
 				DefaultFunc: schema.EnvDefaultFunc(
-                    "AWS_ACCESS_KEY_ID",
+					"AWS_ACCESS_KEY_ID",
 					nil),
 				Description: "AWS access key",
 			},
 			"aws_secret_key": &schema.Schema{
-				Type:        schema.TypeString,
-				Optional:    true,
+				Type:     schema.TypeString,
+				Optional: true,
 				DefaultFunc: schema.EnvDefaultFunc(
-                    "AWS_SECRET_ACCESS_KEY",
+					"AWS_SECRET_ACCESS_KEY",
 					nil),
 				Description: "AWS secret key",
 			},
 			"aws_role_arn": &schema.Schema{
-				Type:        schema.TypeString,
-				Optional:    true,
+				Type:     schema.TypeString,
+				Optional: true,
 				DefaultFunc: schema.EnvDefaultFunc(
-                    "AWS_ROLE_ARN",
+					"AWS_ROLE_ARN",
 					nil),
 				Description: "The AWS Role Arn",
 			},
 			"aws_external_id": &schema.Schema{
-				Type:        schema.TypeString,
-				Optional:    true,
+				Type:     schema.TypeString,
+				Optional: true,
 				DefaultFunc: schema.EnvDefaultFunc(
-                    "AWS_ROLE_EXTERNAL_ID",
+					"AWS_ROLE_EXTERNAL_ID",
 					nil),
 				Description: "The AWS Role External ID",
 			},

--- a/alkira/resource_alkira_group.go
+++ b/alkira/resource_alkira_group.go
@@ -2,7 +2,6 @@ package alkira
 
 import (
 	"log"
-	"strconv"
 
 	"github.com/alkiranet/alkira-client-go/alkira"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -22,10 +21,6 @@ func resourceAlkiraGroup() *schema.Resource {
 		Delete: resourceGroupDelete,
 
 		Schema: map[string]*schema.Schema{
-			"group_id": {
-				Type:     schema.TypeInt,
-				Computed: true,
-			},
 			"name": {
 				Description: "The name of the group.",
 				Type:        schema.TypeString,
@@ -50,8 +45,7 @@ func resourceGroup(d *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 
-	d.SetId(strconv.Itoa(id))
-	d.Set("group_id", id)
+	d.SetId(id)
 
 	return resourceGroupRead(d, meta)
 }
@@ -64,7 +58,7 @@ func resourceGroupUpdate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*alkira.AlkiraClient)
 
 	log.Printf("[INFO] Group Updating")
-	err := client.UpdateGroup(d.Get("group_id").(int), d.Get("name").(string), d.Get("description").(string))
+	err := client.UpdateGroup(d.Id(), d.Get("name").(string), d.Get("description").(string))
 
 	if err != nil {
 		return err
@@ -75,10 +69,9 @@ func resourceGroupUpdate(d *schema.ResourceData, meta interface{}) error {
 
 func resourceGroupDelete(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*alkira.AlkiraClient)
-	groupId := d.Get("group_id").(int)
 
-	log.Printf("[INFO] Deleting Group %d", groupId)
-	err := client.DeleteGroup(groupId)
+	log.Printf("[INFO] Deleting Group %d", d.Id())
+	err := client.DeleteGroup(d.Id())
 
 	if err != nil {
 		return err

--- a/alkira/resource_alkira_segment.go
+++ b/alkira/resource_alkira_segment.go
@@ -2,7 +2,6 @@ package alkira
 
 import (
 	"log"
-	"strconv"
 
 	"github.com/alkiranet/alkira-client-go/alkira"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -37,10 +36,6 @@ func resourceAlkiraSegment() *schema.Resource {
 				Type:        schema.TypeString,
 				Required:    true,
 			},
-			"segment_id": {
-				Type:     schema.TypeInt,
-				Computed: true,
-			},
 		},
 	}
 }
@@ -57,8 +52,7 @@ func resourceSegment(d *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 
-	d.SetId(strconv.Itoa(id))
-	d.Set("segment_id", id)
+	d.SetId(id)
 
 	return resourceSegmentRead(d, meta)
 }
@@ -69,28 +63,18 @@ func resourceSegmentRead(d *schema.ResourceData, meta interface{}) error {
 
 func resourceSegmentUpdate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*alkira.AlkiraClient)
-	segmentId := d.Get("segment_id").(int)
 
-	log.Printf("[INFO] Updateing Segment %d", segmentId)
-	err := client.UpdateSegment(segmentId, d.Get("name").(string), d.Get("asn").(string), d.Get("cidr").(string))
+	log.Printf("[INFO] Updateing Segment %s", d.Id())
+	err := client.UpdateSegment(d.Id(), d.Get("name").(string), d.Get("asn").(string), d.Get("cidr").(string))
 
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return err
 }
 
 func resourceSegmentDelete(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*alkira.AlkiraClient)
-	segmentId := d.Get("segment_id").(int)
 
-	log.Printf("[INFO] Deleting Segment %d", segmentId)
-	err := client.DeleteSegment(segmentId)
+	log.Printf("[INFO] Deleting Segment %s", d.Id())
+	err := client.DeleteSegment(d.Id())
 
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return err
 }


### PR DESCRIPTION
Convert resources' Id from int to string to consistent with Terraform
convention. This commit includes connector_aws_vpc, group and segment. Also,
gofmt one more time across.