### PR TITLE
AK-26616 Add new sub license support for service_pan

### DIFF
--- a/alkira/resource_alkira_service_pan.go
+++ b/alkira/resource_alkira_service_pan.go
@@ -153,6 +153,12 @@ func resourceAlkiraServicePan() *schema.Resource {
 				Required:     true,
 				ValidateFunc: validation.StringInSlice([]string{"BRING_YOUR_OWN", "PAY_AS_YOU_GO"}, false),
 			},
+			"license_sub_type": {
+				Description:  "PAN sub license type, either `CREDIT_BASED` or `MODEL_BASED`. (BETA)",
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"CREDIT_BASED", "MODEL_BASED"}, false),
+			},
 			"panorama_enabled": {
 				Description: "Enable Panorama or not. Default value is `false`.",
 				Type:        schema.TypeBool,
@@ -316,6 +322,7 @@ func resourceServicePanRead(d *schema.ResourceData, m interface{}) error {
 	d.Set("credential_id", pan.CredentialId)
 	d.Set("cxp", pan.CXP)
 	d.Set("license_type", pan.LicenseType)
+	d.Set("license_sub_type", pan.SubLicenseType)
 	d.Set("management_segment_id", pan.ManagementSegmentId)
 	d.Set("master_key_enabled", pan.MasterKeyEnabled)
 	d.Set("max_instance_count", pan.MaxInstanceCount)
@@ -453,6 +460,7 @@ func generateServicePanRequest(d *schema.ResourceData, m interface{}) (*alkira.S
 		GlobalProtectSegmentOptions: globalProtectSegmentOptions,
 		Instances:                   instances,
 		LicenseType:                 d.Get("license_type").(string),
+		SubLicenseType:              d.Get("license_sub_type").(string),
 		MasterKeyCredentialId:       masterKeyCredentialId,
 		MasterKeyEnabled:            d.Get("master_key_enabled").(bool),
 		MaxInstanceCount:            d.Get("max_instance_count").(int),

--- a/docs/resources/service_pan.md
+++ b/docs/resources/service_pan.md
@@ -82,6 +82,7 @@ resource "alkira_service_pan" "test1" {
 - `bundle` (String) The software image bundle that would be used forPAN instance deployment. This is applicable for licenseType`PAY_AS_YOU_GO` only. If not provided, the default`PAN_VM_300_BUNDLE_2` would be used. However `PAN_VM_300_BUNDLE_2`is legacy bundle and is not supported on AWS. It is recommendedto use `VM_SERIES_BUNDLE_1` and `VM_SERIES_BUNDLE_2` (supports Global Protect).
 - `global_protect_enabled` (Boolean) Enable global protect option or not. Default is `false`
 - `global_protect_segment_options` (Block Set) A mapping of segment_id -> zones_to_groups. The only segment names allowed are the segments that are already associated with the service.options should apply. If global_protect_enabled is set to false, global_protect_segment_options shound not be included in your request. (see [below for nested schema](#nestedblock--global_protect_segment_options))
+- `license_sub_type` (String) PAN sub license type, either `CREDIT_BASED` or `MODEL_BASED`. (BETA)
 - `master_key` (String) Master Key for PAN instances.
 - `master_key_enabled` (Boolean) Enable Master Key for PAN instances or not. It's default to `false`.
 - `master_key_expiry` (String) PAN Master Key Expiry. The date should be in format of `YYYY-MM-DD`, e.g. `2000-01-01`.


### PR DESCRIPTION
Add new license_sub_type to service_pan to allow select MODEL_BASED or CREDIT_BASED
under the existing license type.