### PR TITLE
AK-28216 Deprecate fortinet credential resources

### DIFF
--- a/alkira/resource_alkira_credential_fortinet.go
+++ b/alkira/resource_alkira_credential_fortinet.go
@@ -17,6 +17,9 @@ func resourceAlkiraCredentialFortinet() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},
+		DeprecationMessage: "alkira_credential_fortinet has been deprecated. " +
+			"Please specify username and password directly in resource service_fortinet. " +
+			"See documentation for example.",
 
 		Schema: map[string]*schema.Schema{
 			"name": &schema.Schema{

--- a/alkira/resource_alkira_credential_fortinet.go
+++ b/alkira/resource_alkira_credential_fortinet.go
@@ -2,9 +2,6 @@
 package alkira
 
 import (
-	"log"
-
-	"github.com/alkiranet/alkira-client-go/alkira"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
@@ -18,7 +15,7 @@ func resourceAlkiraCredentialFortinet() *schema.Resource {
 			State: schema.ImportStatePassthrough,
 		},
 		DeprecationMessage: "alkira_credential_fortinet has been deprecated. " +
-			"Please specify username and password directly in resource service_fortinet. " +
+			"Please specify `username` and `password` directly in resource alkira_service_fortinet. " +
 			"See documentation for example.",
 
 		Schema: map[string]*schema.Schema{
@@ -42,22 +39,7 @@ func resourceAlkiraCredentialFortinet() *schema.Resource {
 }
 
 func resourceCredentialFortinet(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*alkira.AlkiraClient)
-
-	c := &alkira.CredentialFortinet{
-		UserName: d.Get("username").(string),
-		Password: d.Get("password").(string),
-	}
-
-	log.Printf("[INFO] Creating Credential (Fortinet)")
-	credentialId, err := client.CreateCredential(d.Get("name").(string), alkira.CredentialTypeFortinet, c, 0)
-
-	if err != nil {
-		return err
-	}
-
-	d.SetId(credentialId)
-	return resourceCredentialFortinetRead(d, meta)
+	return nil
 }
 
 func resourceCredentialFortinetRead(d *schema.ResourceData, meta interface{}) error {
@@ -65,39 +47,9 @@ func resourceCredentialFortinetRead(d *schema.ResourceData, meta interface{}) er
 }
 
 func resourceCredentialFortinetUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*alkira.AlkiraClient)
-
-	c := &alkira.CredentialFortinet{
-		UserName: d.Get("username").(string),
-		Password: d.Get("password").(string),
-	}
-
-	log.Printf("[INFO] Updating Credential (Fortinet)")
-	err := client.UpdateCredential(
-		d.Id(),
-		d.Get("name").(string),
-		alkira.CredentialTypeFortinet,
-		c,
-		0,
-	)
-
-	if err != nil {
-		return err
-	}
-
-	return resourceCredentialFortinetRead(d, meta)
+	return nil
 }
 
 func resourceCredentialFortinetDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*alkira.AlkiraClient)
-	credentialId := d.Id()
-
-	log.Printf("[INFO] Deleting Credential (Fortinet %s)\n", credentialId)
-	err := client.DeleteCredential(credentialId, alkira.CredentialTypeFortinet)
-
-	if err != nil {
-		log.Printf("[INFO] Credential (Fortinet %s) was already deleted\n", credentialId)
-	}
-
 	return nil
 }

--- a/alkira/resource_alkira_credential_fortinet_instance.go
+++ b/alkira/resource_alkira_credential_fortinet_instance.go
@@ -1,9 +1,6 @@
 package alkira
 
 import (
-	"log"
-
-	"github.com/alkiranet/alkira-client-go/alkira"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
@@ -25,7 +22,7 @@ func resourceAlkiraCredentialFortinetInstance() *schema.Resource {
 			"You may also use terraform's built in `file` helper function as a literal input for " +
 			"`license_key`. Ex: `license_key = file('/path/to/license/file')`.",
 		DeprecationMessage: "alkira_credential_fortinet_instance has been deprecated. " +
-			"Please specify license_key or license_key_file_path directly in resource service_fortinet. " +
+			"Please specify `license_key` or `license_key_file_path` directly in resource alkira_service_fortinet. " +
 			"See documentation for example.",
 
 		Schema: map[string]*schema.Schema{
@@ -52,34 +49,14 @@ func resourceAlkiraCredentialFortinetInstance() *schema.Resource {
 				Type:         schema.TypeString,
 				Required:     true,
 				ValidateFunc: validation.StringInSlice([]string{"BRING_YOUR_OWN", "PAY_AS_YOU_GO"}, false),
-				Deprecated:   "Not supported anymore. Set license_type in service_fortinet",
+				Deprecated:   "Not supported anymore. Set `license_type` in alkira_service_fortinet",
 			},
 		},
 	}
 }
 
 func resourceCredentialFortinetInstance(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*alkira.AlkiraClient)
-
-	licenseKey, err := extractLicenseKey(
-		d.Get("license_key").(string),
-		d.Get("license_key_file_path").(string),
-	)
-
-	c := alkira.CredentialFortinetInstance{
-		LicenseKey:  licenseKey,
-		LicenseType: d.Get("license_type").(string),
-	}
-
-	log.Printf("[INFO] Creating Credential (Fortinet Instance)")
-	credentialId, err := client.CreateCredential(d.Get("name").(string), alkira.CredentialTypeFortinetInstance, c, 0)
-
-	if err != nil {
-		return err
-	}
-
-	d.SetId(credentialId)
-	return resourceCredentialFortinetInstanceRead(d, meta)
+	return nil
 }
 
 func resourceCredentialFortinetInstanceRead(d *schema.ResourceData, meta interface{}) error {
@@ -87,38 +64,9 @@ func resourceCredentialFortinetInstanceRead(d *schema.ResourceData, meta interfa
 }
 
 func resourceCredentialFortinetInstanceUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*alkira.AlkiraClient)
-
-	licenseKey, err := extractLicenseKey(
-		d.Get("license_key").(string),
-		d.Get("license_key_file_path").(string),
-	)
-
-	c := alkira.CredentialFortinetInstance{
-		LicenseKey:  licenseKey,
-		LicenseType: d.Get("license_type").(string),
-	}
-
-	log.Printf("[INFO] Updating Credential (Fortinet Instance)")
-	err = client.UpdateCredential(d.Id(), d.Get("name").(string), alkira.CredentialTypeFortinetInstance, c, 0)
-
-	if err != nil {
-		return err
-	}
-
-	return resourceCredentialFortinetInstanceRead(d, meta)
+	return nil
 }
 
 func resourceCredentialFortinetInstanceDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*alkira.AlkiraClient)
-	credentialId := d.Id()
-
-	log.Printf("[INFO] Deleting Credential (Fortinet Instance %s)\n", credentialId)
-	err := client.DeleteCredential(credentialId, alkira.CredentialTypeFortinetInstance)
-
-	if err != nil {
-		log.Printf("[INFO] Credential (Fortinet Instance %s) was already deleted\n", credentialId)
-	}
-
 	return nil
 }

--- a/alkira/resource_alkira_credential_fortinet_instance.go
+++ b/alkira/resource_alkira_credential_fortinet_instance.go
@@ -1,10 +1,7 @@
 package alkira
 
 import (
-	"errors"
-	"fmt"
 	"log"
-	"os"
 
 	"github.com/alkiranet/alkira-client-go/alkira"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -27,6 +24,9 @@ func resourceAlkiraCredentialFortinetInstance() *schema.Resource {
 			"the Alkira provider will treat the `license_key` field with precedence. \n\n\n " +
 			"You may also use terraform's built in `file` helper function as a literal input for " +
 			"`license_key`. Ex: `license_key = file('/path/to/license/file')`.",
+		DeprecationMessage: "alkira_credential_fortinet_instance has been deprecated. " +
+			"Please specify license_key or license_key_file_path directly in resource service_fortinet. " +
+			"See documentation for example.",
 
 		Schema: map[string]*schema.Schema{
 			"name": &schema.Schema{
@@ -52,6 +52,7 @@ func resourceAlkiraCredentialFortinetInstance() *schema.Resource {
 				Type:         schema.TypeString,
 				Required:     true,
 				ValidateFunc: validation.StringInSlice([]string{"BRING_YOUR_OWN", "PAY_AS_YOU_GO"}, false),
+				Deprecated:   "Not supported anymore. Set license_type in service_fortinet",
 			},
 		},
 	}
@@ -120,29 +121,4 @@ func resourceCredentialFortinetInstanceDelete(d *schema.ResourceData, meta inter
 	}
 
 	return nil
-}
-
-// extractLicenseKey takes two string values. The order of the string parameters matters. After
-// validation, if both fields have are noto empty strings extractLicenseKey will default to using
-// licenseKey as the return value. Otherwise extractLicenseKey will read from the licenseKeyPath
-// and return the output as a string
-func extractLicenseKey(licenseKey string, licenseKeyPath string) (string, error) {
-	if licenseKey == "" && licenseKeyPath == "" {
-		return "", errors.New("either license_key or license_key_file_path must be populated")
-	}
-
-	if licenseKey != "" {
-		return licenseKey, nil
-	}
-
-	if _, err := os.Stat(licenseKeyPath); errors.Is(err, os.ErrNotExist) {
-		return "", fmt.Errorf("file not found at %s: %w", licenseKeyPath, err)
-	}
-
-	b, err := os.ReadFile(licenseKeyPath)
-	if err != nil {
-		return "", err
-	}
-
-	return string(b), nil
 }

--- a/alkira/resource_alkira_service_fortinet.go
+++ b/alkira/resource_alkira_service_fortinet.go
@@ -37,7 +37,6 @@ func resourceAlkiraServiceFortinet() *schema.Resource {
 			"credential_id": {
 				Description: "ID of Fortinet Firewall credential managed by credential resource.",
 				Type:        schema.TypeString,
-				Optional:    true,
 				Computed:    true,
 			},
 			"cxp": {
@@ -70,22 +69,26 @@ func resourceAlkiraServiceFortinet() *schema.Resource {
 						},
 						"license_key_file_path": {
 							Description: "Fortinet license key file path. The path to the desired license key. " +
-								"`license_key_file_path` will be if both `license_key` and `license_key_file_path` " +
-								"are provided in your configuration file. ",
+								"There are two options for providing the required license key for Fortinet " +
+								"instance credentials. You can either input the value directly into the `license_key` field " +
+								"or provide the file path for the license key file using the `license_key_file_path`. " +
+								"Either `license_key` and `license_key_file_path` must have an input. If both are provided, " +
+								"the Alkira provider will treat the `license_key` field with precedence. \n\n\n " +
+								"You may also use terraform's built in `file` helper function as a literal input for " +
+								"`license_key`. Ex: `license_key = file('/path/to/license/file')`.",
 							Type:     schema.TypeString,
 							Optional: true,
 						},
 						"serial_number": {
 							Description: "The serial_number of the Fortinet Firewall instance. " +
-								"Required only when licenseType is BRING_YOUR_OWN.",
+								"Required only when `license_type` is `BRING_YOUR_OWN.",
 							Type:     schema.TypeString,
 							Optional: true,
 						},
 						"credential_id": {
 							Description: "The ID of the Fortinet Firewall instance credentials. " +
-								"Required only when licenseType is BRING_YOUR_OWN.",
+								"Required only when `license_type` is `BRING_YOUR_OWN`.",
 							Type:     schema.TypeString,
-							Optional: true,
 							Computed: true,
 						},
 						"id": {

--- a/docs/resources/credential_fortinet_instance.md
+++ b/docs/resources/credential_fortinet_instance.md
@@ -29,7 +29,7 @@ resource "alkira_credential_fortinet_instance" "tf_test_fortinet-instance" {
 
 ### Required
 
-- `license_type` (String) Fortinet instance license type, either `BRING_YOUR_OWN` or `PAY_AS_YOU_GO`.
+- `license_type` (String, Deprecated) Fortinet instance license type, either `BRING_YOUR_OWN` or `PAY_AS_YOU_GO`.
 - `name` (String) The name of the credential.
 
 ### Optional

--- a/docs/resources/service_fortinet.md
+++ b/docs/resources/service_fortinet.md
@@ -13,37 +13,37 @@ Manage Fortinet firewall.
 ## Example Usage
 
 ```terraform
-resource "alkira_service_fortinet" "fortinet" {
-
-  credential_id             = alkira_credential_fortinet.credential.id
-  cxp                       = "US-WEST-1"
-  license_type              = "PAY_AS_YOU_GO"
+resource "alkira_service_fortinet" "test1" {
+  username                  = "admin"
+  password                  = "Ak12345678"
+  cxp                       = "US-WEST"
+  license_type              = "BRING_YOUR_OWN"
   management_server_ip      = ""
-  management_server_segment = alkira_segment.segment.name
+  management_server_segment = alkira_segment.test1.name
   max_instance_count        = 1
   min_instance_count        = 1
   name                      = "test1-update"
-  segment_ids               = [alkira_segment.segment.id, alkira_segment.segment1.id]
+  segment_ids               = [alkira_segment.test1.id, alkira_segment.test2.id]
   size                      = "SMALL"
   tunnel_protocol           = "IPSEC"
   version                   = "7.0.2"
 
+  # You can add more instance blocks. Make sure to change "max_instance_count".
   instances {
-    name          = "tf-fortinet-instance-1"
-    serial_number = "mactest-instance-1"
-    credential_id = alkira_credential_fortinet.credential.id
+    name                  = "tf-fortinet-instance-1"
+    serial_number         = "licensekey"
+    license_key_file_path = "/path/to/license.lic"
   }
-
   segment_options {
-    segment_id = alkira_segment.segment.id
+    segment_id = alkira_segment.test.id
     zone_name  = "zonename"
-    groups     = [alkira_group.group.name, alkira_group.group1.name]
+    groups     = [alkira_group.test.name]
   }
 
   segment_options {
-    segment_id = alkira_segment.segment1.id
+    segment_id = alkira_segment.test.id
     zone_name  = "zonename1"
-    groups     = [alkira_group.group2.name]
+    groups     = [alkira_group.test.name]
   }
 }
 ```
@@ -53,7 +53,6 @@ resource "alkira_service_fortinet" "fortinet" {
 
 ### Required
 
-- `credential_id` (String) ID of Fortinet Firewall credential managed by credential resource.
 - `cxp` (String) The CXP where the service should be provisioned.
 - `instances` (Block List, Min: 1) An array containing properties for each Fortinet Firewall instance that needs to be deployed. The number of instances should be equal to `max_instance_count`. (see [below for nested schema](#nestedblock--instances))
 - `license_type` (String) Fortinet license type, either `BRING_YOUR_OWN` or `PAY_AS_YOU_GO`.
@@ -68,10 +67,13 @@ resource "alkira_service_fortinet" "fortinet" {
 
 - `auto_scale` (String) Indicate if auto_scale should be enabled for your Fortinet firewall. `ON` and `OFF` are accepted values. `OFF` is the default if field is omitted
 - `billing_tag_ids` (List of Number) Billing tag IDs to associate with the service.
+- `credential_id` (String) ID of Fortinet Firewall credential managed by credential resource.
 - `management_server_ip` (String) The IP addresses used to access the management server.
 - `min_instance_count` (Number) The minimum number of Fortinet Firewall instances that should be  deployed at any point in time.
+- `password` (String) Fortinet password.
 - `segment_options` (Block Set) The segment options as used by your Fortinet firewall. (see [below for nested schema](#nestedblock--segment_options))
 - `tunnel_protocol` (String) Tunnel Protocol, default to `IPSEC`, could be either `IPSEC` or `GRE`.
+- `username` (String) Fortinet username.
 
 ### Read-Only
 
@@ -80,13 +82,11 @@ resource "alkira_service_fortinet" "fortinet" {
 <a id="nestedblock--instances"></a>
 ### Nested Schema for `instances`
 
-Required:
-
-- `name` (String) The name of the Fortinet Firewall instance.
-
 Optional:
 
 - `credential_id` (String) The ID of the Fortinet Firewall instance credentials. Required only when licenseType is BRING_YOUR_OWN.
+- `license_key_file_path` (String) Fortinet license key file path. The path to the desired license key. `license_key_file_path` will be if both `license_key` and `license_key_file_path` are provided in your configuration file.
+- `name` (String) The name of the Fortinet Firewall instance.
 - `serial_number` (String) The serial_number of the Fortinet Firewall instance. Required only when licenseType is BRING_YOUR_OWN.
 
 Read-Only:

--- a/docs/resources/service_fortinet.md
+++ b/docs/resources/service_fortinet.md
@@ -67,7 +67,6 @@ resource "alkira_service_fortinet" "test1" {
 
 - `auto_scale` (String) Indicate if auto_scale should be enabled for your Fortinet firewall. `ON` and `OFF` are accepted values. `OFF` is the default if field is omitted
 - `billing_tag_ids` (List of Number) Billing tag IDs to associate with the service.
-- `credential_id` (String) ID of Fortinet Firewall credential managed by credential resource.
 - `management_server_ip` (String) The IP addresses used to access the management server.
 - `min_instance_count` (Number) The minimum number of Fortinet Firewall instances that should be  deployed at any point in time.
 - `password` (String) Fortinet password.
@@ -77,6 +76,7 @@ resource "alkira_service_fortinet" "test1" {
 
 ### Read-Only
 
+- `credential_id` (String) ID of Fortinet Firewall credential managed by credential resource.
 - `id` (String) The ID of this resource.
 
 <a id="nestedblock--instances"></a>
@@ -84,13 +84,16 @@ resource "alkira_service_fortinet" "test1" {
 
 Optional:
 
-- `credential_id` (String) The ID of the Fortinet Firewall instance credentials. Required only when licenseType is BRING_YOUR_OWN.
-- `license_key_file_path` (String) Fortinet license key file path. The path to the desired license key. `license_key_file_path` will be if both `license_key` and `license_key_file_path` are provided in your configuration file.
+- `license_key_file_path` (String) Fortinet license key file path. The path to the desired license key. There are two options for providing the required license key for Fortinet instance credentials. You can either input the value directly into the `license_key` field or provide the file path for the license key file using the `license_key_file_path`. Either `license_key` and `license_key_file_path` must have an input. If both are provided, the Alkira provider will treat the `license_key` field with precedence. 
+
+
+ You may also use terraform's built in `file` helper function as a literal input for `license_key`. Ex: `license_key = file('/path/to/license/file')`.
 - `name` (String) The name of the Fortinet Firewall instance.
-- `serial_number` (String) The serial_number of the Fortinet Firewall instance. Required only when licenseType is BRING_YOUR_OWN.
+- `serial_number` (String) The serial_number of the Fortinet Firewall instance. Required only when `license_type` is `BRING_YOUR_OWN.
 
 Read-Only:
 
+- `credential_id` (String) The ID of the Fortinet Firewall instance credentials. Required only when `license_type` is `BRING_YOUR_OWN`.
 - `id` (Number) The ID of the Fortinet Firewall instance.
 
 

--- a/examples/resources/alkira_service_fortinet/resource.tf
+++ b/examples/resources/alkira_service_fortinet/resource.tf
@@ -1,33 +1,33 @@
-resource "alkira_service_fortinet" "fortinet" {
-
-  credential_id             = alkira_credential_fortinet.credential.id
-  cxp                       = "US-WEST-1"
-  license_type              = "PAY_AS_YOU_GO"
+resource "alkira_service_fortinet" "test1" {
+  username                  = "admin"
+  password                  = "Ak12345678"
+  cxp                       = "US-WEST"
+  license_type              = "BRING_YOUR_OWN"
   management_server_ip      = ""
-  management_server_segment = alkira_segment.segment.name
+  management_server_segment = alkira_segment.test1.name
   max_instance_count        = 1
   min_instance_count        = 1
   name                      = "test1-update"
-  segment_ids               = [alkira_segment.segment.id, alkira_segment.segment1.id]
+  segment_ids               = [alkira_segment.test1.id, alkira_segment.test2.id]
   size                      = "SMALL"
   tunnel_protocol           = "IPSEC"
   version                   = "7.0.2"
 
+  # You can add more instance blocks. Make sure to change "max_instance_count".
   instances {
-    name          = "tf-fortinet-instance-1"
-    serial_number = "mactest-instance-1"
-    credential_id = alkira_credential_fortinet.credential.id
+    name                  = "tf-fortinet-instance-1"
+    serial_number         = "licensekey"
+    license_key_file_path = "/path/to/license.lic"
   }
-
   segment_options {
-    segment_id = alkira_segment.segment.id
+    segment_id = alkira_segment.test.id
     zone_name  = "zonename"
-    groups     = [alkira_group.group.name, alkira_group.group1.name]
+    groups     = [alkira_group.test.name]
   }
 
   segment_options {
-    segment_id = alkira_segment.segment1.id
+    segment_id = alkira_segment.test.id
     zone_name  = "zonename1"
-    groups     = [alkira_group.group2.name]
+    groups     = [alkira_group.test.name]
   }
 }


### PR DESCRIPTION
Moved fortinet credentials and fortinet instance credentials into fortinet service. Added deprecation messages. Fixed license_type duplication, only required in service_fortinet.