### PR TITLE
AK-30584 Skip interCxpRoutesRedistribution when it's empty in policy_…

### DIFF
--- a/acceptance/policy_routing.tf
+++ b/acceptance/policy_routing.tf
@@ -1,0 +1,32 @@
+resource "alkira_policy_routing" "test1" {
+  name               = "acceptance-inbound"
+  description        = "aceeptance test of inbound routing policy"
+  enabled            = "false"
+  direction          = "INBOUND"
+  included_group_ids = [alkira_group.test2.id]
+  segment_id         = alkira_segment.test2.id
+
+  rule {
+    name                     = "test-rule-1"
+    action                   = "ALLOW"
+    match_all                = true
+    routes_distribution_type = "ALL"
+  }
+}
+
+resource "alkira_policy_routing" "test2" {
+  name               = "acceptance-outbound"
+  enabled            = false
+  direction          = "OUTBOUND"
+  included_group_ids = [alkira_group.test2.id]
+  segment_id         = alkira_segment.test2.id
+
+  rule {
+    name            = "test-rule-2"
+    action          = "ALLOW"
+    match_all       = false
+    match_group_ids = [alkira_group.test2.id]
+
+    set_as_path_prepend = 65300
+  }
+}

--- a/alkira/resource_alkira_policy_routing.go
+++ b/alkira/resource_alkira_policy_routing.go
@@ -178,7 +178,6 @@ func resourceAlkiraPolicyRouting() *schema.Resource {
 								"`ALL`, `LOCAL_ONLY` and `RESTRICTED_CXPS`.",
 							Type:     schema.TypeString,
 							Optional: true,
-							Default:  "ALL",
 						},
 						"routes_distribution_restricted_cxps": {
 							Description: "List of cxps to which routes " +

--- a/alkira/resource_alkira_policy_routing_helper.go
+++ b/alkira/resource_alkira_policy_routing_helper.go
@@ -2,6 +2,7 @@ package alkira
 
 import (
 	"fmt"
+	"reflect"
 
 	"github.com/alkiranet/alkira-client-go/alkira"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -88,6 +89,10 @@ func expandPolicyRoutingRuleInterCxpRoutesRedistribution(in map[string]interface
 		}
 	}
 
+	if reflect.DeepEqual(distrib, alkira.RoutePolicyRulesInterCxpRoutesRedistribution{}) {
+		return nil, nil
+	}
+
 	return &distrib, nil
 }
 
@@ -127,12 +132,13 @@ func expandPolicyRoutingRule(in *schema.Set) ([]alkira.RoutePolicyRules, error) 
 
 		rule.Set = set
 
-		distribution, err := expandPolicyRoutingRuleInterCxpRoutesRedistribution(input)
-		if err != nil {
-			return nil, err
-		}
+		// distribution, err := expandPolicyRoutingRuleInterCxpRoutesRedistribution(input)
 
-		rule.InterCxpRoutesRedistribution = distribution
+		// if err != nil {
+		// 	return nil, err
+		// }
+
+		rule.InterCxpRoutesRedistribution = nil
 
 		rules[i] = rule
 	}

--- a/alkira/resource_alkira_policy_routing_helper.go
+++ b/alkira/resource_alkira_policy_routing_helper.go
@@ -132,13 +132,13 @@ func expandPolicyRoutingRule(in *schema.Set) ([]alkira.RoutePolicyRules, error) 
 
 		rule.Set = set
 
-		// distribution, err := expandPolicyRoutingRuleInterCxpRoutesRedistribution(input)
+		distribution, err := expandPolicyRoutingRuleInterCxpRoutesRedistribution(input)
 
-		// if err != nil {
-		// 	return nil, err
-		// }
+		if err != nil {
+			return nil, err
+		}
 
-		rule.InterCxpRoutesRedistribution = nil
+		rule.InterCxpRoutesRedistribution = distribution
 
 		rules[i] = rule
 	}

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.18
 replace github.com/hashicorp/go-getter => github.com/hashicorp/go-getter v1.6.1
 
 require (
-	github.com/alkiranet/alkira-client-go v1.35.1
+	github.com/alkiranet/alkira-client-go v1.35.2
 	github.com/hashicorp/terraform-plugin-sdk v1.15.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.1.0
 	github.com/stretchr/testify v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -43,8 +43,8 @@ github.com/agext/levenshtein v1.2.2/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki
 github.com/agl/ed25519 v0.0.0-20170116200512-5312a6153412/go.mod h1:WPjqKcmVOxf0XSf3YxCJs6N6AOSrOx3obionmG7T0y0=
 github.com/alcortesm/tgz v0.0.0-20161220082320-9c5fe88206d7 h1:uSoVVbwJiQipAclBbw+8quDsfcvFjOpI5iCf4p/cqCs=
 github.com/alcortesm/tgz v0.0.0-20161220082320-9c5fe88206d7/go.mod h1:6zEj6s6u/ghQa61ZWa/C2Aw3RkjiTBOix7dkqa1VLIs=
-github.com/alkiranet/alkira-client-go v1.35.1 h1:IfGqefImW6j9PSRWjrbIu3CWVFy8Mz1Ow084GWAzk4Q=
-github.com/alkiranet/alkira-client-go v1.35.1/go.mod h1:axBJiMRcbqmOXHVljOofK+h5afU0ZroPWp6fPucBvk4=
+github.com/alkiranet/alkira-client-go v1.35.2 h1:1lCntfO/yKM9/U7F+juFWB80f/6vv17BiMJ9PbkRQdw=
+github.com/alkiranet/alkira-client-go v1.35.2/go.mod h1:axBJiMRcbqmOXHVljOofK+h5afU0ZroPWp6fPucBvk4=
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239 h1:kFOfPq6dUM1hTo4JG6LR5AXSUEsOjtdm0kw0FtQtMJA=
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239/go.mod h1:2FmKhYUyUczH0OGQWaF5ceTx0UBShxjsH6f8oGKYe2c=
 github.com/apparentlymart/go-cidr v1.0.1 h1:NmIwLZ/KdsjIUlhf+/Np40atNXm/+lZ5txfTJ/SpF+U=

--- a/vendor/github.com/alkiranet/alkira-client-go/alkira/policy_route_policy.go
+++ b/vendor/github.com/alkiranet/alkira-client-go/alkira/policy_route_policy.go
@@ -27,7 +27,7 @@ type RoutePolicyRules struct {
 	Name                         string                                        `json:"name"`
 	Match                        RoutePolicyRulesMatch                         `json:"match"`
 	Set                          *RoutePolicyRulesSet                          `json:"set,omitempty"`
-	InterCxpRoutesRedistribution *RoutePolicyRulesInterCxpRoutesRedistribution `json:"interCxpRoutesRedistribution"`
+	InterCxpRoutesRedistribution *RoutePolicyRulesInterCxpRoutesRedistribution `json:"interCxpRoutesRedistribution,omitempty"`
 }
 
 type RoutePolicyRulesMatch struct {
@@ -47,7 +47,7 @@ type RoutePolicyRulesSet struct {
 }
 
 type RoutePolicyRulesInterCxpRoutesRedistribution struct {
-	DistributionType        string   `json:"distributionType"`
+	DistributionType        string   `json:"distributionType,omitempty"`
 	RedistributeAsSecondary bool     `json:"redistributeAsSecondary,omitempty"`
 	RestrictedCxps          []string `json:"restrictedCxps,omitempty"`
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -13,7 +13,7 @@ cloud.google.com/go/storage
 # github.com/agext/levenshtein v1.2.2
 ## explicit
 github.com/agext/levenshtein
-# github.com/alkiranet/alkira-client-go v1.35.1
+# github.com/alkiranet/alkira-client-go v1.35.2
 ## explicit; go 1.14
 github.com/alkiranet/alkira-client-go/alkira
 # github.com/apparentlymart/go-cidr v1.0.1


### PR DESCRIPTION
…routing

Skip block interCxpRoutesRedistribution when it's empty to avoid backend validation issue.