### PR TITLE
AK-26615 Add IPv6 support to alkira_internet_application

### DIFF
--- a/alkira/resource_alkira_internet_applications.go
+++ b/alkira/resource_alkira_internet_applications.go
@@ -72,6 +72,17 @@ func resourceAlkiraInternetApplication() *schema.Resource {
 				Default:      "DEFAULT",
 				ValidateFunc: validation.StringInSlice([]string{"DEFAULT", "AKAMAI_PROLEXIC"}, false),
 			},
+			"internet_protocol": {
+				Description: "Internet Protocol to be associated with the internet application. " +
+					"The value could be: `IPV4`, `IPV6` or `BOTH`. " +
+					"In order to use the option IPV6 or BOTH, `enable_ipv6_to_ipv4_translation` " +
+					"should be enabled on the associated segment and a valid IP pool range should " +
+					"be provided. `IPV6` and `BOTH` options are only available to Internet " +
+					"Applications on AWS CXPs.",
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"IPV4", "IPV6", "BOTH"}, false),
+			},
 			"name": {
 				Description: "The name of the internet application.",
 				Type:        schema.TypeString,

--- a/docs/resources/internet_application.md
+++ b/docs/resources/internet_application.md
@@ -55,6 +55,7 @@ resource "alkira_internet_application" "test" {
 - `byoip_id` (Number) BYOIP ID.
 - `inbound_connector_id` (String) Inbound connector ID. When `inbound_connector_type` is `DEFAULT`, it could be left empty.
 - `inbound_connector_type` (String) The inbound connector type specifies how the internet application is to be opened up to the external world. By `DEFAULT` the native cloud internet connector is used. In this scenario, Alkira takes care of creating this inbound internet connector implicitly. If instead inbound access is via the `AKAMAI_PROLEXIC` connector, then you need to create and configure that connector and use it with the internet application.
+- `internet_protocol` (String) Internet Protocol to be associated with the internet application. The value could be: `IPV4`, `IPV6` or `BOTH`. In order to use the option IPV6 or BOTH, `enable_ipv6_to_ipv4_translation` should be enabled on the associated segment and a valid IP pool range should be provided. `IPV6` and `BOTH` options are only available to Internet Applications on AWS CXPs.
 - `public_ips` (List of String) This option pertains to the `AKAMAI_PROLEXIC` inbound_connector_type. The public IPs are to be used to access the internet application. These public IPs must belong to one of the BYOIP ranges configured for the Akamai Prolexic Connector.
 
 ### Read-Only

--- a/docs/resources/segment.md
+++ b/docs/resources/segment.md
@@ -28,13 +28,16 @@ resource "alkira_segment" "test" {
 
 ### Required
 
-- `cidrs` (List of String) The CIDR block.
+- `cidrs` (List of String) The list of CIDR blocks.
 - `name` (String) The name of the segment.
 
 ### Optional
 
 - `asn` (Number) The BGP ASN for the segment. Default value is `65514`.
+- `enable_ipv6_to_ipv4_translation` (Boolean) Enable IPv6 to IPv4 translation in the segment for internet application traffic.
 - `reserve_public_ips` (Boolean) Default value is `false`. When this is set to `true`. Alkira reserves public IPs which can be used to create underlay tunnels between an external service and Alkira. For example the reserved public IPs may be used to create tunnels to the Akamai Prolexic.
+- `src_ipv4_pool_end_ip` (String) The end IP address of IPv4 pool.
+- `src_ipv4_pool_start_ip` (String) The start IP address of IPv4 pool.
 
 ### Read-Only
 


### PR DESCRIPTION
+ Add new `internet_protocol` to alkira_internet_application to select used protocol.
+ Add new arguments to segment to allow translation of IPv6 to IPv4 and specify source IPv4 pool.