### PR TITLE
AK-27110 Update some connector and service resoruces to use TypeList

### DIFF
--- a/alkira/resource_alkira_connector_aruba_edge.go
+++ b/alkira/resource_alkira_connector_aruba_edge.go
@@ -85,7 +85,7 @@ func resourceAlkiraConnectorArubaEdge() *schema.Resource {
 			},
 			"instances": {
 				Description: "The Aruba Edge connector instances.",
-				Type:        schema.TypeSet,
+				Type:        schema.TypeList,
 				Required:    true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
@@ -103,6 +103,11 @@ func resourceAlkiraConnectorArubaEdge() *schema.Resource {
 							Description: "The host name given to the Aruba SD-WAN appliance that appears in Silver Peak orchestrator.",
 							Type:        schema.TypeString,
 							Required:    true,
+						},
+						"id": {
+							Description: "The ID of the endpoint.",
+							Type:        schema.TypeInt,
+							Computed:    true,
 						},
 						"name": {
 							Description: "The instance name associated with aruba edge connect instance.",
@@ -236,7 +241,7 @@ func generateConnectorArubaEdgeRequest(d *schema.ResourceData, m interface{}) (*
 		return nil, err
 	}
 
-	instances, err := expandArubaEdgeInstances(d.Get("instances").(*schema.Set), client)
+	instances, err := expandArubaEdgeInstances(d.Get("instances").([]interface{}), client)
 	if err != nil {
 		return nil, err
 	}

--- a/alkira/resource_alkira_connector_aruba_edge_helper.go
+++ b/alkira/resource_alkira_connector_aruba_edge_helper.go
@@ -1,6 +1,7 @@
 package alkira
 
 import (
+	"encoding/json"
 	"errors"
 	"strconv"
 
@@ -25,7 +26,7 @@ func deflateArubaEdgeInstances(ins []alkira.ArubaEdgeInstance) []map[string]inte
 	return instances
 }
 
-func expandArubaEdgeInstances(in *schema.Set, client *alkira.AlkiraClient) ([]alkira.ArubaEdgeInstance, error) {
+func expandArubaEdgeInstances(in []interface{}, client *alkira.AlkiraClient) ([]alkira.ArubaEdgeInstance, error) {
 
 	var instances []alkira.ArubaEdgeInstance
 
@@ -34,8 +35,8 @@ func expandArubaEdgeInstances(in *schema.Set, client *alkira.AlkiraClient) ([]al
 		return nil, err
 	}
 
-	for _, v := range in.List() {
-		var name, accountKey, accountName, hostName, siteTag string
+	for _, v := range in {
+		var name, accountKey, accountName, hostName, id, siteTag string
 		m := v.(map[string]interface{})
 
 		if v, ok := m["account_key"].(string); ok {
@@ -46,6 +47,9 @@ func expandArubaEdgeInstances(in *schema.Set, client *alkira.AlkiraClient) ([]al
 		}
 		if v, ok := m["host_name"].(string); ok {
 			hostName = v
+		}
+		if v, ok := m["id"].(string); ok {
+			id = v
 		}
 		if v, ok := m["account_name"].(string); ok {
 			accountName = v
@@ -63,6 +67,7 @@ func expandArubaEdgeInstances(in *schema.Set, client *alkira.AlkiraClient) ([]al
 			AccountName:  accountName,
 			CredentialId: credId,
 			HostName:     hostName,
+			Id:           json.Number(id),
 			Name:         name,
 			SiteTag:      siteTag,
 		}

--- a/alkira/resource_alkira_connector_cisco_sdwan.go
+++ b/alkira/resource_alkira_connector_cisco_sdwan.go
@@ -61,7 +61,7 @@ func resourceAlkiraConnectorCiscoSdwan() *schema.Resource {
 			},
 			"vedge": &schema.Schema{
 				Description: "Cisco vEdge",
-				Type:        schema.TypeSet,
+				Type:        schema.TypeList,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"cloud_init_file": {
@@ -239,7 +239,7 @@ func generateConnectorCiscoSdwanRequest(ac *alkira.AlkiraClient, d *schema.Resou
 
 	billingTags := convertTypeListToIntList(d.Get("billing_tag_ids").([]interface{}))
 	mappings := expandCiscoSdwanVrfMappings(d.Get("vrf_segment_mapping").(*schema.Set))
-	vedges := expandCiscoSdwanVedges(ac, d.Get("vedge").(*schema.Set))
+	vedges := expandCiscoSdwanVedges(ac, d.Get("vedge").([]interface{}))
 
 	connector := &alkira.ConnectorCiscoSdwan{
 		BillingTags:          billingTags,
@@ -292,15 +292,15 @@ func expandCiscoSdwanVrfMappings(in *schema.Set) []alkira.CiscoSdwanEdgeVrfMappi
 }
 
 // expandCiscoSdwanVedges expand Cisco SD-WAN Edge
-func expandCiscoSdwanVedges(ac *alkira.AlkiraClient, in *schema.Set) []alkira.CiscoSdwanEdgeInfo {
-	if in == nil || in.Len() == 0 {
+func expandCiscoSdwanVedges(ac *alkira.AlkiraClient, in []interface{}) []alkira.CiscoSdwanEdgeInfo {
+	if in == nil || len(in) == 0 {
 		log.Printf("[DEBUG] Empty vedges")
 		return []alkira.CiscoSdwanEdgeInfo{}
 	}
 
-	mappings := make([]alkira.CiscoSdwanEdgeInfo, in.Len())
+	mappings := make([]alkira.CiscoSdwanEdgeInfo, len(in))
 
-	for i, mapping := range in.List() {
+	for i, mapping := range in {
 		r := alkira.CiscoSdwanEdgeInfo{}
 		t := mapping.(map[string]interface{})
 

--- a/alkira/resource_alkira_service_fortinet.go
+++ b/alkira/resource_alkira_service_fortinet.go
@@ -45,11 +45,11 @@ func resourceAlkiraServiceFortinet() *schema.Resource {
 				Required:    true,
 			},
 			"instances": {
-				Type:     schema.TypeSet,
+				Type:     schema.TypeList,
 				Required: true,
 				Description: "An array containing properties for each Fortinet Firewall instance " +
 					"that needs to be deployed. The number of instances should be equal to " +
-					"max_instance_count.",
+					"`max_instance_count`.",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"name": {
@@ -267,7 +267,7 @@ func generateFortinetRequest(d *schema.ResourceData, m interface{}) (*alkira.For
 		IpAddress: d.Get("management_server_ip").(string),
 		Segment:   d.Get("management_server_segment").(string),
 	}
-	instances := expandFortinetInstances(d.Get("instances").(*schema.Set))
+	instances := expandFortinetInstances(d.Get("instances").([]interface{}))
 
 	// convert segment ids to segment names
 	segmentIds := convertTypeListToStringList(d.Get("segment_ids").([]interface{}))

--- a/alkira/resource_alkira_service_fortinet_helper.go
+++ b/alkira/resource_alkira_service_fortinet_helper.go
@@ -8,14 +8,14 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-func expandFortinetInstances(in *schema.Set) []alkira.FortinetInstance {
-	if in == nil || in.Len() == 0 {
+func expandFortinetInstances(in []interface{}) []alkira.FortinetInstance {
+	if in == nil || len(in) == 0 {
 		log.Printf("[DEBUG] invalid Fortinet instance input")
 		return nil
 	}
 
-	instances := make([]alkira.FortinetInstance, in.Len())
-	for i, instance := range in.List() {
+	instances := make([]alkira.FortinetInstance, len(in))
+	for i, instance := range in {
 		r := alkira.FortinetInstance{}
 		instanceCfg := instance.(map[string]interface{})
 		if v, ok := instanceCfg["id"].(int); ok {

--- a/alkira/resource_alkira_service_pan.go
+++ b/alkira/resource_alkira_service_pan.go
@@ -91,7 +91,7 @@ func resourceAlkiraServicePan() *schema.Resource {
 				Required:    true,
 			},
 			"instance": {
-				Type:     schema.TypeSet,
+				Type:     schema.TypeList,
 				Required: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
@@ -388,7 +388,7 @@ func generateServicePanRequest(d *schema.ResourceData, m interface{}) (*alkira.S
 	panoramaIpAddresses := convertTypeListToStringList(d.Get("panorama_ip_addresses").([]interface{}))
 	panoramaTemplate := d.Get("panorama_template").(string)
 
-	instances, err := expandPanInstances(d.Get("instance").(*schema.Set), m)
+	instances, err := expandPanInstances(d.Get("instance").([]interface{}), m)
 	if err != nil {
 		return nil, err
 	}

--- a/alkira/resource_alkira_service_pan_helper.go
+++ b/alkira/resource_alkira_service_pan_helper.go
@@ -133,13 +133,13 @@ func expandPanSegmentOptions(in *schema.Set, m interface{}) (map[string]interfac
 
 	return segmentOptions, nil
 }
-func expandPanInstances(in *schema.Set, m interface{}) ([]alkira.ServicePanInstance, error) {
-	if in == nil || in.Len() == 0 {
-		return nil, errors.New("invalid PAN instance input")
+func expandPanInstances(in []interface{}, m interface{}) ([]alkira.ServicePanInstance, error) {
+	if in == nil || len(in) == 0 {
+		return nil, errors.New("Invalid PAN instance input")
 	}
 
-	instances := make([]alkira.ServicePanInstance, in.Len())
-	for i, instance := range in.List() {
+	instances := make([]alkira.ServicePanInstance, len(in))
+	for i, instance := range in {
 		r := alkira.ServicePanInstance{}
 		instanceCfg := instance.(map[string]interface{})
 		if v, ok := instanceCfg["id"].(int); ok {

--- a/docs/resources/connector_aruba_edge.md
+++ b/docs/resources/connector_aruba_edge.md
@@ -55,7 +55,7 @@ resource "alkira_connector_aruba_edge" "test1" {
 
 - `cxp` (String) The CXP where the connector should be provisioned.
 - `gateway_gbp_asn` (Number) The gateway BGP ASN.
-- `instances` (Block Set, Min: 1) The Aruba Edge connector instances. (see [below for nested schema](#nestedblock--instances))
+- `instances` (Block List, Min: 1) The Aruba Edge connector instances. (see [below for nested schema](#nestedblock--instances))
 - `name` (String) The name of the connector.
 - `segment_ids` (List of String) The IDs of the segments associated with the Aruba Edge connector.
 - `size` (String) The size of the connector, one of `SMALL`, `MEDIUM` or `LARGE`.
@@ -83,6 +83,10 @@ Required:
 - `host_name` (String) The host name given to the Aruba SD-WAN appliance that appears in Silver Peak orchestrator.
 - `name` (String) The instance name associated with aruba edge connect instance.
 - `site_tag` (String) The site tag that appears on the SD-WAN appliance on Silver Peak orchestrator
+
+Read-Only:
+
+- `id` (Number) The ID of the endpoint.
 
 
 <a id="nestedblock--aruba_edge_vrf_mapping"></a>

--- a/docs/resources/connector_cisco_sdwan.md
+++ b/docs/resources/connector_cisco_sdwan.md
@@ -52,7 +52,7 @@ resource "alkira_connector_cisco_sdwan" "test" {
 - `cxp` (String) The CXP where the connector should be provisioned.
 - `name` (String) The name of the connector.
 - `size` (String) The size of the connector, one of `SMALL`, `MEDIUM` and `LARGE`, `2LARGE`, `4LARGE`, `5LARGE`, `10LARGE` and `20LARGE`.
-- `vedge` (Block Set, Min: 1) Cisco vEdge (see [below for nested schema](#nestedblock--vedge))
+- `vedge` (Block List, Min: 1) Cisco vEdge (see [below for nested schema](#nestedblock--vedge))
 - `version` (String) The version of Cisco SD-WAN.
 - `vrf_segment_mapping` (Block Set, Min: 1) Specify target segment for VRF. (see [below for nested schema](#nestedblock--vrf_segment_mapping))
 

--- a/docs/resources/service_fortinet.md
+++ b/docs/resources/service_fortinet.md
@@ -49,7 +49,7 @@ resource "alkira_fortinet" "test1" {
 
 - `credential_id` (String) ID of Fortinet Firewall credential managed by credential resource.
 - `cxp` (String) The CXP where the service should be provisioned.
-- `instances` (Block Set, Min: 1) An array containing properties for each Fortinet Firewall instance that needs to be deployed. The number of instances should be equal to max_instance_count. (see [below for nested schema](#nestedblock--instances))
+- `instances` (Block List, Min: 1) An array containing properties for each Fortinet Firewall instance that needs to be deployed. The number of instances should be equal to `max_instance_count`. (see [below for nested schema](#nestedblock--instances))
 - `license_type` (String) Fortinet license type, either `BRING_YOUR_OWN` or `PAY_AS_YOU_GO`.
 - `management_server_ip` (String) The IP addresses used to access the management server.
 - `management_server_segment` (String) The segment used to access the management server. This segment must be present in the list of segments assigned to this Fortinet Firewall service.

--- a/docs/resources/service_pan.md
+++ b/docs/resources/service_pan.md
@@ -63,7 +63,7 @@ resource "alkira_service_pan" "test1" {
 
 - `credential_id` (String) ID of PAN credential managed by credential resource.
 - `cxp` (String) The CXP where the service should be provisioned.
-- `instance` (Block Set, Min: 1) (see [below for nested schema](#nestedblock--instance))
+- `instance` (Block List, Min: 1) (see [below for nested schema](#nestedblock--instance))
 - `license_type` (String) PAN license type, either `BRING_YOUR_OWN` or `PAY_AS_YOU_GO`.
 - `management_segment_id` (Number) Management Segment ID.
 - `max_instance_count` (Number) Max number of Panorama instances for auto scale.


### PR DESCRIPTION
Switch from TypeSet to TypeList to avoid diff issue when updating resources.

+ Update connector_aruba_edge instances block to use TypeList.
+ Update connector_cisco_sdwan vedge block to use TypeList.
+ Update service_fortinet isntances block to use TypeList.
+ Update service_pan instance block to use TypeList.