### PR TITLE
AK-28710 Mark username and password required in service_pan

### DIFF
--- a/alkira/resource_alkira_service_pan.go
+++ b/alkira/resource_alkira_service_pan.go
@@ -42,14 +42,14 @@ func resourceAlkiraServicePan() *schema.Resource {
 				ValidateFunc: validation.StringInSlice([]string{"VM_SERIES_BUNDLE_1", "VM_SERIES_BUNDLE_2", "PAN_VM_300_BUNDLE_2"}, false),
 			},
 			"pan_password": {
-				Description: "PAN password. This is required when `panorama_enabled` is set to `true`.",
+				Description: "PAN password.",
 				Type:        schema.TypeString,
-				Optional:    true,
+				Required:    true,
 			},
 			"pan_username": {
-				Description: "PAN username. This is required when `panorama_enabled` is set to `true`.",
+				Description: "PAN username.",
 				Type:        schema.TypeString,
-				Optional:    true,
+				Required:    true,
 			},
 			"credential_id": {
 				Description: "ID of PAN credential.",

--- a/docs/resources/service_pan.md
+++ b/docs/resources/service_pan.md
@@ -93,6 +93,8 @@ resource "alkira_service_pan" "test1" {
 - `management_segment_id` (Number) Management Segment ID.
 - `max_instance_count` (Number) Max number of Panorama instances for auto scale.
 - `name` (String) Name of the PAN service.
+- `pan_password` (String) PAN password.
+- `pan_username` (String) PAN username.
 - `registration_pin_expiry` (String) PAN Registration PIN Expiry. The date should be in format of `YYYY-MM-DD`, e.g. `2000-01-01`.
 - `registration_pin_id` (String) PAN Registration PIN ID.
 - `registration_pin_value` (String) PAN Registration PIN Value.
@@ -111,8 +113,6 @@ resource "alkira_service_pan" "test1" {
 - `master_key_enabled` (Boolean) Enable Master Key for PAN instances or not. It's default to `false`.
 - `master_key_expiry` (String) PAN Master Key Expiry. The date should be in format of `YYYY-MM-DD`, e.g. `2000-01-01`.
 - `min_instance_count` (Number) Minimal number of Panorama instances for auto scale. Default value is `0`.
-- `pan_password` (String) PAN password. This is required when `panorama_enabled` is set to `true`.
-- `pan_username` (String) PAN username. This is required when `panorama_enabled` is set to `true`.
 - `panorama_device_group` (String) Panorama device group.
 - `panorama_enabled` (Boolean) Enable Panorama or not. Default value is `false`.
 - `panorama_ip_addresses` (List of String) Panorama IP addresses.


### PR DESCRIPTION
Mark pan_username and pan_password as "Required" in service_pan. Those two are always required now.