### PR TITLE
AK-24537 Fix the allow_nat_exit value set in connector_cisco_sdwan

### DIFF
--- a/alkira/resource_alkira_connector_cisco_sdwan.go
+++ b/alkira/resource_alkira_connector_cisco_sdwan.go
@@ -264,7 +264,7 @@ func expandCiscoSdwanVrfMappings(in *schema.Set) []alkira.CiscoSdwanEdgeVrfMappi
 			r.AdvertiseOnPremRoutes = v
 		}
 		if v, ok := t["allow_nat_exit"].(bool); ok {
-			r.DisableInternetExit = v
+			r.DisableInternetExit = !v
 		}
 		if v, ok := t["customer_asn"].(int); ok {
 			r.CustomerAsn = v


### PR DESCRIPTION
Fix the allow_nat_exit value set in connector_cisco_sdwan. The value needs
to be opposite when passing to API.