### PR TITLE
AK-16154 Adjust connector_aws_vpc to accept a list of VPC CIDRs

### DIFF
--- a/alkira/helper.go
+++ b/alkira/helper.go
@@ -179,21 +179,23 @@ func expandAwsVpcRouteTables(in *schema.Set) []alkira.RouteTables {
 }
 
 // generateUserInputPrefixes generate UserInputPrefixes used in AWS-VPC connector
-func generateUserInputPrefixes(cidr string, subnets *schema.Set) ([]alkira.InputPrefixes, error) {
+func generateUserInputPrefixes(cidr []interface{}, subnets *schema.Set) ([]alkira.InputPrefixes, error) {
 
-	if cidr == "" && subnets == nil {
+	if cidr == nil && subnets == nil {
 		return nil, fmt.Errorf("ERROR: either \"vpc_subnets\" or \"vpc_cidr\" must be specified.")
 	}
 
-	// Processing VPC CIDR
-	if cidr != "" {
-		log.Printf("[DEBUG] Processing VPC CIDR")
-		inputPrefix := alkira.InputPrefixes{
-			Id:    "",
-			Type:  "CIDR",
-			Value: cidr,
+	// Processing "vpc_cidr"
+	if cidr != nil {
+		log.Printf("[DEBUG] Processing vpc_cidr")
+		cidrList := make([]alkira.InputPrefixes, len(cidr))
+
+		for i, value := range cidr {
+			cidrList[i].Value = value.(string)
+			cidrList[i].Type = "CIDR"
 		}
-		return []alkira.InputPrefixes{inputPrefix}, nil
+
+		return cidrList, nil
 	}
 
 	// Processing VPC subnets

--- a/alkira/resource_alkira_connector_aws_vpc.go
+++ b/alkira/resource_alkira_connector_aws_vpc.go
@@ -70,9 +70,10 @@ func resourceAlkiraConnectorAwsVpc() *schema.Resource {
 			},
 			"vpc_cidr": {
 				Description:   "The CIDR of the VPC the connnector connects to.",
-				Type:          schema.TypeString,
+				Type:          schema.TypeList,
 				Optional:      true,
 				ConflictsWith: []string{"vpc_subnet"},
+				Elem:          &schema.Schema{Type: schema.TypeString},
 			},
 			"vpc_subnet": {
 				Description:   "The subnet of the VPC the connnector connects to.",
@@ -132,7 +133,7 @@ func resourceConnectorAwsVpcCreate(d *schema.ResourceData, m interface{}) error 
 
 	segments := []string{d.Get("segment").(string)}
 
-	inputPrefixes, err := generateUserInputPrefixes(d.Get("vpc_cidr").(string), d.Get("vpc_subnet").(*schema.Set))
+	inputPrefixes, err := generateUserInputPrefixes(d.Get("vpc_cidr").([]interface{}), d.Get("vpc_subnet").(*schema.Set))
 
 	if err != nil {
 		return err


### PR DESCRIPTION
Adjust the connector_aws_vpc to accept a list of VPC CIDRs to pass to VPC
routing options.