### PR TITLE
AK-29557 Update customer_asn of alkira_connector_cisco_sdwan to be re…

### DIFF
--- a/alkira/resource_alkira_connector_cisco_sdwan.go
+++ b/alkira/resource_alkira_connector_cisco_sdwan.go
@@ -139,10 +139,10 @@ func resourceAlkiraConnectorCiscoSdwan() *schema.Resource {
 							Default:     true,
 						},
 						"customer_asn": {
-							Description: "BGP ASN on the customer premise side. Default value is `64523`.",
-							Type:        schema.TypeInt,
-							Optional:    true,
-							Default:     64523,
+							Description: "BGP ASN on the customer premise side. A typical value for 2 byte segment " +
+								"is `64523` and `4200064523` for 4 byte segment.",
+							Type:     schema.TypeInt,
+							Required: true,
 						},
 						"segment_id": {
 							Description: "Segment ID.",

--- a/docs/guides/release-notes-v0.9.7.md
+++ b/docs/guides/release-notes-v0.9.7.md
@@ -1,3 +1,10 @@
+---
+subcategory: "Release Notes"
+page_title: "v0.9.7"
+description: |-
+    Release notes for v0.9.7
+---
+
 This release introduces new resource to manage Azure ExpressRoute
 connector and several new data sources with various enhancements and
 bug fixes.

--- a/docs/resources/connector_cisco_sdwan.md
+++ b/docs/resources/connector_cisco_sdwan.md
@@ -82,6 +82,7 @@ Read-Only:
 
 Required:
 
+- `customer_asn` (Number) BGP ASN on the customer premise side. A typical value for 2 byte segment is `64523` and `4200064523` for 4 byte segment.
 - `segment_id` (Number) Segment ID.
 - `vrf_id` (Number) VRF ID.
 
@@ -89,7 +90,6 @@ Optional:
 
 - `advertise_on_prem_routes` (Boolean) Advertise On Prem Routes.
 - `allow_nat_exit` (Boolean) Allow NAT exit.
-- `customer_asn` (Number) BGP ASN on the customer premise side. Default value is `64523`.
 
 ## Import
 

--- a/templates/guides/release-notes-v0.9.7.md
+++ b/templates/guides/release-notes-v0.9.7.md
@@ -1,3 +1,10 @@
+---
+subcategory: "Release Notes"
+page_title: "v0.9.7"
+description: |-
+    Release notes for v0.9.7
+---
+
 This release introduces new resource to manage Azure ExpressRoute
 connector and several new data sources with various enhancements and
 bug fixes.


### PR DESCRIPTION
…quired

The default value of the customer_asn could be different based on 2 byte of 4 byte segment, so make it a required field.

+ Fix the metadata of release notes.
+ Make customer_asn required.
+ Update connector_cisco_sdwan documenation.