### PR TITLE
AK-32460 Fix the wrong segment_id used in helper function of segment_…

### DIFF
--- a/acceptance/policy.tf
+++ b/acceptance/policy.tf
@@ -49,6 +49,7 @@ resource "alkira_policy_nat_rule" "test" {
   name        = "acceptance-test"
   description = "tftest nat rule"
   enabled     = false
+  category    = "DEFAULT"
 
   match {
     src_prefixes = ["any"]

--- a/acceptance/segment_resource.tf
+++ b/acceptance/segment_resource.tf
@@ -1,0 +1,19 @@
+resource "alkira_segment_resource" "test1" {
+  name       = "acceptance-seg-res-test1"
+  segment_id = alkira_segment.test1.id
+
+  group_prefix {
+    group_id       = -1
+    prefix_list_id = -1
+  }
+}
+
+resource "alkira_segment_resource" "test2" {
+  name       = "acceptance-seg-res-test2"
+  segment_id = alkira_segment.test2.id
+
+  group_prefix {
+    group_id       = -1
+    prefix_list_id = -1
+  }
+}

--- a/acceptance/segment_resource_share.tf
+++ b/acceptance/segment_resource_share.tf
@@ -1,0 +1,7 @@
+resource "alkira_segment_resource_share" "test1" {
+  name                       = "acceptance-test1"
+  designated_segment_id      = alkira_segment.test1.id
+  service_ids                = [-1]
+  end_a_segment_resource_ids = [alkira_segment_resource.test1.id]
+  end_b_segment_resource_ids = [alkira_segment_resource.test2.id]
+}

--- a/acceptance/service_zscaler.tf
+++ b/acceptance/service_zscaler.tf
@@ -4,11 +4,11 @@ resource "alkira_service_zscaler" "test1" {
   cxp         = "US-WEST-1"
 
   connector_internet_exit_id = alkira_connector_internet_exit.test1.id
-  primary_public_edge_ip            = "11.11.11.11"
-  secondary_public_edge_ip          = "12.12.12.12"
-  segment_ids                       = [alkira_segment.test1.id]
-  size                              = "MEDIUM"
-  tunnel_protocol                   = "IPSEC"
+  primary_public_edge_ip     = "11.11.11.11"
+  secondary_public_edge_ip   = "12.12.12.12"
+  segment_ids                = [alkira_segment.test1.id]
+  size                       = "MEDIUM"
+  tunnel_protocol            = "IPSEC"
 
   ipsec_configuration {
     esp_dh_group_number      = "MODP1024"

--- a/alkira/resource_alkira_segment_resource_share.go
+++ b/alkira/resource_alkira_segment_resource_share.go
@@ -166,7 +166,7 @@ func resourceSegmentResourceShareDelete(d *schema.ResourceData, m interface{}) e
 func generateSegmentResourceShareRequest(d *schema.ResourceData, m interface{}) (*alkira.SegmentResourceShare, error) {
 
 	// Get segment name
-	segmentName, err := getSegmentNameById(d.Get("segment_id").(string), m)
+	segmentName, err := getSegmentNameById(d.Get("designated_segment_id").(string), m)
 
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
…resoruce_share

Fix the wrong segment_id used in helper function of segment_resource_share.

+ Fix the wrong segment_id to parse.
+ Add segment_resource and segment_resource_share tests.