### PR TITLE
AK-31225 Update advertise_internet_exit of routing_policy with defaul…

### DIFF
--- a/docs/resources/policy_routing.md
+++ b/docs/resources/policy_routing.md
@@ -50,7 +50,7 @@ resource "alkira_policy_routing" "test" {
 ### Optional
 
 - `advertise_custom_routes_prefix_id` (Number) Prefix list ID to send aggregates out towards on-prem connectors.
-- `advertise_internet_exit` (Boolean) Advertise Alkira’s Internet Connector to selected scope. Default value is `false`.
+- `advertise_internet_exit` (Boolean) Advertise Alkira’s Internet Connector to selected scope. This only applies to `OUTBOUND` policy. Default value is `true`.
 - `advertise_on_prem_routes` (Boolean) Advertise routes from other on premise connectors to selected scope. Default value is `false`.
 - `description` (String) The description of the routing policy.
 - `enabled` (Boolean) Whether the routing policy is enabled. By default, it is set to `false`.

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.18
 replace github.com/hashicorp/go-getter => github.com/hashicorp/go-getter v1.6.1
 
 require (
-	github.com/alkiranet/alkira-client-go v1.35.4
+	github.com/alkiranet/alkira-client-go v1.35.5
 	github.com/hashicorp/terraform-plugin-sdk v1.15.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.1.0
 	github.com/stretchr/testify v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -43,8 +43,8 @@ github.com/agext/levenshtein v1.2.2/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki
 github.com/agl/ed25519 v0.0.0-20170116200512-5312a6153412/go.mod h1:WPjqKcmVOxf0XSf3YxCJs6N6AOSrOx3obionmG7T0y0=
 github.com/alcortesm/tgz v0.0.0-20161220082320-9c5fe88206d7 h1:uSoVVbwJiQipAclBbw+8quDsfcvFjOpI5iCf4p/cqCs=
 github.com/alcortesm/tgz v0.0.0-20161220082320-9c5fe88206d7/go.mod h1:6zEj6s6u/ghQa61ZWa/C2Aw3RkjiTBOix7dkqa1VLIs=
-github.com/alkiranet/alkira-client-go v1.35.4 h1:jtFI8+SO+a1wN3a9zPnXk7bDqmaN6a8yM3Vdyr/sQcU=
-github.com/alkiranet/alkira-client-go v1.35.4/go.mod h1:axBJiMRcbqmOXHVljOofK+h5afU0ZroPWp6fPucBvk4=
+github.com/alkiranet/alkira-client-go v1.35.5 h1:AN5mR4472CRqd9Zk/DlvasIcDFD32xO+Rns1JP0UhI8=
+github.com/alkiranet/alkira-client-go v1.35.5/go.mod h1:axBJiMRcbqmOXHVljOofK+h5afU0ZroPWp6fPucBvk4=
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239 h1:kFOfPq6dUM1hTo4JG6LR5AXSUEsOjtdm0kw0FtQtMJA=
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239/go.mod h1:2FmKhYUyUczH0OGQWaF5ceTx0UBShxjsH6f8oGKYe2c=
 github.com/apparentlymart/go-cidr v1.0.1 h1:NmIwLZ/KdsjIUlhf+/Np40atNXm/+lZ5txfTJ/SpF+U=

--- a/vendor/github.com/alkiranet/alkira-client-go/alkira/policy_route_policy.go
+++ b/vendor/github.com/alkiranet/alkira-client-go/alkira/policy_route_policy.go
@@ -16,7 +16,7 @@ type RoutePolicy struct {
 	IncludedGroups                []int              `json:"includedGroups"`
 	ExcludedGroups                []int              `json:"excludedGroups,omitempty"`
 	Id                            json.Number        `json:"id,omitempty"`
-	AdvertiseInternetExit         bool               `json:"advertiseInternetExit,omitempty"`
+	AdvertiseInternetExit         *bool              `json:"advertiseInternetExit"`
 	AdvertiseOnPremRoutes         bool               `json:"advertiseOnPremRoutes,omitempty"`
 	AdvertiseCustomRoutesPrefixId int                `json:"advertiseCustomRoutesPrefixId,omitempty"`
 	Rules                         []RoutePolicyRules `json:"rules"`

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -13,7 +13,7 @@ cloud.google.com/go/storage
 # github.com/agext/levenshtein v1.2.2
 ## explicit
 github.com/agext/levenshtein
-# github.com/alkiranet/alkira-client-go v1.35.4
+# github.com/alkiranet/alkira-client-go v1.35.5
 ## explicit; go 1.14
 github.com/alkiranet/alkira-client-go/alkira
 # github.com/apparentlymart/go-cidr v1.0.1


### PR DESCRIPTION
…t value

Update advertise_internet_exit of routing_policy with default value true, but the field should be only applicable when policy is OUTBOUND. For INBOUND policy, the field should be NULL in the request.