### PR TITLE
AK-30729 Mark several fields in segment resource as BETA

### DIFF
--- a/alkira/resource_alkira_segment.go
+++ b/alkira/resource_alkira_segment.go
@@ -43,7 +43,7 @@ func resourceAlkiraSegment() *schema.Resource {
 			},
 			"enable_ipv6_to_ipv4_translation": {
 				Description: "Enable IPv6 to IPv4 translation in the " +
-					"segment for internet application traffic.",
+					"segment for internet application traffic. (**BETA**)",
 				Type:     schema.TypeBool,
 				Optional: true,
 				Default:  false,
@@ -51,7 +51,7 @@ func resourceAlkiraSegment() *schema.Resource {
 			"enterprise_dns_server_ip": {
 				Description: "The IP of the DNS server used within the segment. This DNS server " +
 					"may be used by the Alkira CXP to resolve the names of LDAP servers for example " +
-					"which are configured on the Remote Access Connector.",
+					"which are configured on the Remote Access Connector. (**BETA**)",
 				Type:     schema.TypeString,
 				Optional: true,
 			},

--- a/docs/resources/segment.md
+++ b/docs/resources/segment.md
@@ -35,8 +35,8 @@ resource "alkira_segment" "test" {
 
 - `asn` (Number) The BGP ASN for the segment. Default value is `65514`.
 - `description` (String) The description of the segment.
-- `enable_ipv6_to_ipv4_translation` (Boolean) Enable IPv6 to IPv4 translation in the segment for internet application traffic.
-- `enterprise_dns_server_ip` (String) The IP of the DNS server used within the segment. This DNS server may be used by the Alkira CXP to resolve the names of LDAP servers for example which are configured on the Remote Access Connector.
+- `enable_ipv6_to_ipv4_translation` (Boolean) Enable IPv6 to IPv4 translation in the segment for internet application traffic. (**BETA**)
+- `enterprise_dns_server_ip` (String) The IP of the DNS server used within the segment. This DNS server may be used by the Alkira CXP to resolve the names of LDAP servers for example which are configured on the Remote Access Connector. (**BETA**)
 - `reserve_public_ips` (Boolean) Default value is `false`. When this is set to `true`. Alkira reserves public IPs which can be used to create underlay tunnels between an external service and Alkira. For example the reserved public IPs may be used to create tunnels to the Akamai Prolexic. (**BETA**)
 - `src_ipv4_pool_end_ip` (String) The end IP address of IPv4 pool.
 - `src_ipv4_pool_start_ip` (String) The start IP address of IPv4 pool.


### PR DESCRIPTION
Mark several fields that is behind feature flags as BETA to avoid confusion.