### PR TITLE
AK-32309 Mark ping_probe_ip as optional in service_zscaler

### DIFF
--- a/acceptance/service_zscaler.tf
+++ b/acceptance/service_zscaler.tf
@@ -1,0 +1,25 @@
+resource "alkira_service_zscaler" "test1" {
+  name        = "acceptance-zia-1"
+  description = "acceptance zia"
+  cxp         = "US-WEST-1"
+
+  connector_internet_exit_id = alkira_connector_internet_exit.test1.id
+  primary_public_edge_ip            = "11.11.11.11"
+  secondary_public_edge_ip          = "12.12.12.12"
+  segment_ids                       = [alkira_segment.test1.id]
+  size                              = "MEDIUM"
+  tunnel_protocol                   = "IPSEC"
+
+  ipsec_configuration {
+    esp_dh_group_number      = "MODP1024"
+    esp_encryption_algorithm = "AES256CBC"
+    esp_integrity_algorithm  = "MD5"
+    health_check_type        = "IKE_STATUS"
+    http_probe_url           = "probe.url"
+    ike_dh_group_number      = "MODP2048"
+    ike_encryption_algorithm = "AES256CBC"
+    ike_integrity_algorithm  = "SHA256"
+    local_fpdn_id            = "local_fpdn_id"
+    pre_shared_key           = "pre_shared_key"
+  }
+}

--- a/alkira/resource_alkira_service_zscaler.go
+++ b/alkira/resource_alkira_service_zscaler.go
@@ -131,10 +131,10 @@ func resourceAlkiraServiceZscaler() *schema.Resource {
 							Required:    true,
 						},
 						"ping_probe_ip": {
-							Description: "The ping destination to check connection health, " +
-								"should be provided when health_check_type is `PING_PROBE`",
+							Description: "The ping destination to check connection health. " +
+								"It should be provided when `health_check_type` is `PING_PROBE`",
 							Type:     schema.TypeString,
-							Required: true,
+							Optional: true,
 						},
 					},
 				},

--- a/docs/resources/service_zscaler.md
+++ b/docs/resources/service_zscaler.md
@@ -72,7 +72,6 @@ Required:
 
 - `health_check_type` (String) The type of health check. Input values must be either `IKE_STATUS` `PING_PROBE` `HTTP_PROBE`
 - `local_fpdn_id` (String) The local FQDN Id.
-- `ping_probe_ip` (String) The ping destination to check connection health, should be provided when health_check_type is `PING_PROBE`
 - `pre_shared_key` (String) The preshared key.
 
 Optional:
@@ -84,5 +83,6 @@ Optional:
 - `ike_dh_group_number` (String) The IPSEC phase 1 DH Group to be used. Input value must either be `MODP1024` or `MODP2048`. The default is `MODP1024`
 - `ike_encryption_algorithm` (String) The IPSEC phase 1 Encryption Algorithm to be used. Only `AES256CBC` is allowed. The default value is `AES256CBC`.
 - `ike_integrity_algorithm` (String) The IPSEC phase 1 Integrity Algorithm to be used. Only `SHA256` is allowed. The default value is `SHA256`.
+- `ping_probe_ip` (String) The ping destination to check connection health. It should be provided when `health_check_type` is `PING_PROBE`
 
 


### PR DESCRIPTION
Mark ping_probe_ip as optional in service_zscaler and add acceptance test for the service.