### PR TITLE
AK-27457 Update acceptance.yml for acceptance action to destroy always

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -46,6 +46,7 @@ jobs:
           terraform apply --auto-approve
       -
         name: Run Terraform Destroy
+        if: ${{ always() }}
         run: |
           cd acceptance
           terraform destroy --auto-approve


### PR DESCRIPTION
Terraform destroy must run to clean up even if Terraform apply fails.