### PR TITLE
AK-22042 Remove deprecated vars from connector-azure-vnet

### DIFF
--- a/alkira/resource_alkira_connector_azure_vnet.go
+++ b/alkira/resource_alkira_connector_azure_vnet.go
@@ -19,22 +19,10 @@ func resourceAlkiraConnectorAzureVnet() *schema.Resource {
 		Delete: resourceConnectorAzureVnetDelete,
 
 		Schema: map[string]*schema.Schema{
-			"azure_region": {
-				Description: "Azure Region where VNET resides.",
-				Type:        schema.TypeString,
-				Required:    true,
-			},
 			"azure_vnet_id": {
 				Description: "Azure Virtual Network Id.",
 				Type:        schema.TypeString,
 				Required:    true,
-			},
-			"azure_subscription_id": {
-				Description: "The Azure subscription ID of the VNET. If the" +
-					"`subscirption_id` was provided in the credential, the one" +
-					"in the credential will be always used.",
-				Type:     schema.TypeString,
-				Optional: true,
 			},
 			"billing_tag_ids": {
 				Description: "Tags for billing.",
@@ -117,8 +105,6 @@ func resourceConnectorAzureVnetRead(d *schema.ResourceData, m interface{}) error
 		return err
 	}
 
-	d.Set("azure_region", connector.CustomerRegion)
-	d.Set("azure_subscription_id", connector.SubscriptionId)
 	d.Set("azure_vnet_id", connector.VnetId)
 	d.Set("billing_tag_ids", connector.BillingTags)
 	d.Set("credential_id", connector.CredentialId)
@@ -181,17 +167,15 @@ func generateConnectorAzureVnetRequest(d *schema.ResourceData, m interface{}) (*
 	}
 
 	request := &alkira.ConnectorAzureVnet{
-		BillingTags:    billingTags,
-		CXP:            d.Get("cxp").(string),
-		CredentialId:   d.Get("credential_id").(string),
-		CustomerRegion: d.Get("azure_region").(string),
-		Group:          d.Get("group").(string),
-		Name:           d.Get("name").(string),
-		Segments:       []string{segment.Name},
-		Size:           d.Get("size").(string),
-		SubscriptionId: d.Get("azure_subscription_id").(string),
-		VnetId:         d.Get("azure_vnet_id").(string),
-		VnetRouting:    routing,
+		BillingTags:  billingTags,
+		CXP:          d.Get("cxp").(string),
+		CredentialId: d.Get("credential_id").(string),
+		Group:        d.Get("group").(string),
+		Name:         d.Get("name").(string),
+		Segments:     []string{segment.Name},
+		Size:         d.Get("size").(string),
+		VnetId:       d.Get("azure_vnet_id").(string),
+		VnetRouting:  routing,
 	}
 
 	return request, nil

--- a/docs/resources/connector_azure_vnet.md
+++ b/docs/resources/connector_azure_vnet.md
@@ -24,7 +24,6 @@ A simple connector could be created like this:
 ```terraform
 resource "alkira_connector_azure_vnet" "test1" {
   name           = "test1"
-  azure_region   = "westus2"
   azure_vnet_id  = "/subscriptions/XXXX/resourceGroups/Test/providers/Microsoft.Network/virtualNetworks/test1"
   credential_id  = alkira_credential_azure_vnet.test1.id
   cxp            = "US-WEST"
@@ -41,7 +40,6 @@ Additionally, you could adjust routing by using `routing_options` and
 ```terraform
 resource "alkira_connector_azure_vnet" "test2" {
   name           = "test2"
-  azure_region   = "westus2"
   azure_vnet_id  = "/subscriptions/XXXX/resourceGroups/Test/providers/Microsoft.Network/virtualNetworks/test-vnet2"
   credential_id  = alkira_credential_azure_vnet.yours.id
   cxp            = "US-WEST"
@@ -59,7 +57,6 @@ resource "alkira_connector_azure_vnet" "test2" {
 
 ### Required
 
-- **azure_region** (String) Azure Region where VNET resides.
 - **azure_vnet_id** (String) Azure Virtual Network ID.
 - **credential_id** (String) ID of credential managed by Credential Manager.
 - **cxp** (String) The CXP where the connector should be provisioned.
@@ -69,7 +66,6 @@ resource "alkira_connector_azure_vnet" "test2" {
 
 ### Optional
 
-- **azure_subscription_id** (String) The Azure subscription ID of the VNET. If the `subscirption_id` was provided in the credential, the one in the credential will be always used.
 - **billing_tag_ids** (List of Number) Tags for billing.
 - **group** (String) The group of the connector.
 - **id** (String) The ID of this resource.

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/alkiranet/terraform-provider-alkira
 go 1.16
 
 require (
-	github.com/alkiranet/alkira-client-go v0.8.3
+	github.com/alkiranet/alkira-client-go v0.8.4
 	github.com/hashicorp/terraform-plugin-sdk v1.15.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.1.0
 )

--- a/go.sum
+++ b/go.sum
@@ -42,6 +42,8 @@ github.com/alcortesm/tgz v0.0.0-20161220082320-9c5fe88206d7 h1:uSoVVbwJiQipAclBb
 github.com/alcortesm/tgz v0.0.0-20161220082320-9c5fe88206d7/go.mod h1:6zEj6s6u/ghQa61ZWa/C2Aw3RkjiTBOix7dkqa1VLIs=
 github.com/alkiranet/alkira-client-go v0.8.3 h1:HILjsntABefO2sJ951OkJIGXFL4PDKzBoPBp88Honm4=
 github.com/alkiranet/alkira-client-go v0.8.3/go.mod h1:ZN48ehBXW6WSeJU0XCnMctSAv4+ki/0Qz7fhn2c/jpM=
+github.com/alkiranet/alkira-client-go v0.8.4 h1:5EnMrK2GkYSj1DQY7Lv4OriUxHrLx77KHohiS5NQYyI=
+github.com/alkiranet/alkira-client-go v0.8.4/go.mod h1:ZN48ehBXW6WSeJU0XCnMctSAv4+ki/0Qz7fhn2c/jpM=
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239 h1:kFOfPq6dUM1hTo4JG6LR5AXSUEsOjtdm0kw0FtQtMJA=
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239/go.mod h1:2FmKhYUyUczH0OGQWaF5ceTx0UBShxjsH6f8oGKYe2c=
 github.com/apparentlymart/go-cidr v1.0.1 h1:NmIwLZ/KdsjIUlhf+/Np40atNXm/+lZ5txfTJ/SpF+U=

--- a/templates/resources/connector_azure_vnet.md.tmpl
+++ b/templates/resources/connector_azure_vnet.md.tmpl
@@ -24,7 +24,6 @@ A simple connector could be created like this:
 ```terraform
 resource "alkira_connector_azure_vnet" "test1" {
   name           = "test1"
-  azure_region   = "westus2"
   azure_vnet_id  = "/subscriptions/XXXX/resourceGroups/Test/providers/Microsoft.Network/virtualNetworks/test1"
   credential_id  = alkira_credential_azure_vnet.test1.id
   cxp            = "US-WEST"
@@ -41,7 +40,6 @@ Additionally, you could adjust routing by using `routing_options` and
 ```terraform
 resource "alkira_connector_azure_vnet" "test2" {
   name           = "test2"
-  azure_region   = "westus2"
   azure_vnet_id  = "/subscriptions/XXXX/resourceGroups/Test/providers/Microsoft.Network/virtualNetworks/test-vnet2"
   credential_id  = alkira_credential_azure_vnet.yours.id
   cxp            = "US-WEST"
@@ -59,7 +57,6 @@ resource "alkira_connector_azure_vnet" "test2" {
 
 ### Required
 
-- **azure_region** (String) Azure Region where VNET resides.
 - **azure_vnet_id** (String) Azure Virtual Network ID.
 - **credential_id** (String) ID of credential managed by Credential Manager.
 - **cxp** (String) The CXP where the connector should be provisioned.
@@ -69,7 +66,6 @@ resource "alkira_connector_azure_vnet" "test2" {
 
 ### Optional
 
-- **azure_subscription_id** (String) The Azure subscription ID of the VNET. If the `subscirption_id` was provided in the credential, the one in the credential will be always used.
 - **billing_tag_ids** (List of Number) Tags for billing.
 - **group** (String) The group of the connector.
 - **id** (String) The ID of this resource.

--- a/vendor/github.com/alkiranet/alkira-client-go/alkira/connector_aws_vpc.go
+++ b/vendor/github.com/alkiranet/alkira-client-go/alkira/connector_aws_vpc.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2020-2021 Alkira Inc. All Rights Reserved.
+// Copyright (C) 2020-2022 Alkira Inc. All Rights Reserved.
 
 package alkira
 
@@ -40,6 +40,7 @@ type ConnectorAwsVpc struct {
 	CustomerName                       string      `json:"customerName"`
 	CustomerRegion                     string      `json:"customerRegion"`
 	DirectInterVPCCommunicationEnabled bool        `json:"directInterVPCCommunicationEnabled,omitempty"`
+	Enabled                            bool        `json:"enabled,omitempty"`
 	Group                              string      `json:"group"`
 	Id                                 json.Number `json:"id,omitempty"`
 	Name                               string      `json:"name"`

--- a/vendor/github.com/alkiranet/alkira-client-go/alkira/connector_azure_vnet.go
+++ b/vendor/github.com/alkiranet/alkira-client-go/alkira/connector_azure_vnet.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2020-2021 Alkira Inc. All Rights Reserved.
+// Copyright (C) 2020-2022 Alkira Inc. All Rights Reserved.
 
 package alkira
 
@@ -17,19 +17,20 @@ type ConnectorVnetRouting struct {
 }
 
 type ConnectorAzureVnet struct {
-	BillingTags    []int                 `json:"billingTags"`
-	CXP            string                `json:"cxp"`
-	CredentialId   string                `json:"credentialId"`
-	CustomerRegion string                `json:"customerRegion"`
-	Group          string                `json:"group"`
-	Id             json.Number           `json:"id,omitempty"`
-	Name           string                `json:"name"`
-	NativeServices []string              `json:"nativeServices,omitempty"`
-	Segments       []string              `json:"segments"`
-	Size           string                `json:"size"`
-	SubscriptionId string                `json:"subscriptionId,omitempty"`
-	VnetId         string                `json:"vnetId"`
-	VnetRouting    *ConnectorVnetRouting `json:"vnetRouting"`
+	BillingTags       []int                 `json:"billingTags"`
+	CXP               string                `json:"cxp"`
+	CredentialId      string                `json:"credentialId"`
+	Group             string                `json:"group"`
+	Enabled           bool                  `json:"enabled,omitempty"`
+	Id                json.Number           `json:"id,omitempty"`
+	Name              string                `json:"name"`
+	NativeServices    []string              `json:"nativeServices,omitempty"`
+	ResourceGroupName string                `json:"resourceGroupName,omitempty"`
+	Segments          []string              `json:"segments"`
+	ServiceTags       []string              `json:"serviceTags,omitempty"`
+	Size              string                `json:"size"`
+	VnetId            string                `json:"vnetId"`
+	VnetRouting       *ConnectorVnetRouting `json:"vnetRouting"`
 }
 
 // CreateConnectorAzureVnet create a AZURE-VNET connector

--- a/vendor/github.com/alkiranet/alkira-client-go/alkira/connector_cisco_sdwan.go
+++ b/vendor/github.com/alkiranet/alkira-client-go/alkira/connector_cisco_sdwan.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2021 Alkira Inc. All Rights Reserved.
+// Copyright (C) 2021-2022 Alkira Inc. All Rights Reserved.
 
 package alkira
 
@@ -29,6 +29,7 @@ type ConnectorCiscoSdwan struct {
 	CiscoEdgeVrfMappings []CiscoSdwanEdgeVrfMapping `json:"ciscoEdgeVRFMappings"`
 	Cxp                  string                     `json:"cxp"`
 	Group                string                     `json:"group,omitempty"`
+	Enabled              bool                       `json:"enabled,omitempty"`
 	Name                 string                     `json:"name"`
 	Id                   int                        `json:"id,omitempty"`
 	Size                 string                     `json:"size"`

--- a/vendor/github.com/alkiranet/alkira-client-go/alkira/connector_gcp_vpc.go
+++ b/vendor/github.com/alkiranet/alkira-client-go/alkira/connector_gcp_vpc.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2020-2021 Alkira Inc. All Rights Reserved.
+// Copyright (C) 2020-2022 Alkira Inc. All Rights Reserved.
 
 package alkira
 
@@ -21,6 +21,7 @@ type ConnectorGcpVpc struct {
 	CXP            string                  `json:"cxp"`
 	CredentialId   string                  `json:"credentialId"`
 	CustomerRegion string                  `json:"customerRegion"`
+	Enabled        bool                    `json:"enabled,omitempty"`
 	GcpRouting     *ConnectorGcpVpcRouting `json:"gcpRouting,omitempty"`
 	Group          string                  `json:"group"`
 	Id             json.Number             `json:"id,omitempty"`

--- a/vendor/github.com/alkiranet/alkira-client-go/alkira/connector_internet_exit.go
+++ b/vendor/github.com/alkiranet/alkira-client-go/alkira/connector_internet_exit.go
@@ -23,6 +23,7 @@ type ConnectorInternet struct {
 	CXP                 string               `json:"cxp"`
 	Description         string               `json:"description"`
 	Group               string               `json:"group,omitempty"`
+	Enabled             bool                 `json:"enabled,omitempty"`
 	Id                  int                  `json:"id"`
 	Name                string               `json:"name"`
 	NumOfPublicIPs      int                  `json:"numOfPublicIPs,omitempty"`

--- a/vendor/github.com/alkiranet/alkira-client-go/alkira/connector_ipsec.go
+++ b/vendor/github.com/alkiranet/alkira-client-go/alkira/connector_ipsec.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2020-2021 Alkira Inc. All Rights Reserved.
+// Copyright (C) 2020-2022 Alkira Inc. All Rights Reserved.
 
 package alkira
 
@@ -81,6 +81,7 @@ type ConnectorIPSec struct {
 	BillingTags    []int                         `json:"billingTags"`
 	CXP            string                        `json:"cxp"`
 	Group          string                        `json:"group"`
+	Enabled        bool                          `json:"enabled,omitempty"`
 	Id             json.Number                   `json:"id,omitempty"`
 	Name           string                        `json:"name"`
 	PolicyOptions  *ConnectorIPSecPolicyOptions  `json:"policyOptions"`

--- a/vendor/github.com/alkiranet/alkira-client-go/alkira/connector_oci_vcn.go
+++ b/vendor/github.com/alkiranet/alkira-client-go/alkira/connector_oci_vcn.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2021 Alkira Inc. All Rights Reserved.
+// Copyright (C) 2021-2022 Alkira Inc. All Rights Reserved.
 
 package alkira
 
@@ -34,19 +34,19 @@ type ConnectorOciVcnRouting struct {
 }
 
 type ConnectorOciVcn struct {
-	Id             json.Number `json:"id,omitempty"`
-	CustomerRegion string      `json:"customerRegion"`
-	VcnId          string      `json:"vcnId"`
+	BillingTags    []int       `json:"billingTags"`
+	CXP            string      `json:"cxp"`
 	CredentialId   string      `json:"credentialId"`
+	CustomerRegion string      `json:"customerRegion"`
+	Enabled        bool        `json:"enabled"`
+	Group          string      `json:"group"`
+	Id             json.Number `json:"id,omitempty"`
+	Name           string      `json:"name"`
+	Primary        bool        `json:"primary"`
 	Segments       []string    `json:"segments"`
 	Size           string      `json:"size"`
+	VcnId          string      `json:"vcnId"`
 	VcnRouting     interface{} `json:"vcnRouting,omitempty"`
-	Enabled        bool        `json:"enabled"`
-	Primary        bool        `json:"primary"`
-	Name           string      `json:"name"`
-	CXP            string      `json:"cxp"`
-	Group          string      `json:"group"`
-	BillingTags    []int       `json:"billingTags"`
 }
 
 // CreateConnectorOciVcn create an OCI-VCN connector

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -10,7 +10,7 @@ cloud.google.com/go/internal/version
 cloud.google.com/go/storage
 # github.com/agext/levenshtein v1.2.2
 github.com/agext/levenshtein
-# github.com/alkiranet/alkira-client-go v0.8.3
+# github.com/alkiranet/alkira-client-go v0.8.4
 ## explicit
 github.com/alkiranet/alkira-client-go/alkira
 # github.com/apparentlymart/go-cidr v1.0.1


### PR DESCRIPTION
Remove vnet_subscription_id and vnet_region from connector-azure-vnet. API
doesn't need them anymore. Also, update alkira-client-go to v0.8.4 for latest
API changes.