### PR TITLE
AK-16725 Add one explicit error message for porvider init failure

### DIFF
--- a/alkira/provider.go
+++ b/alkira/provider.go
@@ -78,6 +78,7 @@ func alkiraConfigure(d *schema.ResourceData) (interface{}, error) {
 	alkiraClient, err := alkira.NewAlkiraClient(d.Get("portal").(string), d.Get("username").(string), d.Get("password").(string))
 
 	if err != nil {
+		log.Printf("[ERROR] failed to initialize alkira provider, please check your credential and portal URI.")
 		return nil, err
 	}
 


### PR DESCRIPTION
Add one explicit error message when provider failed to init due to credential
or incorrect tenant URL.