### PR TITLE
AK-30188 Set Availability when routing_type is BOTH in connector_ipsec

### DIFF
--- a/alkira/resource_alkira_connector_ipsec_helper.go
+++ b/alkira/resource_alkira_connector_ipsec_helper.go
@@ -273,6 +273,7 @@ func expandConnectorIPSecRoutingOptions(in *schema.Set) (*alkira.ConnectorIPSecR
 
 				if availOk {
 					staticOption.Availability = avail
+					dynamicOption.Availability = avail
 				}
 
 				asn, asnOk := routingOptionsInput["customer_gateway_asn"].(string)


### PR DESCRIPTION
Set availability for both static and dynamic routing when routing_type is specified as BOTH.