### PR TITLE
AK-17578 Update connector_gcp_vpc with new client functions

### DIFF
--- a/alkira/resource_alkira_connector_gcp_vpc.go
+++ b/alkira/resource_alkira_connector_gcp_vpc.go
@@ -2,6 +2,7 @@ package alkira
 
 import (
 	"log"
+	"strconv"
 
 	"github.com/alkiranet/alkira-client-go/alkira"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -17,7 +18,7 @@ func resourceAlkiraConnectorGcpVpc() *schema.Resource {
 		Delete: resourceConnectorGcpVpcDelete,
 
 		Schema: map[string]*schema.Schema{
-			"billing_tags": {
+			"billing_tag_ids": {
 				Description: "Tags for billing.",
 				Type:        schema.TypeList,
 				Optional:    true,
@@ -58,9 +59,9 @@ func resourceAlkiraConnectorGcpVpc() *schema.Resource {
 				Type:        schema.TypeString,
 				Required:    true,
 			},
-			"segment": {
-				Description: "The segment of the connector.",
-				Type:        schema.TypeString,
+			"segment_id": {
+				Description: "The Id of the segment associated with the connector.",
+				Type:        schema.TypeInt,
 				Required:    true,
 			},
 			"size": {
@@ -75,23 +76,12 @@ func resourceAlkiraConnectorGcpVpc() *schema.Resource {
 func resourceConnectorGcpVpcCreate(d *schema.ResourceData, m interface{}) error {
 	client := m.(*alkira.AlkiraClient)
 
-	billingTags := convertTypeListToIntList(d.Get("billing_tags").([]interface{}))
-	segments := []string{d.Get("segment").(string)}
+	connector, err := generateConnectorGcpVpcRequest(d, m)
 
-	connector := &alkira.ConnectorGcpVpc{
-		BillingTags:    billingTags,
-		CXP:            d.Get("cxp").(string),
-		CredentialId:   d.Get("credential_id").(string),
-		CustomerRegion: d.Get("gcp_region").(string),
-		Group:          d.Get("group").(string),
-		Name:           d.Get("name").(string),
-		Segments:       segments,
-		Size:           d.Get("size").(string),
-		VpcId:          d.Get("gcp_vpc_id").(string),
-		VpcName:        d.Get("gcp_vpc_name").(string),
+	if err != nil {
+		return err
 	}
 
-	log.Printf("[INFO] Creating Connector (GCP-VPC)")
 	id, err := client.CreateConnectorGcpVpc(connector)
 
 	if err != nil {
@@ -103,18 +93,83 @@ func resourceConnectorGcpVpcCreate(d *schema.ResourceData, m interface{}) error 
 }
 
 func resourceConnectorGcpVpcRead(d *schema.ResourceData, m interface{}) error {
-	return nil
+	client := m.(*alkira.AlkiraClient)
+
+	connector, err := client.GetConnectorGcpVpc(d.Id())
+
+	if err != nil {
+		return err
+	}
+
+	d.Set("billing_tag_ids", connector.BillingTags)
+	d.Set("cxp", connector.CXP)
+	d.Set("credential_id", connector.CredentialId)
+	d.Set("customer_region", connector.CustomerRegion)
+	d.Set("group", connector.Group)
+	d.Set("name", connector.Name)
+	d.Set("size", connector.Size)
+	d.Set("gcp_vpc_id", connector.VpcId)
+	d.Set("gcp_vpc_name", connector.VpcName)
+
+	if len(connector.Segments) > 0 {
+		segment, err := client.GetSegmentByName(connector.Segments[0])
+
+		if err != nil {
+			return err
+		}
+		d.Set("segment_id", segment.Id)
+	}
+
+	return err
 }
 
 func resourceConnectorGcpVpcUpdate(d *schema.ResourceData, m interface{}) error {
+	client := m.(*alkira.AlkiraClient)
+
+	connector, err := generateConnectorGcpVpcRequest(d, m)
+
+	if err != nil {
+		return err
+	}
+
+	err = client.UpdateConnectorGcpVpc(d.Id(), connector)
+
+	if err != nil {
+		return err
+	}
+
 	return resourceConnectorGcpVpcRead(d, m)
 }
 
 func resourceConnectorGcpVpcDelete(d *schema.ResourceData, m interface{}) error {
 	client := m.(*alkira.AlkiraClient)
 
-	log.Printf("[INFO] Deleting Connector (GCP-VPC) %s", d.Id())
-	err := client.DeleteConnectorGcpVpc(d.Id())
+	return client.DeleteConnectorGcpVpc(d.Id())
+}
 
-	return err
+func generateConnectorGcpVpcRequest(d *schema.ResourceData, m interface{}) (*alkira.ConnectorGcpVpc, error) {
+	client := m.(*alkira.AlkiraClient)
+
+	billingTags := convertTypeListToIntList(d.Get("billing_tag_ids").([]interface{}))
+	segment, err := client.GetSegmentById(strconv.Itoa(d.Get("segment_id").(int)))
+
+	if err != nil {
+		log.Printf("[ERROR] failed to get segment by Id: %d", d.Get("segment_id"))
+		return nil, err
+	}
+
+	connector := &alkira.ConnectorGcpVpc{
+		BillingTags:    billingTags,
+		CXP:            d.Get("cxp").(string),
+		CredentialId:   d.Get("credential_id").(string),
+		CustomerRegion: d.Get("gcp_region").(string),
+		Group:          d.Get("group").(string),
+		Name:           d.Get("name").(string),
+		Segments:       []string{segment.Name},
+		Size:           d.Get("size").(string),
+		VpcId:          d.Get("gcp_vpc_id").(string),
+		VpcName:        d.Get("gcp_vpc_name").(string),
+	}
+
+	return connector, nil
 }


### PR DESCRIPTION
Update connector_gcp_vpc with read and update support. Switch billing_tags
and segment to billing_tag_ids and segment_id to be consistent across all
resources in the procider.