### PR TITLE
AK-26491 Reserve endpoint ID of connector_ipsec

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.18
 replace github.com/hashicorp/go-getter => github.com/hashicorp/go-getter v1.6.1
 
 require (
-	github.com/alkiranet/alkira-client-go v1.32.1
+	github.com/alkiranet/alkira-client-go v1.32.2
 	github.com/hashicorp/terraform-plugin-sdk v1.15.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.1.0
 	github.com/stretchr/testify v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -43,8 +43,8 @@ github.com/agext/levenshtein v1.2.2/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki
 github.com/agl/ed25519 v0.0.0-20170116200512-5312a6153412/go.mod h1:WPjqKcmVOxf0XSf3YxCJs6N6AOSrOx3obionmG7T0y0=
 github.com/alcortesm/tgz v0.0.0-20161220082320-9c5fe88206d7 h1:uSoVVbwJiQipAclBbw+8quDsfcvFjOpI5iCf4p/cqCs=
 github.com/alcortesm/tgz v0.0.0-20161220082320-9c5fe88206d7/go.mod h1:6zEj6s6u/ghQa61ZWa/C2Aw3RkjiTBOix7dkqa1VLIs=
-github.com/alkiranet/alkira-client-go v1.32.1 h1:EG7xhc8T194akUGD8sOVXaH0vXPLx2aDcS4kc3LWqUY=
-github.com/alkiranet/alkira-client-go v1.32.1/go.mod h1:lYkuPa3UDqmY50SI6eom3WjiFciYAT2NJgnYsPTOABI=
+github.com/alkiranet/alkira-client-go v1.32.2 h1:/NuT9J9K8Jh8ctEQkZ+ZV70IftMxfhHwGcLYzSzJs6U=
+github.com/alkiranet/alkira-client-go v1.32.2/go.mod h1:lYkuPa3UDqmY50SI6eom3WjiFciYAT2NJgnYsPTOABI=
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239 h1:kFOfPq6dUM1hTo4JG6LR5AXSUEsOjtdm0kw0FtQtMJA=
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239/go.mod h1:2FmKhYUyUczH0OGQWaF5ceTx0UBShxjsH6f8oGKYe2c=
 github.com/apparentlymart/go-cidr v1.0.1 h1:NmIwLZ/KdsjIUlhf+/Np40atNXm/+lZ5txfTJ/SpF+U=

--- a/vendor/github.com/alkiranet/alkira-client-go/alkira/connector_ipsec.go
+++ b/vendor/github.com/alkiranet/alkira-client-go/alkira/connector_ipsec.go
@@ -31,13 +31,16 @@ type ConnectorIPSecSiteAdvanced struct {
 }
 
 type ConnectorIPSecSite struct {
-	Name                   string                      `json:"name"`
-	BillingTags            []int                       `json:"billingTags,omitempty"`
-	CustomerGwAsn          string                      `json:"customerGwAsn"`
-	CustomerGwIp           string                      `json:"customerGwIp"`
-	PresharedKeys          []string                    `json:"presharedKeys"`
-	EnableTunnelRedundancy bool                        `json:"enableTunnelRedundancy,omitempty"`
 	Advanced               *ConnectorIPSecSiteAdvanced `json:"advanced,omitempty"`
+	BillingTags            []int                       `json:"billingTags,omitempty"`
+	CustomerGwAsn          string                      `json:"customerGwAsn,omitempty"`
+	CustomerGwIp           string                      `json:"customerGwIp"`
+	EnableTunnelRedundancy bool                        `json:"enableTunnelRedundancy"`
+	GatewayIpType          string                      `json:"gatewayIpType,omitempty"`
+	HaMode                 string                      `json:"haMode,omitempty"`
+	Id                     int                         `json:"id,omitempty"`
+	Name                   string                      `json:"name"`
+	PresharedKeys          []string                    `json:"presharedKeys"`
 }
 
 type ConnectorIPSecPolicyOptions struct {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -13,7 +13,7 @@ cloud.google.com/go/storage
 # github.com/agext/levenshtein v1.2.2
 ## explicit
 github.com/agext/levenshtein
-# github.com/alkiranet/alkira-client-go v1.32.1
+# github.com/alkiranet/alkira-client-go v1.32.2
 ## explicit; go 1.14
 github.com/alkiranet/alkira-client-go/alkira
 # github.com/apparentlymart/go-cidr v1.0.1


### PR DESCRIPTION
Reserver endpoint ID of connector_ipsec to avoid delete/create case when updating
the connector.

+ Pick up alkira-client-go v1.32.2 with the new connector_ipsec fields.