### PR TITLE
AK-32935 Handle provision state separately from all CRUD operations

### DIFF
--- a/alkira/helper.go
+++ b/alkira/helper.go
@@ -37,7 +37,7 @@ func expandSegmentOptions(in *schema.Set, m interface{}) (alkira.SegmentNameToZo
 		}
 
 		if v, ok := optionsCfg["segment_id"].(string); ok {
-			seg, err := segmentApi.GetById(v)
+			seg, _, err := segmentApi.GetById(v)
 
 			if err != nil {
 				return nil, err

--- a/alkira/resource_alkira_billing_tag.go
+++ b/alkira/resource_alkira_billing_tag.go
@@ -104,5 +104,5 @@ func resourceBillingTagDelete(ctx context.Context, d *schema.ResourceData, m int
 	}
 
 	d.SetId("")
-	return diag.FromErr(err)
+	return nil
 }

--- a/alkira/resource_alkira_billing_tag.go
+++ b/alkira/resource_alkira_billing_tag.go
@@ -42,7 +42,7 @@ func resourceBillingTag(d *schema.ResourceData, m interface{}) error {
 	}
 
 	// Send create request
-	response, _, err := api.Create(request)
+	response, _, err, _ := api.Create(request)
 
 	if err != nil {
 		return err
@@ -58,7 +58,7 @@ func resourceBillingTagRead(d *schema.ResourceData, m interface{}) error {
 	api := alkira.NewBillingTag(m.(*alkira.AlkiraClient))
 
 	// Get resource
-	tag, err := api.GetById(d.Id())
+	tag, _, err := api.GetById(d.Id())
 
 	if err != nil {
 		return err
@@ -81,7 +81,7 @@ func resourceBillingTagUpdate(d *schema.ResourceData, m interface{}) error {
 	}
 
 	// Send update request
-	_, err := api.Update(d.Id(), request)
+	_, err, _ := api.Update(d.Id(), request)
 
 	if err != nil {
 		return err
@@ -94,7 +94,7 @@ func resourceBillingTagDelete(d *schema.ResourceData, m interface{}) error {
 
 	api := alkira.NewBillingTag(m.(*alkira.AlkiraClient))
 
-	_, err := api.Delete(d.Id())
+	_, err, _ := api.Delete(d.Id())
 
 	if err != nil {
 		return err

--- a/alkira/resource_alkira_billing_tag.go
+++ b/alkira/resource_alkira_billing_tag.go
@@ -1,19 +1,22 @@
 package alkira
 
 import (
+	"context"
+
 	"github.com/alkiranet/alkira-client-go/alkira"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 func resourceAlkiraBillingTag() *schema.Resource {
 	return &schema.Resource{
-		Description: "Manage Billing Tag.",
-		Create:      resourceBillingTag,
-		Read:        resourceBillingTagRead,
-		Update:      resourceBillingTagUpdate,
-		Delete:      resourceBillingTagDelete,
+		Description:   "Manage Billing Tag.",
+		CreateContext: resourceBillingTag,
+		ReadContext:   resourceBillingTagRead,
+		UpdateContext: resourceBillingTagUpdate,
+		DeleteContext: resourceBillingTagDelete,
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 
 		Schema: map[string]*schema.Schema{
@@ -31,7 +34,7 @@ func resourceAlkiraBillingTag() *schema.Resource {
 	}
 }
 
-func resourceBillingTag(d *schema.ResourceData, m interface{}) error {
+func resourceBillingTag(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 
 	api := alkira.NewBillingTag(m.(*alkira.AlkiraClient))
 
@@ -45,15 +48,15 @@ func resourceBillingTag(d *schema.ResourceData, m interface{}) error {
 	response, _, err, _ := api.Create(request)
 
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	d.SetId(string(response.Id))
 
-	return resourceBillingTagRead(d, m)
+	return resourceBillingTagRead(ctx, d, m)
 }
 
-func resourceBillingTagRead(d *schema.ResourceData, m interface{}) error {
+func resourceBillingTagRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 
 	api := alkira.NewBillingTag(m.(*alkira.AlkiraClient))
 
@@ -61,7 +64,7 @@ func resourceBillingTagRead(d *schema.ResourceData, m interface{}) error {
 	tag, _, err := api.GetById(d.Id())
 
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	d.Set("name", tag.Name)
@@ -70,7 +73,7 @@ func resourceBillingTagRead(d *schema.ResourceData, m interface{}) error {
 	return nil
 }
 
-func resourceBillingTagUpdate(d *schema.ResourceData, m interface{}) error {
+func resourceBillingTagUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 
 	api := alkira.NewBillingTag(m.(*alkira.AlkiraClient))
 
@@ -84,22 +87,22 @@ func resourceBillingTagUpdate(d *schema.ResourceData, m interface{}) error {
 	_, err, _ := api.Update(d.Id(), request)
 
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
-	return resourceBillingTagRead(d, m)
+	return resourceBillingTagRead(ctx, d, m)
 }
 
-func resourceBillingTagDelete(d *schema.ResourceData, m interface{}) error {
+func resourceBillingTagDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 
 	api := alkira.NewBillingTag(m.(*alkira.AlkiraClient))
 
 	_, err, _ := api.Delete(d.Id())
 
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	d.SetId("")
-	return err
+	return diag.FromErr(err)
 }

--- a/alkira/resource_alkira_byoip_prefix.go
+++ b/alkira/resource_alkira_byoip_prefix.go
@@ -79,7 +79,7 @@ func resourceAlkiraByoipPrefix() *schema.Resource {
 
 func resourceByoipPrefix(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 
-	// Init
+	// INIT
 	client := m.(*alkira.AlkiraClient)
 	api := alkira.NewByoip(client)
 
@@ -105,7 +105,7 @@ func resourceByoipPrefix(ctx context.Context, d *schema.ResourceData, m interfac
 		if provErr != nil {
 			return diag.Diagnostics{{
 				Severity: diag.Warning,
-				Summary:  "PROVISION FAILED",
+				Summary:  "PROVISION (CREATE) FAILED",
 				Detail:   fmt.Sprintf("%s", provErr),
 			}}
 		}
@@ -116,7 +116,7 @@ func resourceByoipPrefix(ctx context.Context, d *schema.ResourceData, m interfac
 
 func resourceByoipPrefixRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 
-	// Init
+	// INIT
 	client := m.(*alkira.AlkiraClient)
 	api := alkira.NewByoip(client)
 
@@ -149,7 +149,7 @@ func resourceByoipPrefixUpdate(ctx context.Context, d *schema.ResourceData, m in
 
 func resourceByoipPrefixDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 
-	// Init
+	// INIT
 	client := m.(*alkira.AlkiraClient)
 	api := alkira.NewByoip(client)
 
@@ -160,13 +160,18 @@ func resourceByoipPrefixDelete(ctx context.Context, d *schema.ResourceData, m in
 		return diag.FromErr(err)
 	}
 
+	d.SetId("")
+
 	// Check provision state
 	if client.Provision == true && provState != "SUCCESS" {
-		return diag.FromErr(fmt.Errorf("failed to delete byoip_prefix %s, provision failed, %v", d.Id(), provErr))
+		return diag.Diagnostics{{
+			Severity: diag.Warning,
+			Summary:  "PROVISION (DELETE) FAILED",
+			Detail:   fmt.Sprintf("%s", provErr),
+		}}
 	}
 
-	d.SetId("")
-	return diag.FromErr(err)
+	return nil
 }
 
 func generateByoipRequest(d *schema.ResourceData, m interface{}) (*alkira.Byoip, error) {

--- a/alkira/resource_alkira_cloudvisor_account.go
+++ b/alkira/resource_alkira_cloudvisor_account.go
@@ -1,18 +1,22 @@
 package alkira
 
 import (
+	"context"
+
 	"github.com/alkiranet/alkira-client-go/alkira"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
 
 func resourceAlkiraCloudVisorAccount() *schema.Resource {
 	return &schema.Resource{
-		Description: "Manage CloudVisor Accounts",
-		Create:      resourceCloudVisorAccount,
-		Read:        resourceCloudVisorAccountRead,
-		Update:      resourceCloudVisorAccountUpdate,
-		Delete:      resourceCloudVisorAccountDelete,
+		Description:   "Manage CloudVisor Accounts",
+		CreateContext: resourceCloudVisorAccount,
+		ReadContext:   resourceCloudVisorAccountRead,
+		UpdateContext: resourceCloudVisorAccountUpdate,
+		DeleteContext: resourceCloudVisorAccountDelete,
 
 		Schema: map[string]*schema.Schema{
 			"name": {
@@ -48,7 +52,7 @@ func resourceAlkiraCloudVisorAccount() *schema.Resource {
 	}
 }
 
-func resourceCloudVisorAccount(d *schema.ResourceData, m interface{}) error {
+func resourceCloudVisorAccount(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 
 	api := alkira.NewCloudProviderAccounts(m.(*alkira.AlkiraClient))
 
@@ -56,26 +60,26 @@ func resourceCloudVisorAccount(d *schema.ResourceData, m interface{}) error {
 	request := generateCloudVisorAccountRequest(d, m)
 
 	// Send create request
-	resource, _, err := api.Create(request)
+	resource, _, err, _ := api.Create(request)
 
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	d.SetId(string(resource.Id))
 
-	return resourceCloudVisorAccountRead(d, m)
+	return resourceCloudVisorAccountRead(ctx, d, m)
 }
 
-func resourceCloudVisorAccountRead(d *schema.ResourceData, m interface{}) error {
+func resourceCloudVisorAccountRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 
 	api := alkira.NewCloudProviderAccounts(m.(*alkira.AlkiraClient))
 
 	// Get resource
-	account, err := api.GetById(d.Id())
+	account, _, err := api.GetById(d.Id())
 
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	d.Set("name", account.Name)
@@ -87,7 +91,7 @@ func resourceCloudVisorAccountRead(d *schema.ResourceData, m interface{}) error 
 	return nil
 }
 
-func resourceCloudVisorAccountUpdate(d *schema.ResourceData, m interface{}) error {
+func resourceCloudVisorAccountUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 
 	api := alkira.NewCloudProviderAccounts(m.(*alkira.AlkiraClient))
 
@@ -95,23 +99,23 @@ func resourceCloudVisorAccountUpdate(d *schema.ResourceData, m interface{}) erro
 	request := generateCloudVisorAccountRequest(d, m)
 
 	// Send update request
-	_, err := api.Update(d.Id(), request)
+	_, err, _ := api.Update(d.Id(), request)
 
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
-	return resourceCloudVisorAccountRead(d, m)
+	return resourceCloudVisorAccountRead(ctx, d, m)
 }
 
-func resourceCloudVisorAccountDelete(d *schema.ResourceData, m interface{}) error {
+func resourceCloudVisorAccountDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 
 	api := alkira.NewCloudProviderAccounts(m.(*alkira.AlkiraClient))
 
-	_, err := api.Delete(d.Id())
+	_, err, _ := api.Delete(d.Id())
 
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	d.SetId("")

--- a/alkira/resource_alkira_connector_aruba_edge_helper.go
+++ b/alkira/resource_alkira_connector_aruba_edge_helper.go
@@ -124,7 +124,7 @@ func expandArubaEdgeVrfMappings(in *schema.Set, m interface{}) ([]alkira.ArubaEd
 			arubaEdgeVRFMapping.AlkiraSegmentId = i
 		}
 		if v, ok := m["aruba_edge_connect_segment_id"].(string); ok {
-			segment, err := api.GetById(v)
+			segment, _, err := api.GetById(v)
 			if err != nil {
 				return nil, err
 			}

--- a/alkira/resource_alkira_connector_aws_vpc.go
+++ b/alkira/resource_alkira_connector_aws_vpc.go
@@ -185,9 +185,12 @@ func resourceAlkiraConnectorAwsVpc() *schema.Resource {
 						"options": {
 							Description: "Routing options, one of `ADVERTISE_DEFAULT_ROUTE`, " +
 								"`OVERRIDE_DEFAULT_ROUTE` and `ADVERTISE_CUSTOM_PREFIX`.",
-							Type:         schema.TypeString,
-							Optional:     true,
-							ValidateFunc: validation.StringInSlice([]string{"ADVERTISE_DEFAULT_ROUTE", "OVERRIDE_DEFAULT_ROUTE", "ADVERTISE_CUSTOM_PREFIX"}, false),
+							Type:     schema.TypeString,
+							Optional: true,
+							ValidateFunc: validation.StringInSlice([]string{
+								"ADVERTISE_DEFAULT_ROUTE",
+								"OVERRIDE_DEFAULT_ROUTE",
+								"ADVERTISE_CUSTOM_PREFIX"}, false),
 						},
 					},
 				},
@@ -199,18 +202,17 @@ func resourceAlkiraConnectorAwsVpc() *schema.Resource {
 
 func resourceConnectorAwsVpcCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 
-	// Init
+	// INIT
 	client := m.(*alkira.AlkiraClient)
 	api := alkira.NewConnectorAwsVpc(client)
 
-	// Create request
 	request, err := generateConnectorAwsVpcRequest(d, m)
 
 	if err != nil {
 		return diag.FromErr(err)
 	}
 
-	// Send create request
+	// CREATE
 	response, provState, err, provErr := api.Create(request)
 
 	if err != nil {
@@ -226,7 +228,7 @@ func resourceConnectorAwsVpcCreate(ctx context.Context, d *schema.ResourceData, 
 		if provErr != nil {
 			return diag.Diagnostics{{
 				Severity: diag.Warning,
-				Summary:  "PROVISION FAILED",
+				Summary:  "PROVISION (CREATE) FAILED",
 				Detail:   fmt.Sprintf("%s", provErr),
 			}}
 		}
@@ -237,11 +239,11 @@ func resourceConnectorAwsVpcCreate(ctx context.Context, d *schema.ResourceData, 
 
 func resourceConnectorAwsVpcRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 
-	// Init
+	// INIT
 	client := m.(*alkira.AlkiraClient)
 	api := alkira.NewConnectorAwsVpc(client)
 
-	// Get connector
+	// GET
 	connector, provState, err := api.GetById(d.Id())
 
 	if err != nil {
@@ -286,18 +288,17 @@ func resourceConnectorAwsVpcRead(ctx context.Context, d *schema.ResourceData, m 
 
 func resourceConnectorAwsVpcUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 
-	// Init
+	// INIT
 	client := m.(*alkira.AlkiraClient)
 	api := alkira.NewConnectorAwsVpc(client)
 
-	// Construct request
 	request, err := generateConnectorAwsVpcRequest(d, m)
 
 	if err != nil {
 		return diag.FromErr(err)
 	}
 
-	// Send update request
+	// UPDATE
 	provState, err, provErr := api.Update(d.Id(), request)
 
 	if err != nil {
@@ -311,7 +312,7 @@ func resourceConnectorAwsVpcUpdate(ctx context.Context, d *schema.ResourceData, 
 		if provErr != nil {
 			return diag.Diagnostics{{
 				Severity: diag.Warning,
-				Summary:  "PROVISION FAILED",
+				Summary:  "PROVISION (UPDATE) FAILED",
 				Detail:   fmt.Sprintf("%s", provErr),
 			}}
 		}
@@ -322,22 +323,27 @@ func resourceConnectorAwsVpcUpdate(ctx context.Context, d *schema.ResourceData, 
 
 func resourceConnectorAwsVpcDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 
-	// Init
+	// INIT
 	client := m.(*alkira.AlkiraClient)
 	api := alkira.NewConnectorAwsVpc(client)
 
-	// Delete resource
+	// DELETE
 	provState, err, provErr := api.Delete(d.Id())
 
 	if err != nil {
 		return diag.FromErr(err)
 	}
 
+	d.SetId("")
+
 	if client.Provision == true && provState != "SUCCESS" {
-		return diag.FromErr(provErr)
+		return diag.Diagnostics{{
+			Severity: diag.Warning,
+			Summary:  "PROVISION (DELETE) FAILED",
+			Detail:   fmt.Sprintf("%s", provErr),
+		}}
 	}
 
-	d.SetId("")
 	return nil
 }
 

--- a/alkira/resource_alkira_connector_azure_expressroute.go
+++ b/alkira/resource_alkira_connector_azure_expressroute.go
@@ -1,9 +1,12 @@
 package alkira
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/alkiranet/alkira-client-go/alkira"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
@@ -12,10 +15,24 @@ func resourceAlkiraConnectorAzureExpressRoute() *schema.Resource {
 	return &schema.Resource{
 		Description: "Manage Azure ExpressRoute Connector. (**BETA**)",
 
-		Create: resourceConnectorAzureExpressRouteCreate,
-		Read:   resourceConnectorAzureExpressRouteRead,
-		Update: resourceConnectorAzureExpressRouteUpdate,
-		Delete: resourceConnectorAzureExpressRouteDelete,
+		CreateContext: resourceConnectorAzureExpressRouteCreate,
+		ReadContext:   resourceConnectorAzureExpressRouteRead,
+		UpdateContext: resourceConnectorAzureExpressRouteUpdate,
+		DeleteContext: resourceConnectorAzureExpressRouteDelete,
+		CustomizeDiff: func(ctx context.Context, d *schema.ResourceDiff, m interface{}) error {
+			client := m.(*alkira.AlkiraClient)
+
+			old, _ := d.GetChange("provision_state")
+
+			if client.Provision == true && old == "FAILED" {
+				d.SetNew("provision_state", "SUCCESS")
+			}
+
+			return nil
+		},
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"name": {
@@ -163,33 +180,50 @@ func resourceAlkiraConnectorAzureExpressRoute() *schema.Resource {
 }
 
 // resourceConnectorAzureExpressRouteCreate create an Azure ExpressRoute connector
-func resourceConnectorAzureExpressRouteCreate(d *schema.ResourceData, m interface{}) error {
+func resourceConnectorAzureExpressRouteCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+
+	client := m.(*alkira.AlkiraClient)
 	api := alkira.NewConnectorAzureExpressRoute(m.(*alkira.AlkiraClient))
-	connector, err := generateConnectorAzureExpressRouteRequest(d, m)
+
+	request, err := generateConnectorAzureExpressRouteRequest(d, m)
 
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
-	resource, provisionState, err := api.Create(connector)
+	resource, provState, err, provErr := api.Create(request)
 
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
-	d.Set("provision_state", provisionState)
 	d.SetId(string(resource.Id))
 
-	return resourceConnectorAzureExpressRouteRead(d, m)
+	if client.Provision == true {
+		d.Set("provision_state", provState)
+
+		if provErr != nil {
+			return diag.Diagnostics{{
+				Severity: diag.Warning,
+				Summary:  "PROVISION FAILED",
+				Detail:   fmt.Sprintf("%s", provErr),
+			}}
+		}
+	}
+
+	return resourceConnectorAzureExpressRouteRead(ctx, d, m)
 }
 
 // resourceConnectorAzureExpressRouteRead get and save an Azure ExpressRoute connectors
-func resourceConnectorAzureExpressRouteRead(d *schema.ResourceData, m interface{}) error {
+func resourceConnectorAzureExpressRouteRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+
+	client := m.(*alkira.AlkiraClient)
 	api := alkira.NewConnectorAzureExpressRoute(m.(*alkira.AlkiraClient))
-	connector, err := api.GetById(d.Id())
+
+	connector, provState, err := api.GetById(d.Id())
 
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	d.Set("size", connector.Size)
@@ -232,37 +266,61 @@ func resourceConnectorAzureExpressRouteRead(d *schema.ResourceData, m interface{
 	}
 	d.Set("segment_options", segments)
 
+	// Set provision state
+	if client.Provision == true && provState != "" {
+		d.Set("provision_state", provState)
+	}
+
 	return nil
 }
 
 // resourceConnectorAzureExpressRouteUpdate update an Azure ExpressRoute connector
-func resourceConnectorAzureExpressRouteUpdate(d *schema.ResourceData, m interface{}) error {
+func resourceConnectorAzureExpressRouteUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+
+	client := m.(*alkira.AlkiraClient)
 	api := alkira.NewConnectorAzureExpressRoute(m.(*alkira.AlkiraClient))
+
 	connector, err := generateConnectorAzureExpressRouteRequest(d, m)
 
 	if err != nil {
-		return fmt.Errorf("UpdateConnectorAzureExpressRoute: failed to marshal: %v", err)
+		return diag.FromErr(err)
 	}
 
-	provisionState, err := api.Update(d.Id(), connector)
+	provState, err, provErr := api.Update(d.Id(), connector)
 
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
-	d.Set("provision_state", provisionState)
-	return resourceConnectorAzureExpressRouteRead(d, m)
+	// Set provision state
+	if client.Provision == true {
+		d.Set("provision_state", provState)
+
+		if provErr != nil {
+			return diag.Diagnostics{{
+				Severity: diag.Warning,
+				Summary:  "PROVISION FAILED",
+				Detail:   fmt.Sprintf("%s", provErr),
+			}}
+		}
+	}
+
+	return resourceConnectorAzureExpressRouteRead(ctx, d, m)
 }
 
-func resourceConnectorAzureExpressRouteDelete(d *schema.ResourceData, m interface{}) error {
+func resourceConnectorAzureExpressRouteDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+
+	client := m.(*alkira.AlkiraClient)
 	api := alkira.NewConnectorAzureExpressRoute(m.(*alkira.AlkiraClient))
-	provisionState, err := api.Delete((d.Id()))
+
+	provState, err, provErr := api.Delete((d.Id()))
 
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
-	if provisionState != "SUCCESS" {
+	if client.Provision == true && provState != "SUCCESS" {
+		return diag.FromErr(provErr)
 	}
 
 	d.SetId("")

--- a/alkira/resource_alkira_connector_azure_expressroute.go
+++ b/alkira/resource_alkira_connector_azure_expressroute.go
@@ -101,38 +101,48 @@ func resourceAlkiraConnectorAzureExpressRoute() *schema.Resource {
 						},
 						"expressroute_circuit_id": {
 							Description: "ExpressRoute circuit ID from Azure. " +
-								"ExpresRoute Circuit should have a private peering connection provisioned, " +
-								"also an valid authorization key associated with it.",
+								"ExpresRoute Circuit should have a private " +
+								"peering connection provisioned, also an valid " +
+								"authorization key associated with it.",
 							Type:     schema.TypeString,
 							Required: true,
 						},
 						"redundant_router": {
-							Description: "Indicates if ExpressRoute Circuit terminates on redundant routers on customer side.",
-							Type:        schema.TypeBool,
-							Optional:    true,
-							Default:     false,
+							Description: "Indicates if ExpressRoute Circuit " +
+								"terminates on redundant routers on customer side.",
+							Type:     schema.TypeBool,
+							Optional: true,
+							Default:  false,
 						},
 						"loopback_subnet": {
-							Description: "A `/26` subnet from which loopback IPs would be used to establish underlay VXLAN GPE tunnels.",
-							Type:        schema.TypeString,
-							Required:    true,
+							Description: "A `/26` subnet from which loopback " +
+								"IPs would be used to establish underlay " +
+								"VXLAN GPE tunnels.",
+							Type:     schema.TypeString,
+							Required: true,
 						},
 						"credential_id": {
-							Description: "An opaque identifier generated when storing Azure VNET credentials.",
-							Type:        schema.TypeString,
-							Required:    true,
+							Description: "An opaque identifier generated when " +
+								"storing Azure VNET credentials.",
+							Type:     schema.TypeString,
+							Required: true,
 						},
 						"gateway_mac_address": {
-							Description: "An array containing the mac addresses of VXLAN gateways reachable through ExpressRoute circuit. " +
-								"The gatewayMacAddresses is only expected if VXLAN tunnel protocol is selected, " +
-								"and 2 gateway mac addresses are expected only if redundant_router is enabled.",
+							Description: "An array containing the mac addresses " +
+								"of VXLAN gateways reachable through ExpressRoute " +
+								"circuit. The field is only expected if VXLAN " +
+								"tunnel protocol is selected, and 2 gateway MAC " +
+								"addresses are expected only if `redundant_router` " +
+								"is enabled.",
 							Type:     schema.TypeList,
 							Optional: true,
 							Elem:     &schema.Schema{Type: schema.TypeString},
 						},
 						"virtual_network_interface": {
-							Description: "This is an optional field if the tunnel protocol is VXLAN. " +
-								"If not specified Alkira allocates unique VNI from the range [16773023, 16777215].",
+							Description: "This is an optional field if the " +
+								"`tunnel_protocol` is `VXLAN`. If not specified " +
+								"Alkira allocates unique VNI from the range " +
+								"`[16773023, 16777215]`.",
 							Type:     schema.TypeList,
 							Optional: true,
 							Elem:     &schema.Schema{Type: schema.TypeInt},
@@ -161,16 +171,19 @@ func resourceAlkiraConnectorAzureExpressRoute() *schema.Resource {
 							Required:    true,
 						},
 						"disable_internet_exit": {
-							Description: "Enable or disable access to the internet when traffic arrives via this connector.",
-							Type:        schema.TypeBool,
-							Optional:    true,
-							Default:     true,
+							Description: "Enable or disable access to the " +
+								"internet when traffic arrives via this " +
+								"connector.",
+							Type:     schema.TypeBool,
+							Optional: true,
+							Default:  true,
 						},
 						"advertise_on_prem_routes": {
-							Description: "Allow routes from the branch/premises to be advertised to the cloud.",
-							Type:        schema.TypeBool,
-							Optional:    true,
-							Default:     false,
+							Description: "Allow routes from the branch/premises " +
+								"to be advertised to the cloud.",
+							Type:     schema.TypeBool,
+							Optional: true,
+							Default:  false,
 						},
 					},
 				},
@@ -182,6 +195,7 @@ func resourceAlkiraConnectorAzureExpressRoute() *schema.Resource {
 // resourceConnectorAzureExpressRouteCreate create an Azure ExpressRoute connector
 func resourceConnectorAzureExpressRouteCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 
+	// INIT
 	client := m.(*alkira.AlkiraClient)
 	api := alkira.NewConnectorAzureExpressRoute(m.(*alkira.AlkiraClient))
 
@@ -191,6 +205,7 @@ func resourceConnectorAzureExpressRouteCreate(ctx context.Context, d *schema.Res
 		return diag.FromErr(err)
 	}
 
+	// CREATE
 	resource, provState, err, provErr := api.Create(request)
 
 	if err != nil {
@@ -205,7 +220,7 @@ func resourceConnectorAzureExpressRouteCreate(ctx context.Context, d *schema.Res
 		if provErr != nil {
 			return diag.Diagnostics{{
 				Severity: diag.Warning,
-				Summary:  "PROVISION FAILED",
+				Summary:  "PROVISION (CREATE) FAILED",
 				Detail:   fmt.Sprintf("%s", provErr),
 			}}
 		}
@@ -217,9 +232,11 @@ func resourceConnectorAzureExpressRouteCreate(ctx context.Context, d *schema.Res
 // resourceConnectorAzureExpressRouteRead get and save an Azure ExpressRoute connectors
 func resourceConnectorAzureExpressRouteRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 
+	// INIT
 	client := m.(*alkira.AlkiraClient)
 	api := alkira.NewConnectorAzureExpressRoute(m.(*alkira.AlkiraClient))
 
+	// GET
 	connector, provState, err := api.GetById(d.Id())
 
 	if err != nil {
@@ -277,6 +294,7 @@ func resourceConnectorAzureExpressRouteRead(ctx context.Context, d *schema.Resou
 // resourceConnectorAzureExpressRouteUpdate update an Azure ExpressRoute connector
 func resourceConnectorAzureExpressRouteUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 
+	// INIT
 	client := m.(*alkira.AlkiraClient)
 	api := alkira.NewConnectorAzureExpressRoute(m.(*alkira.AlkiraClient))
 
@@ -286,6 +304,7 @@ func resourceConnectorAzureExpressRouteUpdate(ctx context.Context, d *schema.Res
 		return diag.FromErr(err)
 	}
 
+	// UPDATE
 	provState, err, provErr := api.Update(d.Id(), connector)
 
 	if err != nil {
@@ -299,7 +318,7 @@ func resourceConnectorAzureExpressRouteUpdate(ctx context.Context, d *schema.Res
 		if provErr != nil {
 			return diag.Diagnostics{{
 				Severity: diag.Warning,
-				Summary:  "PROVISION FAILED",
+				Summary:  "PROVISION (UPDATE) FAILED",
 				Detail:   fmt.Sprintf("%s", provErr),
 			}}
 		}
@@ -310,20 +329,27 @@ func resourceConnectorAzureExpressRouteUpdate(ctx context.Context, d *schema.Res
 
 func resourceConnectorAzureExpressRouteDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 
+	// INIT
 	client := m.(*alkira.AlkiraClient)
 	api := alkira.NewConnectorAzureExpressRoute(m.(*alkira.AlkiraClient))
 
+	// DELETE
 	provState, err, provErr := api.Delete((d.Id()))
 
 	if err != nil {
 		return diag.FromErr(err)
 	}
 
+	d.SetId("")
+
 	if client.Provision == true && provState != "SUCCESS" {
-		return diag.FromErr(provErr)
+		return diag.Diagnostics{{
+			Severity: diag.Warning,
+			Summary:  "PROVISION (DELETE) FAILED",
+			Detail:   fmt.Sprintf("%s", provErr),
+		}}
 	}
 
-	d.SetId("")
 	return nil
 }
 

--- a/alkira/resource_alkira_connector_azure_vnet.go
+++ b/alkira/resource_alkira_connector_azure_vnet.go
@@ -62,10 +62,11 @@ func resourceAlkiraConnectorAzureVnet() *schema.Resource {
 				Default:     true,
 			},
 			"failover_cxps": {
-				Description: "A list of additional CXPs where the connector should be provisioned for failover.",
-				Type:        schema.TypeList,
-				Optional:    true,
-				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: "A list of additional CXPs where the connector " +
+					"should be provisioned for failover.",
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 			"group": {
 				Description: "The group of the connector.",
@@ -73,9 +74,10 @@ func resourceAlkiraConnectorAzureVnet() *schema.Resource {
 				Optional:    true,
 			},
 			"implicit_group_id": {
-				Description: "The ID of implicit group automaticaly created with the connector.",
-				Type:        schema.TypeInt,
-				Computed:    true,
+				Description: "The ID of implicit group automaticaly created " +
+					"with the connector.",
+				Type:     schema.TypeInt,
+				Computed: true,
 			},
 			"name": {
 				Description: "The name of the connector.",
@@ -118,7 +120,9 @@ func resourceAlkiraConnectorAzureVnet() *schema.Resource {
 							Required:    true,
 						},
 						"routing_options": {
-							Description:  "Routing options for the CIDR, either `ADVERTISE_DEFAULT_ROUTE` or `ADVERTISE_CUSTOM_PREFIX`.",
+							Description: "Routing options for the CIDR, either " +
+								"`ADVERTISE_DEFAULT_ROUTE` or " +
+								"`ADVERTISE_CUSTOM_PREFIX`.",
 							Type:         schema.TypeString,
 							Optional:     true,
 							ValidateFunc: validation.StringInSlice([]string{"ADVERTISE_DEFAULT_ROUTE", "ADVERTISE_CUSTOM_PREFIX"}, false),
@@ -197,18 +201,17 @@ func resourceAlkiraConnectorAzureVnet() *schema.Resource {
 
 func resourceConnectorAzureVnetCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 
-	// Init
+	// INIT
 	client := m.(*alkira.AlkiraClient)
 	api := alkira.NewConnectorAzureVnet(m.(*alkira.AlkiraClient))
 
-	// Construct request
 	request, err := generateConnectorAzureVnetRequest(d, m)
 
 	if err != nil {
 		return diag.FromErr(err)
 	}
 
-	// Send create request
+	// CREATE
 	response, provState, err, provErr := api.Create(request)
 
 	if err != nil {
@@ -224,7 +227,7 @@ func resourceConnectorAzureVnetCreate(ctx context.Context, d *schema.ResourceDat
 		if provErr != nil {
 			return diag.Diagnostics{{
 				Severity: diag.Warning,
-				Summary:  "PROVISION FAILED",
+				Summary:  "PROVISION (CREATE) FAILED",
 				Detail:   fmt.Sprintf("%s", provErr),
 			}}
 		}
@@ -282,17 +285,17 @@ func resourceConnectorAzureVnetRead(ctx context.Context, d *schema.ResourceData,
 
 func resourceConnectorAzureVnetUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 
+	// INIT
 	client := m.(*alkira.AlkiraClient)
 	api := alkira.NewConnectorAzureVnet(m.(*alkira.AlkiraClient))
 
-	// Construct update request
 	request, err := generateConnectorAzureVnetRequest(d, m)
 
 	if err != nil {
 		return diag.FromErr(err)
 	}
 
-	// Send update request
+	// UPDATE
 	provState, err, provErr := api.Update(d.Id(), request)
 
 	if err != nil {
@@ -306,7 +309,7 @@ func resourceConnectorAzureVnetUpdate(ctx context.Context, d *schema.ResourceDat
 		if provErr != nil {
 			return diag.Diagnostics{{
 				Severity: diag.Warning,
-				Summary:  "PROVISION FAILED",
+				Summary:  "PROVISION (UPDATE) FAILED",
 				Detail:   fmt.Sprintf("%s", provErr),
 			}}
 		}
@@ -317,20 +320,27 @@ func resourceConnectorAzureVnetUpdate(ctx context.Context, d *schema.ResourceDat
 
 func resourceConnectorAzureVnetDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 
+	// INIT
 	client := m.(*alkira.AlkiraClient)
 	api := alkira.NewConnectorAzureVnet(m.(*alkira.AlkiraClient))
 
+	// DELETE
 	provState, err, provErr := api.Delete(d.Id())
 
 	if err != nil {
 		return diag.FromErr(err)
 	}
 
+	d.SetId("")
+
 	if client.Provision == true && provState != "SUCCESS" {
-		return diag.FromErr(provErr)
+		return diag.Diagnostics{{
+			Severity: diag.Warning,
+			Summary:  "PROVISION (DELETE) FAILED",
+			Detail:   fmt.Sprintf("%s", provErr),
+		}}
 	}
 
-	d.SetId("")
 	return nil
 }
 

--- a/alkira/resource_alkira_connector_cisco_sdwan.go
+++ b/alkira/resource_alkira_connector_cisco_sdwan.go
@@ -6,17 +6,19 @@ import (
 	"log"
 
 	"github.com/alkiranet/alkira-client-go/alkira"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
 
 func resourceAlkiraConnectorCiscoSdwan() *schema.Resource {
 	return &schema.Resource{
-		Description: "Manage Cisco SD-WAN Connector.",
-		Create:      resourceConnectorCiscoSdwanCreate,
-		Read:        resourceConnectorCiscoSdwanRead,
-		Update:      resourceConnectorCiscoSdwanUpdate,
-		Delete:      resourceConnectorCiscoSdwanDelete,
+		Description:   "Manage Cisco SD-WAN Connector.",
+		CreateContext: resourceConnectorCiscoSdwanCreate,
+		ReadContext:   resourceConnectorCiscoSdwanRead,
+		UpdateContext: resourceConnectorCiscoSdwanUpdate,
+		DeleteContext: resourceConnectorCiscoSdwanDelete,
 		CustomizeDiff: func(ctx context.Context, d *schema.ResourceDiff, m interface{}) error {
 			client := m.(*alkira.AlkiraClient)
 
@@ -29,7 +31,7 @@ func resourceAlkiraConnectorCiscoSdwan() *schema.Resource {
 			return nil
 		},
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 
 		Schema: map[string]*schema.Schema{
@@ -180,7 +182,7 @@ func resourceAlkiraConnectorCiscoSdwan() *schema.Resource {
 	}
 }
 
-func resourceConnectorCiscoSdwanCreate(d *schema.ResourceData, m interface{}) error {
+func resourceConnectorCiscoSdwanCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 
 	client := m.(*alkira.AlkiraClient)
 	api := alkira.NewConnectorCiscoSdwan(m.(*alkira.AlkiraClient))
@@ -189,35 +191,43 @@ func resourceConnectorCiscoSdwanCreate(d *schema.ResourceData, m interface{}) er
 	request, err := generateConnectorCiscoSdwanRequest(d, m)
 
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	// Send create request
-	response, provisionState, err := api.Create(request)
+	response, provState, err, provErr := api.Create(request)
 
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	// Set states
 	d.SetId(string(response.Id))
 
 	if client.Provision == true {
-		d.Set("provision_state", provisionState)
+		d.Set("provision_state", provState)
+
+		if provErr != nil {
+			return diag.Diagnostics{{
+				Severity: diag.Warning,
+				Summary:  "PROVISION FAILED",
+				Detail:   fmt.Sprintf("%s", provErr),
+			}}
+		}
 	}
 
-	return resourceConnectorCiscoSdwanRead(d, m)
+	return resourceConnectorCiscoSdwanRead(ctx, d, m)
 }
 
-func resourceConnectorCiscoSdwanRead(d *schema.ResourceData, m interface{}) error {
+func resourceConnectorCiscoSdwanRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 
 	client := m.(*alkira.AlkiraClient)
 	api := alkira.NewConnectorCiscoSdwan(m.(*alkira.AlkiraClient))
 
-	connector, err := api.GetById(d.Id())
+	connector, provState, err := api.GetById(d.Id())
 
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	d.Set("billing_tag_ids", connector.BillingTags)
@@ -250,16 +260,14 @@ func resourceConnectorCiscoSdwanRead(d *schema.ResourceData, m interface{}) erro
 	d.Set("version", connector.Version)
 
 	// Set provision state
-	_, provisionState, err := api.GetByName(d.Get("name").(string))
-
-	if client.Provision == true && provisionState != "" {
-		d.Set("provision_state", provisionState)
+	if client.Provision == true && provState != "" {
+		d.Set("provision_state", provState)
 	}
 
 	return nil
 }
 
-func resourceConnectorCiscoSdwanUpdate(d *schema.ResourceData, m interface{}) error {
+func resourceConnectorCiscoSdwanUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 
 	client := m.(*alkira.AlkiraClient)
 	api := alkira.NewConnectorCiscoSdwan(m.(*alkira.AlkiraClient))
@@ -268,37 +276,45 @@ func resourceConnectorCiscoSdwanUpdate(d *schema.ResourceData, m interface{}) er
 	request, err := generateConnectorCiscoSdwanRequest(d, m)
 
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	// Send update request
-	provisionState, err := api.Update(d.Id(), request)
+	provState, err, provErr := api.Update(d.Id(), request)
 
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	// Set provision state
 	if client.Provision == true {
-		d.Set("provision_state", provisionState)
+		d.Set("provision_state", provState)
+
+		if provErr != nil {
+			return diag.Diagnostics{{
+				Severity: diag.Warning,
+				Summary:  "PROVISION FAILED",
+				Detail:   fmt.Sprintf("%s", provErr),
+			}}
+		}
 	}
 
-	return resourceConnectorCiscoSdwanRead(d, m)
+	return resourceConnectorCiscoSdwanRead(ctx, d, m)
 }
 
-func resourceConnectorCiscoSdwanDelete(d *schema.ResourceData, m interface{}) error {
+func resourceConnectorCiscoSdwanDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 
 	client := m.(*alkira.AlkiraClient)
 	api := alkira.NewConnectorCiscoSdwan(m.(*alkira.AlkiraClient))
 
-	provisionState, err := api.Delete(d.Id())
+	provState, err, provErr := api.Delete(d.Id())
 
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
-	if client.Provision == true && provisionState != "SUCCESS" {
-		return fmt.Errorf("failed to delete connector_cisco_sdwan %s, provision failed", d.Id())
+	if client.Provision == true && provState != "SUCCESS" {
+		return diag.FromErr(provErr)
 	}
 
 	d.SetId("")

--- a/alkira/resource_alkira_connector_cisco_sdwan.go
+++ b/alkira/resource_alkira_connector_cisco_sdwan.go
@@ -184,17 +184,17 @@ func resourceAlkiraConnectorCiscoSdwan() *schema.Resource {
 
 func resourceConnectorCiscoSdwanCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 
+	// INIT
 	client := m.(*alkira.AlkiraClient)
 	api := alkira.NewConnectorCiscoSdwan(m.(*alkira.AlkiraClient))
 
-	// Construct request
 	request, err := generateConnectorCiscoSdwanRequest(d, m)
 
 	if err != nil {
 		return diag.FromErr(err)
 	}
 
-	// Send create request
+	// CREATE
 	response, provState, err, provErr := api.Create(request)
 
 	if err != nil {
@@ -210,7 +210,7 @@ func resourceConnectorCiscoSdwanCreate(ctx context.Context, d *schema.ResourceDa
 		if provErr != nil {
 			return diag.Diagnostics{{
 				Severity: diag.Warning,
-				Summary:  "PROVISION FAILED",
+				Summary:  "PROVISION (CREATE) FAILED",
 				Detail:   fmt.Sprintf("%s", provErr),
 			}}
 		}
@@ -221,9 +221,11 @@ func resourceConnectorCiscoSdwanCreate(ctx context.Context, d *schema.ResourceDa
 
 func resourceConnectorCiscoSdwanRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 
+	// INIT
 	client := m.(*alkira.AlkiraClient)
 	api := alkira.NewConnectorCiscoSdwan(m.(*alkira.AlkiraClient))
 
+	// GET
 	connector, provState, err := api.GetById(d.Id())
 
 	if err != nil {
@@ -269,17 +271,17 @@ func resourceConnectorCiscoSdwanRead(ctx context.Context, d *schema.ResourceData
 
 func resourceConnectorCiscoSdwanUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 
+	// INIT
 	client := m.(*alkira.AlkiraClient)
 	api := alkira.NewConnectorCiscoSdwan(m.(*alkira.AlkiraClient))
 
-	// Construct update request
 	request, err := generateConnectorCiscoSdwanRequest(d, m)
 
 	if err != nil {
 		return diag.FromErr(err)
 	}
 
-	// Send update request
+	// UPDATE
 	provState, err, provErr := api.Update(d.Id(), request)
 
 	if err != nil {
@@ -293,7 +295,7 @@ func resourceConnectorCiscoSdwanUpdate(ctx context.Context, d *schema.ResourceDa
 		if provErr != nil {
 			return diag.Diagnostics{{
 				Severity: diag.Warning,
-				Summary:  "PROVISION FAILED",
+				Summary:  "PROVISION (UPDATE) FAILED",
 				Detail:   fmt.Sprintf("%s", provErr),
 			}}
 		}
@@ -304,9 +306,11 @@ func resourceConnectorCiscoSdwanUpdate(ctx context.Context, d *schema.ResourceDa
 
 func resourceConnectorCiscoSdwanDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 
+	// INIT
 	client := m.(*alkira.AlkiraClient)
 	api := alkira.NewConnectorCiscoSdwan(m.(*alkira.AlkiraClient))
 
+	// DELETE
 	provState, err, provErr := api.Delete(d.Id())
 
 	if err != nil {
@@ -314,7 +318,11 @@ func resourceConnectorCiscoSdwanDelete(ctx context.Context, d *schema.ResourceDa
 	}
 
 	if client.Provision == true && provState != "SUCCESS" {
-		return diag.FromErr(provErr)
+		return diag.Diagnostics{{
+			Severity: diag.Warning,
+			Summary:  "PROVISION (DELETE) FAILED",
+			Detail:   fmt.Sprintf("%s", provErr),
+		}}
 	}
 
 	d.SetId("")

--- a/alkira/resource_alkira_connector_gcp_vpc.go
+++ b/alkira/resource_alkira_connector_gcp_vpc.go
@@ -178,17 +178,17 @@ func resourceAlkiraConnectorGcpVpc() *schema.Resource {
 
 func resourceConnectorGcpVpcCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 
+	// INIT
 	client := m.(*alkira.AlkiraClient)
 	api := alkira.NewConnectorGcpVpc(m.(*alkira.AlkiraClient))
 
-	// Construct request
 	request, err := generateConnectorGcpVpcRequest(d, m)
 
 	if err != nil {
 		return diag.FromErr(err)
 	}
 
-	// Send create request
+	// CREATE
 	response, provState, err, provErr := api.Create(request)
 
 	if err != nil {
@@ -204,7 +204,7 @@ func resourceConnectorGcpVpcCreate(ctx context.Context, d *schema.ResourceData, 
 		if provErr != nil {
 			return diag.Diagnostics{{
 				Severity: diag.Warning,
-				Summary:  "PROVISION FAILED",
+				Summary:  "PROVISION (CREATE) FAILED",
 				Detail:   fmt.Sprintf("%s", provErr),
 			}}
 		}
@@ -215,9 +215,11 @@ func resourceConnectorGcpVpcCreate(ctx context.Context, d *schema.ResourceData, 
 
 func resourceConnectorGcpVpcRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 
+	// INIT
 	client := m.(*alkira.AlkiraClient)
 	api := alkira.NewConnectorGcpVpc(m.(*alkira.AlkiraClient))
 
+	// GET
 	connector, provState, err := api.GetById(d.Id())
 
 	if err != nil {
@@ -262,17 +264,17 @@ func resourceConnectorGcpVpcRead(ctx context.Context, d *schema.ResourceData, m 
 
 func resourceConnectorGcpVpcUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 
+	// INIT
 	client := m.(*alkira.AlkiraClient)
 	api := alkira.NewConnectorGcpVpc(m.(*alkira.AlkiraClient))
 
-	// Construct request
 	request, err := generateConnectorGcpVpcRequest(d, m)
 
 	if err != nil {
 		return diag.FromErr(err)
 	}
 
-	// Send update request
+	// UPDATE
 	provState, err, provErr := api.Update(d.Id(), request)
 
 	if err != nil {
@@ -286,7 +288,7 @@ func resourceConnectorGcpVpcUpdate(ctx context.Context, d *schema.ResourceData, 
 		if provErr != nil {
 			return diag.Diagnostics{{
 				Severity: diag.Warning,
-				Summary:  "PROVISION FAILED",
+				Summary:  "PROVISION (UPDATE) FAILED",
 				Detail:   fmt.Sprintf("%s", provErr),
 			}}
 		}
@@ -297,20 +299,26 @@ func resourceConnectorGcpVpcUpdate(ctx context.Context, d *schema.ResourceData, 
 
 func resourceConnectorGcpVpcDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 
+	// INIT
 	client := m.(*alkira.AlkiraClient)
 	api := alkira.NewConnectorGcpVpc(m.(*alkira.AlkiraClient))
 
+	// DELETE
 	provState, err, provErr := api.Delete(d.Id())
 
 	if err != nil {
 		return diag.FromErr(err)
 	}
 
-	if client.Provision == true && provState != "SUCCESS" {
-		return diag.FromErr(provErr)
-	}
-
 	d.SetId("")
+
+	if client.Provision == true && provState != "SUCCESS" {
+		return diag.Diagnostics{{
+			Severity: diag.Warning,
+			Summary:  "PROVISION (DELETE) FAILED",
+			Detail:   fmt.Sprintf("%s", provErr),
+		}}
+	}
 
 	return nil
 }

--- a/alkira/resource_alkira_connector_internet_exit.go
+++ b/alkira/resource_alkira_connector_internet_exit.go
@@ -5,17 +5,19 @@ import (
 	"fmt"
 
 	"github.com/alkiranet/alkira-client-go/alkira"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
 
 func resourceAlkiraConnectorInternetExit() *schema.Resource {
 	return &schema.Resource{
-		Description: "Manage Internet Exit Connector.",
-		Create:      resourceConnectorInternetExitCreate,
-		Read:        resourceConnectorInternetExitRead,
-		Update:      resourceConnectorInternetExitUpdate,
-		Delete:      resourceConnectorInternetExitDelete,
+		Description:   "Manage Internet Exit Connector.",
+		CreateContext: resourceConnectorInternetExitCreate,
+		ReadContext:   resourceConnectorInternetExitRead,
+		UpdateContext: resourceConnectorInternetExitUpdate,
+		DeleteContext: resourceConnectorInternetExitDelete,
 		CustomizeDiff: func(ctx context.Context, d *schema.ResourceDiff, m interface{}) error {
 			client := m.(*alkira.AlkiraClient)
 
@@ -28,7 +30,7 @@ func resourceAlkiraConnectorInternetExit() *schema.Resource {
 			return nil
 		},
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 		Schema: map[string]*schema.Schema{
 			"billing_tag_ids": {
@@ -119,7 +121,7 @@ func resourceAlkiraConnectorInternetExit() *schema.Resource {
 	}
 }
 
-func resourceConnectorInternetExitCreate(d *schema.ResourceData, m interface{}) error {
+func resourceConnectorInternetExitCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 
 	client := m.(*alkira.AlkiraClient)
 	api := alkira.NewConnectorInternet(m.(*alkira.AlkiraClient))
@@ -128,35 +130,43 @@ func resourceConnectorInternetExitCreate(d *schema.ResourceData, m interface{}) 
 	request, err := generateConnectorInternetRequest(d, m)
 
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	// Send create request
-	response, provisionState, err := api.Create(request)
+	response, provState, err, provErr := api.Create(request)
 
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	// Set the state
 	d.SetId(string(response.Id))
 
 	if client.Provision == true {
-		d.Set("provision_state", provisionState)
+		d.Set("provision_state", provState)
+
+		if provErr != nil {
+			return diag.Diagnostics{{
+				Severity: diag.Warning,
+				Summary:  "PROVISION FAILED",
+				Detail:   fmt.Sprintf("%s", provErr),
+			}}
+		}
 	}
 
-	return resourceConnectorInternetExitRead(d, m)
+	return resourceConnectorInternetExitRead(ctx, d, m)
 }
 
-func resourceConnectorInternetExitRead(d *schema.ResourceData, m interface{}) error {
+func resourceConnectorInternetExitRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 
 	client := m.(*alkira.AlkiraClient)
 	api := alkira.NewConnectorInternet(m.(*alkira.AlkiraClient))
 
-	connector, err := api.GetById(d.Id())
+	connector, provState, err := api.GetById(d.Id())
 
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	d.Set("billing_tag_ids", connector.BillingTags)
@@ -176,11 +186,11 @@ func resourceConnectorInternetExitRead(d *schema.ResourceData, m interface{}) er
 		segmentId, err := getSegmentIdByName(connector.Segments[0], m)
 
 		if err != nil {
-			return err
+			return diag.FromErr(err)
 		}
 		d.Set("segment_id", segmentId)
 	} else {
-		return fmt.Errorf("the number of segments are invalid %n", numOfSegments)
+		return diag.FromErr(fmt.Errorf("the number of segments are invalid %n", numOfSegments))
 	}
 
 	if connector.TrafficDistribution != nil {
@@ -189,16 +199,14 @@ func resourceConnectorInternetExitRead(d *schema.ResourceData, m interface{}) er
 	}
 
 	// Set provision state
-	_, provisionState, err := api.GetByName(d.Get("name").(string))
-
-	if client.Provision == true && provisionState != "" {
-		d.Set("provision_state", provisionState)
+	if client.Provision == true && provState != "" {
+		d.Set("provision_state", provState)
 	}
 
 	return nil
 }
 
-func resourceConnectorInternetExitUpdate(d *schema.ResourceData, m interface{}) error {
+func resourceConnectorInternetExitUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 
 	client := m.(*alkira.AlkiraClient)
 	api := alkira.NewConnectorInternet(m.(*alkira.AlkiraClient))
@@ -207,33 +215,41 @@ func resourceConnectorInternetExitUpdate(d *schema.ResourceData, m interface{}) 
 	request, err := generateConnectorInternetRequest(d, m)
 
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	// Send update request
-	provisionState, err := api.Update(d.Id(), request)
+	provState, err, provErr := api.Update(d.Id(), request)
 
 	// Set provision state
 	if client.Provision == true {
-		d.Set("provision_state", provisionState)
+		d.Set("provision_state", provState)
+
+		if provErr != nil {
+			return diag.Diagnostics{{
+				Severity: diag.Warning,
+				Summary:  "PROVISION FAILED",
+				Detail:   fmt.Sprintf("%s", provErr),
+			}}
+		}
 	}
 
-	return err
+	return diag.FromErr(err)
 }
 
-func resourceConnectorInternetExitDelete(d *schema.ResourceData, m interface{}) error {
+func resourceConnectorInternetExitDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 
 	client := m.(*alkira.AlkiraClient)
 	api := alkira.NewConnectorInternet(m.(*alkira.AlkiraClient))
 
-	provisionState, err := api.Delete(d.Id())
+	provState, err, provErr := api.Delete(d.Id())
 
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
-	if client.Provision == true && provisionState != "SUCCESS" {
-		return fmt.Errorf("failed to delete connector_internet_exit %s, provision failed", d.Id())
+	if client.Provision == true && provState != "SUCCESS" {
+		return diag.FromErr(provErr)
 	}
 
 	d.SetId("")

--- a/alkira/resource_alkira_connector_oci_vcn.go
+++ b/alkira/resource_alkira_connector_oci_vcn.go
@@ -199,7 +199,7 @@ func resourceConnectorOciVcnCreate(ctx context.Context, d *schema.ResourceData, 
 		if provErr != nil {
 			return diag.Diagnostics{{
 				Severity: diag.Warning,
-				Summary:  "PROVISION FAILED",
+				Summary:  "PROVISION (CREATE) FAILED",
 				Detail:   fmt.Sprintf("%s", provErr),
 			}}
 		}
@@ -211,10 +211,11 @@ func resourceConnectorOciVcnCreate(ctx context.Context, d *schema.ResourceData, 
 
 func resourceConnectorOciVcnRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 
+	// INIT
 	client := m.(*alkira.AlkiraClient)
 	api := alkira.NewConnectorOciVcn(m.(*alkira.AlkiraClient))
 
-	// Read connector
+	// GET
 	connector, provState, err := api.GetById(d.Id())
 
 	if err != nil {
@@ -256,6 +257,7 @@ func resourceConnectorOciVcnRead(ctx context.Context, d *schema.ResourceData, m 
 
 func resourceConnectorOciVcnUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 
+	// INIT
 	client := m.(*alkira.AlkiraClient)
 	api := alkira.NewConnectorOciVcn(m.(*alkira.AlkiraClient))
 
@@ -266,7 +268,7 @@ func resourceConnectorOciVcnUpdate(ctx context.Context, d *schema.ResourceData, 
 		return diag.FromErr(err)
 	}
 
-	// Send request to update connector
+	// UPDATE
 	provState, err, provErr := api.Update(d.Id(), connector)
 
 	// Set provision state
@@ -276,7 +278,7 @@ func resourceConnectorOciVcnUpdate(ctx context.Context, d *schema.ResourceData, 
 		if provErr != nil {
 			return diag.Diagnostics{{
 				Severity: diag.Warning,
-				Summary:  "PROVISION FAILED",
+				Summary:  "PROVISION (UPDATE) FAILED",
 				Detail:   fmt.Sprintf("%s", provErr),
 			}}
 		}
@@ -287,20 +289,27 @@ func resourceConnectorOciVcnUpdate(ctx context.Context, d *schema.ResourceData, 
 
 func resourceConnectorOciVcnDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 
+	// INIT
 	client := m.(*alkira.AlkiraClient)
 	api := alkira.NewConnectorOciVcn(m.(*alkira.AlkiraClient))
 
+	// DELETE
 	provState, err, provErr := api.Delete(d.Id())
 
 	if err != nil {
 		return diag.FromErr(err)
 	}
 
+	d.SetId("")
+
 	if client.Provision == true && provState != "SUCCESS" {
-		return diag.FromErr(provErr)
+		return diag.Diagnostics{{
+			Severity: diag.Warning,
+			Summary:  "PROVISION (DELETE) FAILED",
+			Detail:   fmt.Sprintf("%s", provErr),
+		}}
 	}
 
-	d.SetId("")
 	return nil
 }
 

--- a/alkira/resource_alkira_connector_vmware_sdwan.go
+++ b/alkira/resource_alkira_connector_vmware_sdwan.go
@@ -175,6 +175,7 @@ func resourceAlkiraConnectorVmwareSdwan() *schema.Resource {
 
 func resourceConnectorVmwareSdwanCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 
+	// INIT
 	client := m.(*alkira.AlkiraClient)
 	api := alkira.NewConnectorVmwareSdwan(m.(*alkira.AlkiraClient))
 
@@ -201,7 +202,7 @@ func resourceConnectorVmwareSdwanCreate(ctx context.Context, d *schema.ResourceD
 		if provErr != nil {
 			return diag.Diagnostics{{
 				Severity: diag.Warning,
-				Summary:  "PROVISION FAILED",
+				Summary:  "PROVISION (CREATE) FAILED",
 				Detail:   fmt.Sprintf("%s", provErr),
 			}}
 		}
@@ -212,9 +213,11 @@ func resourceConnectorVmwareSdwanCreate(ctx context.Context, d *schema.ResourceD
 
 func resourceConnectorVmwareSdwanRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 
+	// INIT
 	client := m.(*alkira.AlkiraClient)
 	api := alkira.NewConnectorVmwareSdwan(m.(*alkira.AlkiraClient))
 
+	// GET
 	connector, provState, err := api.GetById(d.Id())
 
 	if err != nil {
@@ -260,17 +263,17 @@ func resourceConnectorVmwareSdwanRead(ctx context.Context, d *schema.ResourceDat
 
 func resourceConnectorVmwareSdwanUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 
+	// INIT
 	client := m.(*alkira.AlkiraClient)
 	api := alkira.NewConnectorVmwareSdwan(m.(*alkira.AlkiraClient))
 
-	// Construct update request
 	request, err := generateConnectorVmwareSdwanRequest(d, m)
 
 	if err != nil {
 		return diag.FromErr(err)
 	}
 
-	// Send update request
+	// UPDATE
 	provState, err, provErr := api.Update(d.Id(), request)
 
 	if err != nil {
@@ -283,7 +286,7 @@ func resourceConnectorVmwareSdwanUpdate(ctx context.Context, d *schema.ResourceD
 		if provErr != nil {
 			return diag.Diagnostics{{
 				Severity: diag.Warning,
-				Summary:  "PROVISION FAILED",
+				Summary:  "PROVISION (UPDATE) FAILED",
 				Detail:   fmt.Sprintf("%s", provErr),
 			}}
 		}
@@ -294,20 +297,26 @@ func resourceConnectorVmwareSdwanUpdate(ctx context.Context, d *schema.ResourceD
 
 func resourceConnectorVmwareSdwanDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 
+	// INIT
 	client := m.(*alkira.AlkiraClient)
 	api := alkira.NewConnectorVmwareSdwan(m.(*alkira.AlkiraClient))
 
+	// DELETE
 	provState, err, provErr := api.Delete(d.Id())
 
 	if err != nil {
 		return diag.FromErr(err)
 	}
 
-	if client.Provision == true && provState != "SUCCESS" {
-		return diag.FromErr(provErr)
-	}
-
 	d.SetId("")
+
+	if client.Provision == true && provState != "SUCCESS" {
+		return diag.Diagnostics{{
+			Severity: diag.Warning,
+			Summary:  "PROVISION (DELETE) FAILED",
+			Detail:   fmt.Sprintf("%s", provErr),
+		}}
+	}
 
 	return nil
 }

--- a/alkira/resource_alkira_connector_vmware_sdwan.go
+++ b/alkira/resource_alkira_connector_vmware_sdwan.go
@@ -5,17 +5,19 @@ import (
 	"fmt"
 
 	"github.com/alkiranet/alkira-client-go/alkira"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
 
 func resourceAlkiraConnectorVmwareSdwan() *schema.Resource {
 	return &schema.Resource{
-		Description: "Manage VMWARE SD-WAN Connector.",
-		Create:      resourceConnectorVmwareSdwanCreate,
-		Read:        resourceConnectorVmwareSdwanRead,
-		Update:      resourceConnectorVmwareSdwanUpdate,
-		Delete:      resourceConnectorVmwareSdwanDelete,
+		Description:   "Manage VMWARE SD-WAN Connector.",
+		CreateContext: resourceConnectorVmwareSdwanCreate,
+		ReadContext:   resourceConnectorVmwareSdwanRead,
+		UpdateContext: resourceConnectorVmwareSdwanUpdate,
+		DeleteContext: resourceConnectorVmwareSdwanDelete,
 		CustomizeDiff: func(ctx context.Context, d *schema.ResourceDiff, m interface{}) error {
 			client := m.(*alkira.AlkiraClient)
 
@@ -28,7 +30,7 @@ func resourceAlkiraConnectorVmwareSdwan() *schema.Resource {
 			return nil
 		},
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 
 		Schema: map[string]*schema.Schema{
@@ -171,7 +173,7 @@ func resourceAlkiraConnectorVmwareSdwan() *schema.Resource {
 	}
 }
 
-func resourceConnectorVmwareSdwanCreate(d *schema.ResourceData, m interface{}) error {
+func resourceConnectorVmwareSdwanCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 
 	client := m.(*alkira.AlkiraClient)
 	api := alkira.NewConnectorVmwareSdwan(m.(*alkira.AlkiraClient))
@@ -180,35 +182,43 @@ func resourceConnectorVmwareSdwanCreate(d *schema.ResourceData, m interface{}) e
 	request, err := generateConnectorVmwareSdwanRequest(d, m)
 
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	// Send create request
-	response, provisionState, err := api.Create(request)
+	response, provState, err, provErr := api.Create(request)
 
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	// Set states
 	d.SetId(string(response.Id))
 
 	if client.Provision == true {
-		d.Set("provision_state", provisionState)
+		d.Set("provision_state", provState)
+
+		if provErr != nil {
+			return diag.Diagnostics{{
+				Severity: diag.Warning,
+				Summary:  "PROVISION FAILED",
+				Detail:   fmt.Sprintf("%s", provErr),
+			}}
+		}
 	}
 
-	return resourceConnectorVmwareSdwanRead(d, m)
+	return resourceConnectorVmwareSdwanRead(ctx, d, m)
 }
 
-func resourceConnectorVmwareSdwanRead(d *schema.ResourceData, m interface{}) error {
+func resourceConnectorVmwareSdwanRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 
 	client := m.(*alkira.AlkiraClient)
 	api := alkira.NewConnectorVmwareSdwan(m.(*alkira.AlkiraClient))
 
-	connector, err := api.GetById(d.Id())
+	connector, provState, err := api.GetById(d.Id())
 
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	d.Set("billing_tag_ids", connector.BillingTags)
@@ -241,16 +251,14 @@ func resourceConnectorVmwareSdwanRead(d *schema.ResourceData, m interface{}) err
 	d.Set("version", connector.Version)
 
 	// Set provision state
-	_, provisionState, err := api.GetByName(d.Get("name").(string))
-
-	if client.Provision == true && provisionState != "" {
-		d.Set("provision_state", provisionState)
+	if client.Provision == true && provState != "" {
+		d.Set("provision_state", provState)
 	}
 
 	return nil
 }
 
-func resourceConnectorVmwareSdwanUpdate(d *schema.ResourceData, m interface{}) error {
+func resourceConnectorVmwareSdwanUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 
 	client := m.(*alkira.AlkiraClient)
 	api := alkira.NewConnectorVmwareSdwan(m.(*alkira.AlkiraClient))
@@ -259,37 +267,44 @@ func resourceConnectorVmwareSdwanUpdate(d *schema.ResourceData, m interface{}) e
 	request, err := generateConnectorVmwareSdwanRequest(d, m)
 
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	// Send update request
-	provisionState, err := api.Update(d.Id(), request)
+	provState, err, provErr := api.Update(d.Id(), request)
 
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	// Set provision state
 	if client.Provision == true {
-		d.Set("provision_state", provisionState)
+		d.Set("provision_state", provState)
+		if provErr != nil {
+			return diag.Diagnostics{{
+				Severity: diag.Warning,
+				Summary:  "PROVISION FAILED",
+				Detail:   fmt.Sprintf("%s", provErr),
+			}}
+		}
 	}
 
-	return resourceConnectorVmwareSdwanRead(d, m)
+	return resourceConnectorVmwareSdwanRead(ctx, d, m)
 }
 
-func resourceConnectorVmwareSdwanDelete(d *schema.ResourceData, m interface{}) error {
+func resourceConnectorVmwareSdwanDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 
 	client := m.(*alkira.AlkiraClient)
 	api := alkira.NewConnectorVmwareSdwan(m.(*alkira.AlkiraClient))
 
-	provisionState, err := api.Delete(d.Id())
+	provState, err, provErr := api.Delete(d.Id())
 
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
-	if client.Provision == true && provisionState != "SUCCESS" {
-		return fmt.Errorf("failed to delete connector_vmware_sdwan %s, provision failed", d.Id())
+	if client.Provision == true && provState != "SUCCESS" {
+		return diag.FromErr(provErr)
 	}
 
 	d.SetId("")

--- a/alkira/resource_alkira_credential_aws_vpc.go
+++ b/alkira/resource_alkira_credential_aws_vpc.go
@@ -126,7 +126,14 @@ func resourceCredentialAwsVpcDelete(ctx context.Context, d *schema.ResourceData,
 	credentialId := d.Id()
 
 	log.Printf("[INFO] Deleting credential (AWS-VPC %s)\n", credentialId)
-	return diag.FromErr(client.DeleteCredential(credentialId, alkira.CredentialTypeAwsVpc))
+	err := client.DeleteCredential(credentialId, alkira.CredentialTypeAwsVpc)
+
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	d.SetId("")
+	return nil
 }
 
 func generateCredentialAwsVpc(d *schema.ResourceData) (interface{}, error) {

--- a/alkira/resource_alkira_credential_azure_vnet.go
+++ b/alkira/resource_alkira_credential_azure_vnet.go
@@ -114,16 +114,13 @@ func resourceCredentialAzureVnetUpdate(ctx context.Context, d *schema.ResourceDa
 
 func resourceCredentialAzureVnetDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*alkira.AlkiraClient)
-	id := d.Id()
 
-	log.Printf("[INFO] Deleting Credential (AZURE-VNET %s)\n", id)
-	err := client.DeleteCredential(id, alkira.CredentialTypeAzureVnet)
+	err := client.DeleteCredential(d.Id(), alkira.CredentialTypeAzureVnet)
 
 	if err != nil {
 		return diag.FromErr(err)
 	}
 
-	log.Printf("[INFO] Deleted Credential (AZURE-VNET %s)\n", id)
 	d.SetId("")
 	return nil
 }

--- a/alkira/resource_alkira_credential_azure_vnet.go
+++ b/alkira/resource_alkira_credential_azure_vnet.go
@@ -1,9 +1,12 @@
 package alkira
 
 import (
+	"context"
 	"log"
 
 	"github.com/alkiranet/alkira-client-go/alkira"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
@@ -14,12 +17,12 @@ func resourceAlkiraCredentialAzureVnet() *schema.Resource {
 			"environmental variables:\n\n * AK_AZURE_APPLICATION_ID\n " +
 			"* AK_AZURE_SUBSCRIPTION_ID\n * AK_AZURE_SECRET_KEY\n " +
 			"* AK_AZURE_TENANT_ID\n",
-		Create: resourceCredentialAzureVnet,
-		Read:   resourceCredentialAzureVnetRead,
-		Update: resourceCredentialAzureVnetUpdate,
-		Delete: resourceCredentialAzureVnetDelete,
+		CreateContext: resourceCredentialAzureVnet,
+		ReadContext:   resourceCredentialAzureVnetRead,
+		UpdateContext: resourceCredentialAzureVnetUpdate,
+		DeleteContext: resourceCredentialAzureVnetDelete,
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 
 		Schema: map[string]*schema.Schema{
@@ -64,7 +67,7 @@ func resourceAlkiraCredentialAzureVnet() *schema.Resource {
 	}
 }
 
-func resourceCredentialAzureVnet(d *schema.ResourceData, meta interface{}) error {
+func resourceCredentialAzureVnet(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*alkira.AlkiraClient)
 
 	c := alkira.CredentialAzureVnet{
@@ -78,18 +81,18 @@ func resourceCredentialAzureVnet(d *schema.ResourceData, meta interface{}) error
 	id, err := client.CreateCredential(d.Get("name").(string), alkira.CredentialTypeAzureVnet, c, 0)
 
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	d.SetId(id)
-	return resourceCredentialAzureVnetRead(d, meta)
+	return resourceCredentialAzureVnetRead(ctx, d, meta)
 }
 
-func resourceCredentialAzureVnetRead(d *schema.ResourceData, meta interface{}) error {
+func resourceCredentialAzureVnetRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	return nil
 }
 
-func resourceCredentialAzureVnetUpdate(d *schema.ResourceData, meta interface{}) error {
+func resourceCredentialAzureVnetUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*alkira.AlkiraClient)
 
 	c := alkira.CredentialAzureVnet{
@@ -103,13 +106,13 @@ func resourceCredentialAzureVnetUpdate(d *schema.ResourceData, meta interface{})
 	err := client.UpdateCredential(d.Id(), d.Get("name").(string), alkira.CredentialTypeAzureVnet, c, 0)
 
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
-	return resourceCredentialAzureVnetRead(d, meta)
+	return resourceCredentialAzureVnetRead(ctx, d, meta)
 }
 
-func resourceCredentialAzureVnetDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceCredentialAzureVnetDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*alkira.AlkiraClient)
 	id := d.Id()
 
@@ -117,7 +120,7 @@ func resourceCredentialAzureVnetDelete(d *schema.ResourceData, meta interface{})
 	err := client.DeleteCredential(id, alkira.CredentialTypeAzureVnet)
 
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	log.Printf("[INFO] Deleted Credential (AZURE-VNET %s)\n", id)

--- a/alkira/resource_alkira_credential_gcp_vpc.go
+++ b/alkira/resource_alkira_credential_gcp_vpc.go
@@ -1,21 +1,24 @@
 package alkira
 
 import (
+	"context"
 	"log"
 
 	"github.com/alkiranet/alkira-client-go/alkira"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 func resourceAlkiraCredentialGcpVpc() *schema.Resource {
 	return &schema.Resource{
-		Description: "Manage Credential for GCP.",
-		Create:      resourceCredentialGcpVpc,
-		Read:        resourceCredentialGcpVpcRead,
-		Update:      resourceCredentialGcpVpcUpdate,
-		Delete:      resourceCredentialGcpVpcDelete,
+		Description:   "Manage Credential for GCP.",
+		CreateContext: resourceCredentialGcpVpc,
+		ReadContext:   resourceCredentialGcpVpcRead,
+		UpdateContext: resourceCredentialGcpVpcUpdate,
+		DeleteContext: resourceCredentialGcpVpcDelete,
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 
 		Schema: map[string]*schema.Schema{
@@ -82,7 +85,7 @@ func resourceAlkiraCredentialGcpVpc() *schema.Resource {
 	}
 }
 
-func resourceCredentialGcpVpc(d *schema.ResourceData, meta interface{}) error {
+func resourceCredentialGcpVpc(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*alkira.AlkiraClient)
 
 	c := alkira.CredentialGcpVpc{
@@ -102,18 +105,18 @@ func resourceCredentialGcpVpc(d *schema.ResourceData, meta interface{}) error {
 	credentialId, err := client.CreateCredential(d.Get("name").(string), "gcpvpc", c, 0)
 
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	d.SetId(credentialId)
-	return resourceCredentialGcpVpcRead(d, meta)
+	return resourceCredentialGcpVpcRead(ctx, d, meta)
 }
 
-func resourceCredentialGcpVpcRead(d *schema.ResourceData, meta interface{}) error {
+func resourceCredentialGcpVpcRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	return nil
 }
 
-func resourceCredentialGcpVpcUpdate(d *schema.ResourceData, meta interface{}) error {
+func resourceCredentialGcpVpcUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*alkira.AlkiraClient)
 
 	c := alkira.CredentialGcpVpc{
@@ -133,13 +136,13 @@ func resourceCredentialGcpVpcUpdate(d *schema.ResourceData, meta interface{}) er
 	err := client.UpdateCredential(d.Id(), d.Get("name").(string), "gcpvpc", c, 0)
 
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
-	return resourceCredentialGcpVpcRead(d, meta)
+	return resourceCredentialGcpVpcRead(ctx, d, meta)
 }
 
-func resourceCredentialGcpVpcDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceCredentialGcpVpcDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*alkira.AlkiraClient)
 	id := d.Id()
 
@@ -147,7 +150,7 @@ func resourceCredentialGcpVpcDelete(d *schema.ResourceData, meta interface{}) er
 	err := client.DeleteCredential(id, "gcpvpc")
 
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	log.Printf("[INFO] Deleted Credential (GCP-VPC %s)\n", id)

--- a/alkira/resource_alkira_credential_gcp_vpc.go
+++ b/alkira/resource_alkira_credential_gcp_vpc.go
@@ -144,16 +144,13 @@ func resourceCredentialGcpVpcUpdate(ctx context.Context, d *schema.ResourceData,
 
 func resourceCredentialGcpVpcDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*alkira.AlkiraClient)
-	id := d.Id()
 
-	log.Printf("[INFO] Deleting Credential (GCP-VPC %s)\n", id)
-	err := client.DeleteCredential(id, "gcpvpc")
+	err := client.DeleteCredential(d.Id(), "gcpvpc")
 
 	if err != nil {
 		return diag.FromErr(err)
 	}
 
-	log.Printf("[INFO] Deleted Credential (GCP-VPC %s)\n", id)
 	d.SetId("")
 	return nil
 }

--- a/alkira/resource_alkira_credential_oci_vcn.go
+++ b/alkira/resource_alkira_credential_oci_vcn.go
@@ -1,9 +1,12 @@
 package alkira
 
 import (
+	"context"
 	"log"
 
 	"github.com/alkiranet/alkira-client-go/alkira"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
@@ -14,12 +17,12 @@ func resourceAlkiraCredentialOciVcn() *schema.Resource {
 			"variables:\n\n * AK_OCI_USER_OCID\n " +
 			"* AK_OCI_FINGERPRINT\n * AK_OCI_KEY\n " +
 			"* AK_OCI_TENANT_OCID\n",
-		Create: resourceCredentialOciVcn,
-		Read:   resourceCredentialOciVcnRead,
-		Update: resourceCredentialOciVcnUpdate,
-		Delete: resourceCredentialOciVcnDelete,
+		CreateContext: resourceCredentialOciVcn,
+		ReadContext:   resourceCredentialOciVcnRead,
+		UpdateContext: resourceCredentialOciVcnUpdate,
+		DeleteContext: resourceCredentialOciVcnDelete,
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 
 		Schema: map[string]*schema.Schema{
@@ -64,7 +67,7 @@ func resourceAlkiraCredentialOciVcn() *schema.Resource {
 	}
 }
 
-func resourceCredentialOciVcn(d *schema.ResourceData, meta interface{}) error {
+func resourceCredentialOciVcn(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*alkira.AlkiraClient)
 
 	c := generateCredentialOciVcnRequest(d)
@@ -73,18 +76,18 @@ func resourceCredentialOciVcn(d *schema.ResourceData, meta interface{}) error {
 	credentialId, err := client.CreateCredential(d.Get("name").(string), alkira.CredentialTypeOciVcn, c, 0)
 
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	d.SetId(credentialId)
-	return resourceCredentialOciVcnRead(d, meta)
+	return resourceCredentialOciVcnRead(ctx, d, meta)
 }
 
-func resourceCredentialOciVcnRead(d *schema.ResourceData, meta interface{}) error {
+func resourceCredentialOciVcnRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	return nil
 }
 
-func resourceCredentialOciVcnUpdate(d *schema.ResourceData, meta interface{}) error {
+func resourceCredentialOciVcnUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*alkira.AlkiraClient)
 
 	c := generateCredentialOciVcnRequest(d)
@@ -93,13 +96,13 @@ func resourceCredentialOciVcnUpdate(d *schema.ResourceData, meta interface{}) er
 	err := client.UpdateCredential(d.Id(), d.Get("name").(string), alkira.CredentialTypeOciVcn, c, 0)
 
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
-	return resourceCredentialOciVcnRead(d, meta)
+	return resourceCredentialOciVcnRead(ctx, d, meta)
 }
 
-func resourceCredentialOciVcnDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceCredentialOciVcnDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*alkira.AlkiraClient)
 	id := d.Id()
 
@@ -107,7 +110,7 @@ func resourceCredentialOciVcnDelete(d *schema.ResourceData, meta interface{}) er
 	err := client.DeleteCredential(id, alkira.CredentialTypeOciVcn)
 
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	log.Printf("[INFO] Deleted Credential (OCI-VCN) %s", id)

--- a/alkira/resource_alkira_credential_oci_vcn.go
+++ b/alkira/resource_alkira_credential_oci_vcn.go
@@ -2,7 +2,6 @@ package alkira
 
 import (
 	"context"
-	"log"
 
 	"github.com/alkiranet/alkira-client-go/alkira"
 
@@ -72,7 +71,6 @@ func resourceCredentialOciVcn(ctx context.Context, d *schema.ResourceData, meta 
 
 	c := generateCredentialOciVcnRequest(d)
 
-	log.Printf("[INFO] Creating Credential (OCI-VCN)")
 	credentialId, err := client.CreateCredential(d.Get("name").(string), alkira.CredentialTypeOciVcn, c, 0)
 
 	if err != nil {
@@ -92,7 +90,6 @@ func resourceCredentialOciVcnUpdate(ctx context.Context, d *schema.ResourceData,
 
 	c := generateCredentialOciVcnRequest(d)
 
-	log.Printf("[INFO] Updating Credential (OCI-VCN)")
 	err := client.UpdateCredential(d.Id(), d.Get("name").(string), alkira.CredentialTypeOciVcn, c, 0)
 
 	if err != nil {
@@ -104,16 +101,13 @@ func resourceCredentialOciVcnUpdate(ctx context.Context, d *schema.ResourceData,
 
 func resourceCredentialOciVcnDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*alkira.AlkiraClient)
-	id := d.Id()
 
-	log.Printf("[INFO] Deleting Credential (OCI-VCN) %s", id)
-	err := client.DeleteCredential(id, alkira.CredentialTypeOciVcn)
+	err := client.DeleteCredential(d.Id(), alkira.CredentialTypeOciVcn)
 
 	if err != nil {
 		return diag.FromErr(err)
 	}
 
-	log.Printf("[INFO] Deleted Credential (OCI-VCN) %s", id)
 	d.SetId("")
 	return nil
 }

--- a/alkira/resource_alkira_credential_ssh_key_pair.go
+++ b/alkira/resource_alkira_credential_ssh_key_pair.go
@@ -2,7 +2,6 @@ package alkira
 
 import (
 	"context"
-	"log"
 
 	"github.com/alkiranet/alkira-client-go/alkira"
 
@@ -69,7 +68,6 @@ func resourceCredentialSshKeyPairUpdate(ctx context.Context, d *schema.ResourceD
 		Type:      "IMPORTED",
 	}
 
-	log.Printf("[INFO] Updating Credential (SSH key pair)")
 	err := client.UpdateCredential(d.Id(), d.Get("name").(string), alkira.CredentialTypeKeyPair, c, 0)
 
 	if err != nil {
@@ -82,8 +80,12 @@ func resourceCredentialSshKeyPairUpdate(ctx context.Context, d *schema.ResourceD
 func resourceCredentialSshKeyPairDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*alkira.AlkiraClient)
 
-	log.Printf("[INFO] Deleting credential (SSH key pair %s)\n", d.Id())
 	err := client.DeleteCredential(d.Id(), alkira.CredentialTypeKeyPair)
 
-	return diag.FromErr(err)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	d.SetId("")
+	return nil
 }

--- a/alkira/resource_alkira_credential_ssh_key_pair.go
+++ b/alkira/resource_alkira_credential_ssh_key_pair.go
@@ -1,21 +1,24 @@
 package alkira
 
 import (
+	"context"
 	"log"
 
 	"github.com/alkiranet/alkira-client-go/alkira"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 func resourceAlkiraCredentialSshKeyPair() *schema.Resource {
 	return &schema.Resource{
-		Description: "Provides SSH Key Pair credential resource.",
-		Create:      resourceCredentialSshKeyPairCreate,
-		Read:        resourceCredentialSshKeyPairRead,
-		Update:      resourceCredentialSshKeyPairUpdate,
-		Delete:      resourceCredentialSshKeyPairDelete,
+		Description:   "Provides SSH Key Pair credential resource.",
+		CreateContext: resourceCredentialSshKeyPairCreate,
+		ReadContext:   resourceCredentialSshKeyPairRead,
+		UpdateContext: resourceCredentialSshKeyPairUpdate,
+		DeleteContext: resourceCredentialSshKeyPairDelete,
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 
 		Schema: map[string]*schema.Schema{
@@ -36,7 +39,7 @@ func resourceAlkiraCredentialSshKeyPair() *schema.Resource {
 	}
 }
 
-func resourceCredentialSshKeyPairCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceCredentialSshKeyPairCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*alkira.AlkiraClient)
 
 	c := alkira.CredentialKeyPair{
@@ -47,18 +50,18 @@ func resourceCredentialSshKeyPairCreate(d *schema.ResourceData, meta interface{}
 	id, err := client.CreateCredential(d.Get("name").(string), alkira.CredentialTypeKeyPair, c, 0)
 
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	d.SetId(id)
-	return resourceCredentialSshKeyPairRead(d, meta)
+	return resourceCredentialSshKeyPairRead(ctx, d, meta)
 }
 
-func resourceCredentialSshKeyPairRead(d *schema.ResourceData, meta interface{}) error {
+func resourceCredentialSshKeyPairRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	return nil
 }
 
-func resourceCredentialSshKeyPairUpdate(d *schema.ResourceData, meta interface{}) error {
+func resourceCredentialSshKeyPairUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*alkira.AlkiraClient)
 
 	c := alkira.CredentialKeyPair{
@@ -70,17 +73,17 @@ func resourceCredentialSshKeyPairUpdate(d *schema.ResourceData, meta interface{}
 	err := client.UpdateCredential(d.Id(), d.Get("name").(string), alkira.CredentialTypeKeyPair, c, 0)
 
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
-	return resourceCredentialSshKeyPairRead(d, meta)
+	return resourceCredentialSshKeyPairRead(ctx, d, meta)
 }
 
-func resourceCredentialSshKeyPairDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceCredentialSshKeyPairDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*alkira.AlkiraClient)
 
 	log.Printf("[INFO] Deleting credential (SSH key pair %s)\n", d.Id())
 	err := client.DeleteCredential(d.Id(), alkira.CredentialTypeKeyPair)
 
-	return err
+	return diag.FromErr(err)
 }

--- a/alkira/resource_alkira_group_user.go
+++ b/alkira/resource_alkira_group_user.go
@@ -1,19 +1,22 @@
 package alkira
 
 import (
+	"context"
 	"log"
 
 	"github.com/alkiranet/alkira-client-go/alkira"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 func resourceAlkiraGroupUser() *schema.Resource {
 	return &schema.Resource{
-		Description: "Manage user groups\n\n",
-		Create:      resourceGroupUser,
-		Read:        resourceGroupUserRead,
-		Update:      resourceGroupUserUpdate,
-		Delete:      resourceGroupUserDelete,
+		Description:   "Manage user groups\n\n",
+		CreateContext: resourceGroupUser,
+		ReadContext:   resourceGroupUserRead,
+		UpdateContext: resourceGroupUserUpdate,
+		DeleteContext: resourceGroupUserDelete,
 
 		Schema: map[string]*schema.Schema{
 			"name": {
@@ -30,7 +33,7 @@ func resourceAlkiraGroupUser() *schema.Resource {
 	}
 }
 
-func resourceGroupUser(d *schema.ResourceData, m interface{}) error {
+func resourceGroupUser(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	api := alkira.NewUserGroup(m.(*alkira.AlkiraClient))
 
 	group := &alkira.UserGroup{
@@ -38,24 +41,24 @@ func resourceGroupUser(d *schema.ResourceData, m interface{}) error {
 		Description: d.Get("description").(string),
 	}
 
-	resource, _, err := api.Create(group)
+	resource, _, err, _ := api.Create(group)
 
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	d.SetId(string(resource.Id))
 
-	return resourceGroupUserRead(d, m)
+	return resourceGroupUserRead(ctx, d, m)
 }
 
-func resourceGroupUserRead(d *schema.ResourceData, m interface{}) error {
+func resourceGroupUserRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	api := alkira.NewUserGroup(m.(*alkira.AlkiraClient))
 
-	group, err := api.GetById(d.Id())
+	group, _, err := api.GetById(d.Id())
 
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	d.Set("name", group.Name)
@@ -64,7 +67,7 @@ func resourceGroupUserRead(d *schema.ResourceData, m interface{}) error {
 	return nil
 }
 
-func resourceGroupUserUpdate(d *schema.ResourceData, m interface{}) error {
+func resourceGroupUserUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	api := alkira.NewUserGroup(m.(*alkira.AlkiraClient))
 
 	group := &alkira.UserGroup{
@@ -73,22 +76,22 @@ func resourceGroupUserUpdate(d *schema.ResourceData, m interface{}) error {
 	}
 
 	log.Printf("[INFO] Updating User Group (%s)", d.Id())
-	_, err := api.Update(d.Id(), group)
+	_, err, _ := api.Update(d.Id(), group)
 
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	return nil
 }
 
-func resourceGroupUserDelete(d *schema.ResourceData, m interface{}) error {
+func resourceGroupUserDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	api := alkira.NewUserGroup(m.(*alkira.AlkiraClient))
 
-	_, err := api.Delete(d.Id())
+	_, err, _ := api.Delete(d.Id())
 
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	d.SetId("")

--- a/alkira/resource_alkira_internet_applications.go
+++ b/alkira/resource_alkira_internet_applications.go
@@ -5,17 +5,19 @@ import (
 	"fmt"
 
 	"github.com/alkiranet/alkira-client-go/alkira"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
 
 func resourceAlkiraInternetApplication() *schema.Resource {
 	return &schema.Resource{
-		Description: "Manage Internet Application.",
-		Create:      resourceInternetApplicationCreate,
-		Read:        resourceInternetApplicationRead,
-		Update:      resourceInternetApplicationUpdate,
-		Delete:      resourceInternetApplicationDelete,
+		Description:   "Manage Internet Application.",
+		CreateContext: resourceInternetApplicationCreate,
+		ReadContext:   resourceInternetApplicationRead,
+		UpdateContext: resourceInternetApplicationUpdate,
+		DeleteContext: resourceInternetApplicationDelete,
 		CustomizeDiff: func(ctx context.Context, d *schema.ResourceDiff, m interface{}) error {
 			client := m.(*alkira.AlkiraClient)
 
@@ -28,7 +30,7 @@ func resourceAlkiraInternetApplication() *schema.Resource {
 			return nil
 		},
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 
 		Schema: map[string]*schema.Schema{
@@ -160,7 +162,7 @@ func resourceAlkiraInternetApplication() *schema.Resource {
 	}
 }
 
-func resourceInternetApplicationCreate(d *schema.ResourceData, m interface{}) error {
+func resourceInternetApplicationCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 
 	client := m.(*alkira.AlkiraClient)
 	api := alkira.NewInternetApplication(m.(*alkira.AlkiraClient))
@@ -169,34 +171,42 @@ func resourceInternetApplicationCreate(d *schema.ResourceData, m interface{}) er
 	request, err := generateInternetApplicationRequest(d, m)
 
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	// Send request to create
-	response, provisionState, err := api.Create(request)
+	response, provState, err, provErr := api.Create(request)
 
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	// Set provision state
 	if client.Provision == true {
-		d.Set("provision_state", provisionState)
+		d.Set("provision_state", provState)
+
+		if provErr != nil {
+			return diag.Diagnostics{{
+				Severity: diag.Warning,
+				Summary:  "PROVISION FAILED",
+				Detail:   fmt.Sprintf("%s", provErr),
+			}}
+		}
 	}
 
 	d.SetId(string(response.Id))
-	return resourceInternetApplicationRead(d, m)
+	return resourceInternetApplicationRead(ctx, d, m)
 }
 
-func resourceInternetApplicationRead(d *schema.ResourceData, m interface{}) error {
+func resourceInternetApplicationRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 
 	client := m.(*alkira.AlkiraClient)
 	api := alkira.NewInternetApplication(m.(*alkira.AlkiraClient))
 
-	app, err := api.GetById(d.Id())
+	app, provState, err := api.GetById(d.Id())
 
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	d.Set("billing_tag_ids", app.BillingTags)
@@ -212,7 +222,7 @@ func resourceInternetApplicationRead(d *schema.ResourceData, m interface{}) erro
 	segmentId, err := getSegmentIdByName(app.SegmentName, m)
 
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	d.Set("segment_id", segmentId)
@@ -233,16 +243,14 @@ func resourceInternetApplicationRead(d *schema.ResourceData, m interface{}) erro
 	d.Set("targets", targets)
 
 	// Set provision state
-	_, provisionState, err := api.GetByName(d.Get("name").(string))
-
-	if client.Provision == true && provisionState != "" {
-		d.Set("provision_state", provisionState)
+	if client.Provision == true && provState != "" {
+		d.Set("provision_state", provState)
 	}
 
 	return nil
 }
 
-func resourceInternetApplicationUpdate(d *schema.ResourceData, m interface{}) error {
+func resourceInternetApplicationUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 
 	client := m.(*alkira.AlkiraClient)
 	api := alkira.NewInternetApplication(m.(*alkira.AlkiraClient))
@@ -251,37 +259,45 @@ func resourceInternetApplicationUpdate(d *schema.ResourceData, m interface{}) er
 	request, err := generateInternetApplicationRequest(d, m)
 
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	// Send update request
-	provisionState, err := api.Update(d.Id(), request)
+	provState, err, provErr := api.Update(d.Id(), request)
 
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	// Set provision state
 	if client.Provision == true {
-		d.Set("provision_state", provisionState)
+		d.Set("provision_state", provState)
+
+		if provErr != nil {
+			return diag.Diagnostics{{
+				Severity: diag.Warning,
+				Summary:  "PROVISION FAILED",
+				Detail:   fmt.Sprintf("%s", provErr),
+			}}
+		}
 	}
 
-	return resourceInternetApplicationRead(d, m)
+	return resourceInternetApplicationRead(ctx, d, m)
 }
 
-func resourceInternetApplicationDelete(d *schema.ResourceData, m interface{}) error {
+func resourceInternetApplicationDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 
 	client := m.(*alkira.AlkiraClient)
 	api := alkira.NewInternetApplication(m.(*alkira.AlkiraClient))
 
-	provisionState, err := api.Delete(d.Id())
+	provState, err, provErr := api.Delete(d.Id())
 
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
-	if client.Provision == true && provisionState != "SUCCESS" {
-		return fmt.Errorf("failed to delete internet_application %s, provision failed", d.Id())
+	if client.Provision == true && provState != "SUCCESS" {
+		return diag.FromErr(provErr)
 	}
 
 	d.SetId("")

--- a/alkira/resource_alkira_internet_applications.go
+++ b/alkira/resource_alkira_internet_applications.go
@@ -164,17 +164,17 @@ func resourceAlkiraInternetApplication() *schema.Resource {
 
 func resourceInternetApplicationCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 
+	// INIT
 	client := m.(*alkira.AlkiraClient)
 	api := alkira.NewInternetApplication(m.(*alkira.AlkiraClient))
 
-	// Construct request
 	request, err := generateInternetApplicationRequest(d, m)
 
 	if err != nil {
 		return diag.FromErr(err)
 	}
 
-	// Send request to create
+	// CREATE
 	response, provState, err, provErr := api.Create(request)
 
 	if err != nil {
@@ -188,7 +188,7 @@ func resourceInternetApplicationCreate(ctx context.Context, d *schema.ResourceDa
 		if provErr != nil {
 			return diag.Diagnostics{{
 				Severity: diag.Warning,
-				Summary:  "PROVISION FAILED",
+				Summary:  "PROVISION (CREATE) FAILED",
 				Detail:   fmt.Sprintf("%s", provErr),
 			}}
 		}
@@ -200,9 +200,11 @@ func resourceInternetApplicationCreate(ctx context.Context, d *schema.ResourceDa
 
 func resourceInternetApplicationRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 
+	// INIT
 	client := m.(*alkira.AlkiraClient)
 	api := alkira.NewInternetApplication(m.(*alkira.AlkiraClient))
 
+	// GET
 	app, provState, err := api.GetById(d.Id())
 
 	if err != nil {
@@ -252,17 +254,17 @@ func resourceInternetApplicationRead(ctx context.Context, d *schema.ResourceData
 
 func resourceInternetApplicationUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 
+	// INIT
 	client := m.(*alkira.AlkiraClient)
 	api := alkira.NewInternetApplication(m.(*alkira.AlkiraClient))
 
-	// Construct update request
 	request, err := generateInternetApplicationRequest(d, m)
 
 	if err != nil {
 		return diag.FromErr(err)
 	}
 
-	// Send update request
+	// UPDATE
 	provState, err, provErr := api.Update(d.Id(), request)
 
 	if err != nil {
@@ -287,6 +289,7 @@ func resourceInternetApplicationUpdate(ctx context.Context, d *schema.ResourceDa
 
 func resourceInternetApplicationDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 
+	// INIT
 	client := m.(*alkira.AlkiraClient)
 	api := alkira.NewInternetApplication(m.(*alkira.AlkiraClient))
 
@@ -296,11 +299,16 @@ func resourceInternetApplicationDelete(ctx context.Context, d *schema.ResourceDa
 		return diag.FromErr(err)
 	}
 
+	d.SetId("")
+
 	if client.Provision == true && provState != "SUCCESS" {
-		return diag.FromErr(provErr)
+		return diag.Diagnostics{{
+			Severity: diag.Warning,
+			Summary:  "PROVISION (DELETE) FAILED",
+			Detail:   fmt.Sprintf("%s", provErr),
+		}}
 	}
 
-	d.SetId("")
 	return nil
 }
 

--- a/alkira/resource_alkira_list_as_path.go
+++ b/alkira/resource_alkira_list_as_path.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 
 	"github.com/alkiranet/alkira-client-go/alkira"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
@@ -13,10 +15,10 @@ func resourceAlkiraListAsPath() *schema.Resource {
 		Description: "This list could be used in a policy rule, a route " +
 			"will match successfully if any one value from the list is " +
 			"included within the AS-PATH of the route.",
-		Create: resourceListAsPath,
-		Read:   resourceListAsPathRead,
-		Update: resourceListAsPathUpdate,
-		Delete: resourceListAsPathDelete,
+		CreateContext: resourceListAsPath,
+		ReadContext:   resourceListAsPathRead,
+		UpdateContext: resourceListAsPathUpdate,
+		DeleteContext: resourceListAsPathDelete,
 		CustomizeDiff: func(ctx context.Context, d *schema.ResourceDiff, m interface{}) error {
 			client := m.(*alkira.AlkiraClient)
 
@@ -29,7 +31,7 @@ func resourceAlkiraListAsPath() *schema.Resource {
 			return nil
 		},
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 
 		Schema: map[string]*schema.Schema{
@@ -60,7 +62,7 @@ func resourceAlkiraListAsPath() *schema.Resource {
 	}
 }
 
-func resourceListAsPath(d *schema.ResourceData, m interface{}) error {
+func resourceListAsPath(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 
 	client := m.(*alkira.AlkiraClient)
 	api := alkira.NewListAsPath(m.(*alkira.AlkiraClient))
@@ -69,34 +71,42 @@ func resourceListAsPath(d *schema.ResourceData, m interface{}) error {
 	request, err := generateListAsPathRequest(d, m)
 
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	// Send request
-	resource, provisionState, err := api.Create(request)
+	resource, provState, err, provErr := api.Create(request)
 
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	// Set provision state
 	if client.Provision == true {
-		d.Set("provision_state", provisionState)
+		d.Set("provision_state", provState)
+
+		if provErr != nil {
+			return diag.Diagnostics{{
+				Severity: diag.Warning,
+				Summary:  "PROVISION FAILED",
+				Detail:   fmt.Sprintf("%s", provErr),
+			}}
+		}
 	}
 
 	d.SetId(string(resource.Id))
-	return resourceListAsPathRead(d, m)
+	return resourceListAsPathRead(ctx, d, m)
 }
 
-func resourceListAsPathRead(d *schema.ResourceData, m interface{}) error {
+func resourceListAsPathRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 
 	client := m.(*alkira.AlkiraClient)
 	api := alkira.NewListAsPath(m.(*alkira.AlkiraClient))
 
-	list, err := api.GetById(d.Id())
+	list, provState, err := api.GetById(d.Id())
 
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	d.Set("name", list.Name)
@@ -104,16 +114,14 @@ func resourceListAsPathRead(d *schema.ResourceData, m interface{}) error {
 	d.Set("values", list.Values)
 
 	// Set provision state
-	_, provisionState, err := api.GetByName(d.Get("name").(string))
-
-	if client.Provision == true && provisionState != "" {
-		d.Set("provision_state", provisionState)
+	if client.Provision == true && provState != "" {
+		d.Set("provision_state", provState)
 	}
 
 	return nil
 }
 
-func resourceListAsPathUpdate(d *schema.ResourceData, m interface{}) error {
+func resourceListAsPathUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 
 	client := m.(*alkira.AlkiraClient)
 	api := alkira.NewListAsPath(m.(*alkira.AlkiraClient))
@@ -122,37 +130,45 @@ func resourceListAsPathUpdate(d *schema.ResourceData, m interface{}) error {
 	request, err := generateListAsPathRequest(d, m)
 
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	// Send update request
-	provisionState, err := api.Update(d.Id(), request)
+	provState, err, provErr := api.Update(d.Id(), request)
 
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	// Set provision state
 	if client.Provision == true {
-		d.Set("provision_state", provisionState)
+		d.Set("provision_state", provState)
+
+		if provErr != nil {
+			return diag.Diagnostics{{
+				Severity: diag.Warning,
+				Summary:  "PROVISION FAILED",
+				Detail:   fmt.Sprintf("%s", provErr),
+			}}
+		}
 	}
 
-	return resourceListAsPathRead(d, m)
+	return resourceListAsPathRead(ctx, d, m)
 }
 
-func resourceListAsPathDelete(d *schema.ResourceData, m interface{}) error {
+func resourceListAsPathDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 
 	client := m.(*alkira.AlkiraClient)
 	api := alkira.NewListAsPath(m.(*alkira.AlkiraClient))
 
-	provisionState, err := api.Delete(d.Id())
+	provState, err, provErr := api.Delete(d.Id())
 
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
-	if client.Provision == true && provisionState != "SUCCESS" {
-		return fmt.Errorf("failed to delete list_as_path %s, provision failed", d.Id())
+	if client.Provision == true && provState != "SUCCESS" {
+		return diag.FromErr(provErr)
 	}
 
 	d.SetId("")

--- a/alkira/resource_alkira_list_as_path.go
+++ b/alkira/resource_alkira_list_as_path.go
@@ -88,7 +88,7 @@ func resourceListAsPath(ctx context.Context, d *schema.ResourceData, m interface
 		if provErr != nil {
 			return diag.Diagnostics{{
 				Severity: diag.Warning,
-				Summary:  "PROVISION FAILED",
+				Summary:  "PROVISION (CREATE) FAILED",
 				Detail:   fmt.Sprintf("%s", provErr),
 			}}
 		}
@@ -147,7 +147,7 @@ func resourceListAsPathUpdate(ctx context.Context, d *schema.ResourceData, m int
 		if provErr != nil {
 			return diag.Diagnostics{{
 				Severity: diag.Warning,
-				Summary:  "PROVISION FAILED",
+				Summary:  "PROVISION (UPDATE) FAILED",
 				Detail:   fmt.Sprintf("%s", provErr),
 			}}
 		}
@@ -167,11 +167,16 @@ func resourceListAsPathDelete(ctx context.Context, d *schema.ResourceData, m int
 		return diag.FromErr(err)
 	}
 
+	d.SetId("")
+
 	if client.Provision == true && provState != "SUCCESS" {
-		return diag.FromErr(provErr)
+		return diag.Diagnostics{{
+			Severity: diag.Warning,
+			Summary:  "PROVISION (DELETE) FAILED",
+			Detail:   fmt.Sprintf("%s", provErr),
+		}}
 	}
 
-	d.SetId("")
 	return nil
 }
 

--- a/alkira/resource_alkira_list_community.go
+++ b/alkira/resource_alkira_list_community.go
@@ -85,7 +85,7 @@ func resourceListCommunity(ctx context.Context, d *schema.ResourceData, m interf
 		if provErr != nil {
 			return diag.Diagnostics{{
 				Severity: diag.Warning,
-				Summary:  "PROVISION FAILED",
+				Summary:  "PROVISION (CREATE) FAILED",
 				Detail:   fmt.Sprintf("%s", provErr),
 			}}
 		}
@@ -140,7 +140,7 @@ func resourceListCommunityUpdate(ctx context.Context, d *schema.ResourceData, m 
 		if provErr != nil {
 			return diag.Diagnostics{{
 				Severity: diag.Warning,
-				Summary:  "PROVISION FAILED",
+				Summary:  "PROVISION (UPDATE) FAILED",
 				Detail:   fmt.Sprintf("%s", provErr),
 			}}
 		}
@@ -160,11 +160,16 @@ func resourceListCommunityDelete(ctx context.Context, d *schema.ResourceData, m 
 		return diag.FromErr(err)
 	}
 
+	d.SetId("")
+
 	if client.Provision == true && provState != "SUCCESS" {
-		return diag.FromErr(provErr)
+		return diag.Diagnostics{{
+			Severity: diag.Warning,
+			Summary:  "PROVISION (DELETE) FAILED",
+			Detail:   fmt.Sprintf("%s", provErr),
+		}}
 	}
 
-	d.SetId("")
 	return nil
 }
 

--- a/alkira/resource_alkira_list_community.go
+++ b/alkira/resource_alkira_list_community.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 
 	"github.com/alkiranet/alkira-client-go/alkira"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
@@ -13,10 +15,10 @@ func resourceAlkiraListCommunity() *schema.Resource {
 		Description: "This list could be used to matches a route when all " +
 			"values in the list are present on the route. A route matches " +
 			"a list when any of the values match.",
-		Create: resourceListCommunity,
-		Read:   resourceListCommunityRead,
-		Update: resourceListCommunityUpdate,
-		Delete: resourceListCommunityDelete,
+		CreateContext: resourceListCommunity,
+		ReadContext:   resourceListCommunityRead,
+		UpdateContext: resourceListCommunityUpdate,
+		DeleteContext: resourceListCommunityDelete,
 		CustomizeDiff: func(ctx context.Context, d *schema.ResourceDiff, m interface{}) error {
 			client := m.(*alkira.AlkiraClient)
 
@@ -29,7 +31,7 @@ func resourceAlkiraListCommunity() *schema.Resource {
 			return nil
 		},
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 
 		Schema: map[string]*schema.Schema{
@@ -61,7 +63,7 @@ func resourceAlkiraListCommunity() *schema.Resource {
 	}
 }
 
-func resourceListCommunity(d *schema.ResourceData, m interface{}) error {
+func resourceListCommunity(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 
 	client := m.(*alkira.AlkiraClient)
 	api := alkira.NewListCommunity(m.(*alkira.AlkiraClient))
@@ -70,30 +72,38 @@ func resourceListCommunity(d *schema.ResourceData, m interface{}) error {
 	request := generateListCommunityRequest(d, m)
 
 	// Send request
-	response, provisionState, err := api.Create(request)
+	response, provState, err, provErr := api.Create(request)
 
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	// Set provision state
 	if client.Provision == true {
-		d.Set("provision_state", provisionState)
+		d.Set("provision_state", provState)
+
+		if provErr != nil {
+			return diag.Diagnostics{{
+				Severity: diag.Warning,
+				Summary:  "PROVISION FAILED",
+				Detail:   fmt.Sprintf("%s", provErr),
+			}}
+		}
 	}
 
 	d.SetId(string(response.Id))
-	return resourceListCommunityRead(d, m)
+	return resourceListCommunityRead(ctx, d, m)
 }
 
-func resourceListCommunityRead(d *schema.ResourceData, m interface{}) error {
+func resourceListCommunityRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 
 	client := m.(*alkira.AlkiraClient)
 	api := alkira.NewListCommunity(m.(*alkira.AlkiraClient))
 
-	list, err := api.GetById(d.Id())
+	list, provState, err := api.GetById(d.Id())
 
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	d.Set("name", list.Name)
@@ -101,16 +111,14 @@ func resourceListCommunityRead(d *schema.ResourceData, m interface{}) error {
 	d.Set("values", list.Values)
 
 	// Set provision state
-	_, provisionState, err := api.GetByName(d.Get("name").(string))
-
-	if client.Provision == true && provisionState != "" {
-		d.Set("provision_state", provisionState)
+	if client.Provision == true && provState != "" {
+		d.Set("provision_state", provState)
 	}
 
 	return nil
 }
 
-func resourceListCommunityUpdate(d *schema.ResourceData, m interface{}) error {
+func resourceListCommunityUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 
 	client := m.(*alkira.AlkiraClient)
 	api := alkira.NewListCommunity(m.(*alkira.AlkiraClient))
@@ -119,33 +127,41 @@ func resourceListCommunityUpdate(d *schema.ResourceData, m interface{}) error {
 	request := generateListCommunityRequest(d, m)
 
 	// Send update request
-	provisionState, err := api.Update(d.Id(), request)
+	provState, err, provErr := api.Update(d.Id(), request)
 
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	// Set provision state
 	if client.Provision == true {
-		d.Set("provision_state", provisionState)
+		d.Set("provision_state", provState)
+
+		if provErr != nil {
+			return diag.Diagnostics{{
+				Severity: diag.Warning,
+				Summary:  "PROVISION FAILED",
+				Detail:   fmt.Sprintf("%s", provErr),
+			}}
+		}
 	}
 
-	return resourceListCommunityRead(d, m)
+	return resourceListCommunityRead(ctx, d, m)
 }
 
-func resourceListCommunityDelete(d *schema.ResourceData, m interface{}) error {
+func resourceListCommunityDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 
 	client := m.(*alkira.AlkiraClient)
 	api := alkira.NewListCommunity(m.(*alkira.AlkiraClient))
 
-	provisionState, err := api.Delete(d.Id())
+	provState, err, provErr := api.Delete(d.Id())
 
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
-	if client.Provision == true && provisionState != "SUCCESS" {
-		return fmt.Errorf("failed to delete list_community %s, provision failed", d.Id())
+	if client.Provision == true && provState != "SUCCESS" {
+		return diag.FromErr(provErr)
 	}
 
 	d.SetId("")

--- a/alkira/resource_alkira_list_extended_community.go
+++ b/alkira/resource_alkira_list_extended_community.go
@@ -81,6 +81,8 @@ func resourceListExtendedCommunity(ctx context.Context, d *schema.ResourceData, 
 		return diag.FromErr(err)
 	}
 
+	d.SetId(string(response.Id))
+
 	// Set provision state
 	if client.Provision == true {
 		d.Set("provision_state", provState)
@@ -88,13 +90,12 @@ func resourceListExtendedCommunity(ctx context.Context, d *schema.ResourceData, 
 		if provErr != nil {
 			return diag.Diagnostics{{
 				Severity: diag.Warning,
-				Summary:  "PROVISION FAILED",
+				Summary:  "PROVISION (CREATE) FAILED",
 				Detail:   fmt.Sprintf("%s", provErr),
 			}}
 		}
 	}
 
-	d.SetId(string(response.Id))
 	return resourceListExtendedCommunityRead(ctx, d, m)
 }
 
@@ -143,7 +144,7 @@ func resourceListExtendedCommunityUpdate(ctx context.Context, d *schema.Resource
 		if provErr != nil {
 			return diag.Diagnostics{{
 				Severity: diag.Warning,
-				Summary:  "PROVISION FAILED",
+				Summary:  "PROVISION (UPDATE) FAILED",
 				Detail:   fmt.Sprintf("%s", provErr),
 			}}
 		}
@@ -163,11 +164,16 @@ func resourceListExtendedCommunityDelete(ctx context.Context, d *schema.Resource
 		return diag.FromErr(err)
 	}
 
+	d.SetId("")
+
 	if client.Provision == true && provState != "SUCCESS" {
-		return diag.FromErr(provErr)
+		return diag.Diagnostics{{
+			Severity: diag.Warning,
+			Summary:  "PROVISION (DELETE) FAILED",
+			Detail:   fmt.Sprintf("%s", provErr),
+		}}
 	}
 
-	d.SetId("")
 	return nil
 }
 

--- a/alkira/resource_alkira_list_global_cidr.go
+++ b/alkira/resource_alkira_list_global_cidr.go
@@ -95,7 +95,7 @@ func resourceListGlobalCidr(ctx context.Context, d *schema.ResourceData, m inter
 		if provErr != nil {
 			return diag.Diagnostics{{
 				Severity: diag.Warning,
-				Summary:  "PROVISION FAILED",
+				Summary:  "PROVISION (CREATE) FAILED",
 				Detail:   fmt.Sprintf("%s", provErr),
 			}}
 		}
@@ -151,7 +151,7 @@ func resourceListGlobalCidrUpdate(ctx context.Context, d *schema.ResourceData, m
 		if provErr != nil {
 			return diag.Diagnostics{{
 				Severity: diag.Warning,
-				Summary:  "PROVISION FAILED",
+				Summary:  "PROVISION (UPDATE) FAILED",
 				Detail:   fmt.Sprintf("%s", provErr),
 			}}
 		}
@@ -171,11 +171,16 @@ func resourceListGlobalCidrDelete(ctx context.Context, d *schema.ResourceData, m
 		return diag.FromErr(err)
 	}
 
+	d.SetId("")
+
 	if client.Provision == true && provState != "SUCCESS" {
-		return diag.FromErr(provErr)
+		return diag.Diagnostics{{
+			Severity: diag.Warning,
+			Summary:  "PROVISION (DELETE) FAILED",
+			Detail:   fmt.Sprintf("%s", provErr),
+		}}
 	}
 
-	d.SetId("")
 	return nil
 }
 

--- a/alkira/resource_alkira_policy.go
+++ b/alkira/resource_alkira_policy.go
@@ -102,7 +102,7 @@ func resourcePolicy(ctx context.Context, d *schema.ResourceData, m interface{}) 
 		if provErr != nil {
 			return diag.Diagnostics{{
 				Severity: diag.Warning,
-				Summary:  "PROVISION FAILED",
+				Summary:  "PROVISION (CREATE) FAILED",
 				Detail:   fmt.Sprintf("%s", provErr),
 			}}
 		}
@@ -161,7 +161,7 @@ func resourcePolicyUpdate(ctx context.Context, d *schema.ResourceData, m interfa
 		if provErr != nil {
 			return diag.Diagnostics{{
 				Severity: diag.Warning,
-				Summary:  "PROVISION FAILED",
+				Summary:  "PROVISION (UPDATE) FAILED",
 				Detail:   fmt.Sprintf("%s", provErr),
 			}}
 		}
@@ -181,11 +181,16 @@ func resourcePolicyDelete(ctx context.Context, d *schema.ResourceData, m interfa
 		return diag.FromErr(err)
 	}
 
+	d.SetId("")
+
 	if client.Provision == true && provState != "SUCCESS" {
-		return diag.FromErr(provErr)
+		return diag.Diagnostics{{
+			Severity: diag.Warning,
+			Summary:  "PROVISION (DELETE) FAILED",
+			Detail:   fmt.Sprintf("%s", provErr),
+		}}
 	}
 
-	d.SetId("")
 	return nil
 }
 

--- a/alkira/resource_alkira_policy.go
+++ b/alkira/resource_alkira_policy.go
@@ -5,16 +5,18 @@ import (
 	"fmt"
 
 	"github.com/alkiranet/alkira-client-go/alkira"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 func resourceAlkiraPolicy() *schema.Resource {
 	return &schema.Resource{
-		Description: "Manage policy.",
-		Create:      resourcePolicy,
-		Read:        resourcePolicyRead,
-		Update:      resourcePolicyUpdate,
-		Delete:      resourcePolicyDelete,
+		Description:   "Manage policy.",
+		CreateContext: resourcePolicy,
+		ReadContext:   resourcePolicyRead,
+		UpdateContext: resourcePolicyUpdate,
+		DeleteContext: resourcePolicyDelete,
 		CustomizeDiff: func(ctx context.Context, d *schema.ResourceDiff, m interface{}) error {
 			client := m.(*alkira.AlkiraClient)
 
@@ -27,7 +29,7 @@ func resourceAlkiraPolicy() *schema.Resource {
 			return nil
 		},
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 
 		Schema: map[string]*schema.Schema{
@@ -78,7 +80,7 @@ func resourceAlkiraPolicy() *schema.Resource {
 	}
 }
 
-func resourcePolicy(d *schema.ResourceData, m interface{}) error {
+func resourcePolicy(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 
 	client := m.(*alkira.AlkiraClient)
 	api := alkira.NewTrafficPolicy(m.(*alkira.AlkiraClient))
@@ -87,30 +89,38 @@ func resourcePolicy(d *schema.ResourceData, m interface{}) error {
 	request := generatePolicyRequest(d, m)
 
 	// Send request
-	response, provisionState, err := api.Create(request)
+	response, provState, err, provErr := api.Create(request)
 
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	// Set provision state
 	if client.Provision == true {
-		d.Set("provision_state", provisionState)
+		d.Set("provision_state", provState)
+
+		if provErr != nil {
+			return diag.Diagnostics{{
+				Severity: diag.Warning,
+				Summary:  "PROVISION FAILED",
+				Detail:   fmt.Sprintf("%s", provErr),
+			}}
+		}
 	}
 
 	d.SetId(string(response.Id))
-	return resourcePolicyRead(d, m)
+	return resourcePolicyRead(ctx, d, m)
 }
 
-func resourcePolicyRead(d *schema.ResourceData, m interface{}) error {
+func resourcePolicyRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 
 	client := m.(*alkira.AlkiraClient)
 	api := alkira.NewTrafficPolicy(m.(*alkira.AlkiraClient))
 
-	policy, err := api.GetById(d.Id())
+	policy, provState, err := api.GetById(d.Id())
 
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	d.Set("description", policy.Description)
@@ -122,16 +132,14 @@ func resourcePolicyRead(d *schema.ResourceData, m interface{}) error {
 	d.Set("to_groups", policy.ToGroups)
 
 	// Set provision state
-	_, provisionState, err := api.GetByName(d.Get("name").(string))
-
-	if client.Provision == true && provisionState != "" {
-		d.Set("provision_state", provisionState)
+	if client.Provision == true && provState != "" {
+		d.Set("provision_state", provState)
 	}
 
 	return nil
 }
 
-func resourcePolicyUpdate(d *schema.ResourceData, m interface{}) error {
+func resourcePolicyUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 
 	client := m.(*alkira.AlkiraClient)
 	api := alkira.NewTrafficPolicy(m.(*alkira.AlkiraClient))
@@ -140,33 +148,41 @@ func resourcePolicyUpdate(d *schema.ResourceData, m interface{}) error {
 	request := generatePolicyRequest(d, m)
 
 	// Send update request
-	provisionState, err := api.Update(d.Id(), request)
+	provState, err, provErr := api.Update(d.Id(), request)
 
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	// Set provision state
 	if client.Provision == true {
-		d.Set("provision_state", provisionState)
+		d.Set("provision_state", provState)
+
+		if provErr != nil {
+			return diag.Diagnostics{{
+				Severity: diag.Warning,
+				Summary:  "PROVISION FAILED",
+				Detail:   fmt.Sprintf("%s", provErr),
+			}}
+		}
 	}
 
-	return resourcePolicyRead(d, m)
+	return resourcePolicyRead(ctx, d, m)
 }
 
-func resourcePolicyDelete(d *schema.ResourceData, m interface{}) error {
+func resourcePolicyDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 
 	client := m.(*alkira.AlkiraClient)
 	api := alkira.NewTrafficPolicy(m.(*alkira.AlkiraClient))
 
-	provisionState, err := api.Delete(d.Id())
+	provState, err, provErr := api.Delete(d.Id())
 
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
-	if client.Provision == true && provisionState != "SUCCESS" {
-		return fmt.Errorf("failed to delete policy %s, provision failed", d.Id())
+	if client.Provision == true && provState != "SUCCESS" {
+		return diag.FromErr(provErr)
 	}
 
 	d.SetId("")

--- a/alkira/resource_alkira_policy_nat.go
+++ b/alkira/resource_alkira_policy_nat.go
@@ -1,20 +1,25 @@
 package alkira
 
 import (
+	"context"
+	"fmt"
+
 	"github.com/alkiranet/alkira-client-go/alkira"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
 
 func resourceAlkiraPolicyNat() *schema.Resource {
 	return &schema.Resource{
-		Description: "Manage NAT policy.",
-		Create:      resourcePolicyNat,
-		Read:        resourcePolicyNatRead,
-		Update:      resourcePolicyNatUpdate,
-		Delete:      resourcePolicyNatDelete,
+		Description:   "Manage NAT policy.",
+		CreateContext: resourcePolicyNat,
+		ReadContext:   resourcePolicyNatRead,
+		UpdateContext: resourcePolicyNatUpdate,
+		DeleteContext: resourcePolicyNatDelete,
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 
 		Schema: map[string]*schema.Schema{
@@ -73,36 +78,52 @@ func resourceAlkiraPolicyNat() *schema.Resource {
 	}
 }
 
-func resourcePolicyNat(d *schema.ResourceData, m interface{}) error {
+func resourcePolicyNat(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+
+	// Init
+	client := m.(*alkira.AlkiraClient)
 	api := alkira.NewNatPolicy(m.(*alkira.AlkiraClient))
 
 	// Construct request
 	request, err := generatePolicyNatRequest(d, m)
 
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	// Send request
-	resource, provisionState, err := api.Create(request)
+	resource, provState, err, provErr := api.Create(request)
 
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	d.SetId(string(resource.Id))
-	d.Set("provision_state", provisionState)
 
-	return resourcePolicyNatRead(d, m)
+	if client.Provision == true {
+		d.Set("provision_state", provState)
+
+		if provErr != nil {
+			return diag.Diagnostics{{
+				Severity: diag.Warning,
+				Summary:  "PROVISION FAILED",
+				Detail:   fmt.Sprintf("%s", provErr),
+			}}
+		}
+	}
+
+	return resourcePolicyNatRead(ctx, d, m)
 }
 
-func resourcePolicyNatRead(d *schema.ResourceData, m interface{}) error {
+func resourcePolicyNatRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+
+	client := m.(*alkira.AlkiraClient)
 	api := alkira.NewNatPolicy(m.(*alkira.AlkiraClient))
 
-	policy, err := api.GetById(d.Id())
+	policy, provState, err := api.GetById(d.Id())
 
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	d.Set("name", policy.Name)
@@ -117,46 +138,76 @@ func resourcePolicyNatRead(d *schema.ResourceData, m interface{}) error {
 	segmentId, err := getSegmentIdByName(policy.Segment, m)
 
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	d.Set("segment_id", segmentId)
 
+	// Set provision state
+	if client.Provision == true && provState != "" {
+		d.Set("provision_state", provState)
+	}
+
 	return nil
 }
 
-func resourcePolicyNatUpdate(d *schema.ResourceData, m interface{}) error {
+func resourcePolicyNatUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+
+	// Init
+	client := m.(*alkira.AlkiraClient)
 	api := alkira.NewNatPolicy(m.(*alkira.AlkiraClient))
 
 	// Construct request
 	request, err := generatePolicyNatRequest(d, m)
 
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	// Send update request
-	provisionState, err := api.Update(d.Id(), request)
+	provState, err, provErr := api.Update(d.Id(), request)
 
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
-	d.Set("provision_state", provisionState)
+	if client.Provision == true {
+		d.Set("provision_state", provState)
 
-	return resourcePolicyNatRead(d, m)
+		if provState == "FAILED" {
+			return diag.Diagnostics{{
+				Severity: diag.Warning,
+				Summary:  "PROVISION FAILED",
+				Detail:   fmt.Sprintf("%s", provErr),
+			}}
+		}
+	}
+
+	return resourcePolicyNatRead(ctx, d, m)
 }
 
-func resourcePolicyNatDelete(d *schema.ResourceData, m interface{}) error {
+func resourcePolicyNatDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+
+	client := m.(*alkira.AlkiraClient)
 	api := alkira.NewNatPolicy(m.(*alkira.AlkiraClient))
 
-	provisionState, err := api.Delete(d.Id())
+	provState, err, provErr := api.Delete(d.Id())
 
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
-	if provisionState != "SUCCESS" {
+	// Set provision state
+	if client.Provision == true {
+		d.Set("provision_state", provState)
+
+		if provErr != nil {
+			return diag.Diagnostics{{
+				Severity: diag.Warning,
+				Summary:  "PROVISION FAILED",
+				Detail:   fmt.Sprintf("%s", provErr),
+			}}
+		}
 	}
 
 	d.SetId("")

--- a/alkira/resource_alkira_policy_nat.go
+++ b/alkira/resource_alkira_policy_nat.go
@@ -80,7 +80,7 @@ func resourceAlkiraPolicyNat() *schema.Resource {
 
 func resourcePolicyNat(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 
-	// Init
+	// INIT
 	client := m.(*alkira.AlkiraClient)
 	api := alkira.NewNatPolicy(m.(*alkira.AlkiraClient))
 
@@ -106,7 +106,7 @@ func resourcePolicyNat(ctx context.Context, d *schema.ResourceData, m interface{
 		if provErr != nil {
 			return diag.Diagnostics{{
 				Severity: diag.Warning,
-				Summary:  "PROVISION FAILED",
+				Summary:  "PROVISION (CREATE) FAILED",
 				Detail:   fmt.Sprintf("%s", provErr),
 			}}
 		}
@@ -153,7 +153,7 @@ func resourcePolicyNatRead(ctx context.Context, d *schema.ResourceData, m interf
 
 func resourcePolicyNatUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 
-	// Init
+	// INIT
 	client := m.(*alkira.AlkiraClient)
 	api := alkira.NewNatPolicy(m.(*alkira.AlkiraClient))
 
@@ -177,7 +177,7 @@ func resourcePolicyNatUpdate(ctx context.Context, d *schema.ResourceData, m inte
 		if provState == "FAILED" {
 			return diag.Diagnostics{{
 				Severity: diag.Warning,
-				Summary:  "PROVISION FAILED",
+				Summary:  "PROVISION (UPDATE) FAILED",
 				Detail:   fmt.Sprintf("%s", provErr),
 			}}
 		}
@@ -197,6 +197,8 @@ func resourcePolicyNatDelete(ctx context.Context, d *schema.ResourceData, m inte
 		return diag.FromErr(err)
 	}
 
+	d.SetId("")
+
 	// Set provision state
 	if client.Provision == true {
 		d.Set("provision_state", provState)
@@ -204,13 +206,12 @@ func resourcePolicyNatDelete(ctx context.Context, d *schema.ResourceData, m inte
 		if provErr != nil {
 			return diag.Diagnostics{{
 				Severity: diag.Warning,
-				Summary:  "PROVISION FAILED",
+				Summary:  "PROVISION(DLETE) FAILED",
 				Detail:   fmt.Sprintf("%s", provErr),
 			}}
 		}
 	}
 
-	d.SetId("")
 	return nil
 }
 

--- a/alkira/resource_alkira_policy_nat_rule.go
+++ b/alkira/resource_alkira_policy_nat_rule.go
@@ -221,6 +221,8 @@ func resourcePolicyNatRule(ctx context.Context, d *schema.ResourceData, m interf
 		return diag.FromErr(err)
 	}
 
+	d.SetId(string(response.Id))
+
 	// Set provision state
 	if client.Provision == true {
 		d.Set("provision_state", provState)
@@ -228,13 +230,12 @@ func resourcePolicyNatRule(ctx context.Context, d *schema.ResourceData, m interf
 		if provErr != nil {
 			return diag.Diagnostics{{
 				Severity: diag.Warning,
-				Summary:  "PROVISION FAILED",
+				Summary:  "PROVISION (CREATE) FAILED",
 				Detail:   fmt.Sprintf("%s", provErr),
 			}}
 		}
 	}
 
-	d.SetId(string(response.Id))
 	return resourcePolicyNatRuleRead(ctx, d, m)
 }
 
@@ -288,7 +289,7 @@ func resourcePolicyNatRuleUpdate(ctx context.Context, d *schema.ResourceData, m 
 		if provErr != nil {
 			return diag.Diagnostics{{
 				Severity: diag.Warning,
-				Summary:  "PROVISION FAILED",
+				Summary:  "PROVISION (UPDATE) FAILED",
 				Detail:   fmt.Sprintf("%s", provErr),
 			}}
 		}
@@ -308,11 +309,16 @@ func resourcePolicyNatRuleDelete(ctx context.Context, d *schema.ResourceData, m 
 		return diag.FromErr(err)
 	}
 
+	d.SetId("")
+
 	if client.Provision == true && provState != "SUCCESS" {
-		return diag.FromErr(provErr)
+		return diag.Diagnostics{{
+			Severity: diag.Warning,
+			Summary:  "PROVISION (DELETE) FAILED",
+			Detail:   fmt.Sprintf("%s", provErr),
+		}}
 	}
 
-	d.SetId("")
 	return nil
 }
 

--- a/alkira/resource_alkira_policy_prefix_list.go
+++ b/alkira/resource_alkira_policy_prefix_list.go
@@ -111,7 +111,7 @@ func resourcePolicyPrefixList(ctx context.Context, d *schema.ResourceData, m int
 		if provErr != nil {
 			return diag.Diagnostics{{
 				Severity: diag.Warning,
-				Summary:  "PROVISION FAILED",
+				Summary:  "PROVISION (CREATE) FAILED",
 				Detail:   fmt.Sprintf("%s", provErr),
 			}}
 		}
@@ -170,7 +170,7 @@ func resourcePolicyPrefixListUpdate(ctx context.Context, d *schema.ResourceData,
 		if provErr != nil {
 			return diag.Diagnostics{{
 				Severity: diag.Warning,
-				Summary:  "PROVISION FAILED",
+				Summary:  "PROVISION (UPDATE) FAILED",
 				Detail:   fmt.Sprintf("%s", provErr),
 			}}
 		}
@@ -190,11 +190,16 @@ func resourcePolicyPrefixListDelete(ctx context.Context, d *schema.ResourceData,
 		return diag.FromErr(err)
 	}
 
+	d.SetId("")
+
 	if client.Provision == true && provState != "SUCCESS" {
-		return diag.FromErr(provErr)
+		return diag.Diagnostics{{
+			Severity: diag.Warning,
+			Summary:  "PROVISION (DELETE) FAILED",
+			Detail:   fmt.Sprintf("%s", provErr),
+		}}
 	}
 
-	d.SetId("")
 	return nil
 }
 

--- a/alkira/resource_alkira_policy_routing.go
+++ b/alkira/resource_alkira_policy_routing.go
@@ -253,7 +253,7 @@ func resourcePolicyRouting(ctx context.Context, d *schema.ResourceData, m interf
 		if provErr != nil {
 			return diag.Diagnostics{{
 				Severity: diag.Warning,
-				Summary:  "PROVISION FAILED",
+				Summary:  "PROVISION (CREATE) FAILED",
 				Detail:   fmt.Sprintf("%s", provErr),
 			}}
 		}
@@ -379,7 +379,7 @@ func resourcePolicyRoutingUpdate(ctx context.Context, d *schema.ResourceData, m 
 		if provErr != nil {
 			return diag.Diagnostics{{
 				Severity: diag.Warning,
-				Summary:  "PROVISION FAILED",
+				Summary:  "PROVISION (UPDATE) FAILED",
 				Detail:   fmt.Sprintf("%s", provErr),
 			}}
 		}
@@ -400,7 +400,11 @@ func resourcePolicyRoutingDelete(ctx context.Context, d *schema.ResourceData, m 
 	}
 
 	if client.Provision == true && provState != "SUCCESS" {
-		return diag.FromErr(provErr)
+		return diag.Diagnostics{{
+			Severity: diag.Warning,
+			Summary:  "PROVISION (DELETE) FAILED",
+			Detail:   fmt.Sprintf("%s", provErr),
+		}}
 	}
 
 	d.SetId("")

--- a/alkira/resource_alkira_policy_routing.go
+++ b/alkira/resource_alkira_policy_routing.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 
 	"github.com/alkiranet/alkira-client-go/alkira"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
@@ -14,10 +16,10 @@ func resourceAlkiraPolicyRouting() *schema.Resource {
 		Description: "Manage Routing Policy.\n\n" +
 			"Configure a routing policy between the Alkira " +
 			"CSX and a selected scope with custom rules",
-		Create: resourcePolicyRouting,
-		Read:   resourcePolicyRoutingRead,
-		Update: resourcePolicyRoutingUpdate,
-		Delete: resourcePolicyRoutingDelete,
+		CreateContext: resourcePolicyRouting,
+		ReadContext:   resourcePolicyRoutingRead,
+		UpdateContext: resourcePolicyRoutingUpdate,
+		DeleteContext: resourcePolicyRoutingDelete,
 		CustomizeDiff: func(ctx context.Context, d *schema.ResourceDiff, m interface{}) error {
 			client := m.(*alkira.AlkiraClient)
 
@@ -30,7 +32,7 @@ func resourceAlkiraPolicyRouting() *schema.Resource {
 			return nil
 		},
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 
 		Schema: map[string]*schema.Schema{
@@ -225,7 +227,7 @@ func resourceAlkiraPolicyRouting() *schema.Resource {
 	}
 }
 
-func resourcePolicyRouting(d *schema.ResourceData, m interface{}) error {
+func resourcePolicyRouting(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 
 	client := m.(*alkira.AlkiraClient)
 	api := alkira.NewRoutePolicy(m.(*alkira.AlkiraClient))
@@ -234,34 +236,42 @@ func resourcePolicyRouting(d *schema.ResourceData, m interface{}) error {
 	request, err := generatePolicyRoutingRequest(d, m)
 
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	// Send create request
-	response, provisionState, err := api.Create(request)
+	response, provState, err, provErr := api.Create(request)
 
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	// Set provision state
 	if client.Provision == true {
-		d.Set("provision_state", provisionState)
+		d.Set("provision_state", provState)
+
+		if provErr != nil {
+			return diag.Diagnostics{{
+				Severity: diag.Warning,
+				Summary:  "PROVISION FAILED",
+				Detail:   fmt.Sprintf("%s", provErr),
+			}}
+		}
 	}
 
 	d.SetId(string(response.Id))
-	return resourcePolicyRoutingRead(d, m)
+	return resourcePolicyRoutingRead(ctx, d, m)
 }
 
-func resourcePolicyRoutingRead(d *schema.ResourceData, m interface{}) error {
+func resourcePolicyRoutingRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 
 	client := m.(*alkira.AlkiraClient)
 	api := alkira.NewRoutePolicy(m.(*alkira.AlkiraClient))
 
-	policy, err := api.GetById(d.Id())
+	policy, provState, err := api.GetById(d.Id())
 
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	if policy.AdvertiseInternetExit != nil {
@@ -283,7 +293,7 @@ func resourcePolicyRoutingRead(d *schema.ResourceData, m interface{}) error {
 	segmentId, err := getSegmentIdByName(policy.Segment, m)
 
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 	d.Set("segment_id", segmentId)
 
@@ -336,16 +346,14 @@ func resourcePolicyRoutingRead(d *schema.ResourceData, m interface{}) error {
 	d.Set("rule", rules)
 
 	// Set provision state
-	_, provisionState, err := api.GetByName(d.Get("name").(string))
-
-	if client.Provision == true && provisionState != "" {
-		d.Set("provision_state", provisionState)
+	if client.Provision == true && provState != "" {
+		d.Set("provision_state", provState)
 	}
 
 	return nil
 }
 
-func resourcePolicyRoutingUpdate(d *schema.ResourceData, m interface{}) error {
+func resourcePolicyRoutingUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 
 	client := m.(*alkira.AlkiraClient)
 	api := alkira.NewRoutePolicy(m.(*alkira.AlkiraClient))
@@ -354,37 +362,45 @@ func resourcePolicyRoutingUpdate(d *schema.ResourceData, m interface{}) error {
 	request, err := generatePolicyRoutingRequest(d, m)
 
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	// Send update request
-	provisionState, err := api.Update(d.Id(), request)
+	provState, err, provErr := api.Update(d.Id(), request)
 
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	// Set provision state
 	if client.Provision == true {
-		d.Set("provision_state", provisionState)
+		d.Set("provision_state", provState)
+
+		if provErr != nil {
+			return diag.Diagnostics{{
+				Severity: diag.Warning,
+				Summary:  "PROVISION FAILED",
+				Detail:   fmt.Sprintf("%s", provErr),
+			}}
+		}
 	}
 
-	return resourcePolicyRoutingRead(d, m)
+	return resourcePolicyRoutingRead(ctx, d, m)
 }
 
-func resourcePolicyRoutingDelete(d *schema.ResourceData, m interface{}) error {
+func resourcePolicyRoutingDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 
 	client := m.(*alkira.AlkiraClient)
 	api := alkira.NewRoutePolicy(m.(*alkira.AlkiraClient))
 
-	provisionState, err := api.Delete(d.Id())
+	provState, err, provErr := api.Delete(d.Id())
 
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
-	if client.Provision == true && provisionState != "SUCCESS" {
-		return fmt.Errorf("failed to delete policy_routing %s, provision failed", d.Id())
+	if client.Provision == true && provState != "SUCCESS" {
+		return diag.FromErr(provErr)
 	}
 
 	d.SetId("")

--- a/alkira/resource_alkira_policy_rule.go
+++ b/alkira/resource_alkira_policy_rule.go
@@ -172,7 +172,7 @@ func resourcePolicyRule(ctx context.Context, d *schema.ResourceData, m interface
 		if provErr != nil {
 			return diag.Diagnostics{{
 				Severity: diag.Warning,
-				Summary:  "PROVISION FAILED",
+				Summary:  "PROVISION (CREATE) FAILED",
 				Detail:   fmt.Sprintf("%s", provErr),
 			}}
 		}
@@ -246,7 +246,7 @@ func resourcePolicyRuleUpdate(ctx context.Context, d *schema.ResourceData, m int
 		if provErr != nil {
 			return diag.Diagnostics{{
 				Severity: diag.Warning,
-				Summary:  "PROVISION FAILED",
+				Summary:  "PROVISION (UPDATE) FAILED",
 				Detail:   fmt.Sprintf("%s", provErr),
 			}}
 		}
@@ -266,11 +266,16 @@ func resourcePolicyRuleDelete(ctx context.Context, d *schema.ResourceData, m int
 		return diag.FromErr(err)
 	}
 
+	d.SetId("")
+
 	if client.Provision == true && provState != "SUCCESS" {
-		return diag.FromErr(provErr)
+		return diag.Diagnostics{{
+			Severity: diag.Warning,
+			Summary:  "PROVISION (DELETE) FAILED",
+			Detail:   fmt.Sprintf("%s", provErr),
+		}}
 	}
 
-	d.SetId("")
 	return nil
 }
 

--- a/alkira/resource_alkira_policy_rule.go
+++ b/alkira/resource_alkira_policy_rule.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 
 	"github.com/alkiranet/alkira-client-go/alkira"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
@@ -15,10 +17,10 @@ func resourceAlkiraPolicyRule() *schema.Resource {
 			"This resource is usually used along with policy resources:" +
 			"`policy_prefix_list`, `policy_rule_list` and `policy`" +
 			"control the network traffic.",
-		Create: resourcePolicyRule,
-		Read:   resourcePolicyRuleRead,
-		Update: resourcePolicyRuleUpdate,
-		Delete: resourcePolicyRuleDelete,
+		CreateContext: resourcePolicyRule,
+		ReadContext:   resourcePolicyRuleRead,
+		UpdateContext: resourcePolicyRuleUpdate,
+		DeleteContext: resourcePolicyRuleDelete,
 		CustomizeDiff: func(ctx context.Context, d *schema.ResourceDiff, m interface{}) error {
 			client := m.(*alkira.AlkiraClient)
 
@@ -31,7 +33,7 @@ func resourceAlkiraPolicyRule() *schema.Resource {
 			return nil
 		},
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 
 		Schema: map[string]*schema.Schema{
@@ -146,7 +148,7 @@ func resourceAlkiraPolicyRule() *schema.Resource {
 	}
 }
 
-func resourcePolicyRule(d *schema.ResourceData, m interface{}) error {
+func resourcePolicyRule(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 
 	client := m.(*alkira.AlkiraClient)
 	api := alkira.NewTrafficPolicyRule(m.(*alkira.AlkiraClient))
@@ -155,30 +157,39 @@ func resourcePolicyRule(d *schema.ResourceData, m interface{}) error {
 	request := generatePolicyRuleRequest(d, m)
 
 	// Send create request
-	response, provisionState, err := api.Create(request)
+	response, provState, err, provErr := api.Create(request)
 
 	if err != nil {
-		return err
-	}
-
-	// Set provision state
-	if client.Provision == true {
-		d.Set("provision_state", provisionState)
+		return diag.FromErr(err)
 	}
 
 	d.SetId(string(response.Id))
-	return resourcePolicyRuleRead(d, m)
+
+	// Set provision state
+	if client.Provision == true {
+		d.Set("provision_state", provState)
+
+		if provErr != nil {
+			return diag.Diagnostics{{
+				Severity: diag.Warning,
+				Summary:  "PROVISION FAILED",
+				Detail:   fmt.Sprintf("%s", provErr),
+			}}
+		}
+	}
+
+	return resourcePolicyRuleRead(ctx, d, m)
 }
 
-func resourcePolicyRuleRead(d *schema.ResourceData, m interface{}) error {
+func resourcePolicyRuleRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 
 	client := m.(*alkira.AlkiraClient)
 	api := alkira.NewTrafficPolicyRule(m.(*alkira.AlkiraClient))
 
-	rule, err := api.GetById(d.Id())
+	rule, provState, err := api.GetById(d.Id())
 
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	d.Set("name", rule.Name)
@@ -206,16 +217,14 @@ func resourcePolicyRuleRead(d *schema.ResourceData, m interface{}) error {
 	d.Set("rule_action_service_ids", rule.RuleAction.ServiceList)
 
 	// Set provision state
-	_, provisionState, err := api.GetByName(d.Get("name").(string))
-
-	if client.Provision == true && provisionState != "" {
-		d.Set("provision_state", provisionState)
+	if client.Provision == true && provState != "" {
+		d.Set("provision_state", provState)
 	}
 
 	return nil
 }
 
-func resourcePolicyRuleUpdate(d *schema.ResourceData, m interface{}) error {
+func resourcePolicyRuleUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 
 	client := m.(*alkira.AlkiraClient)
 	api := alkira.NewTrafficPolicyRule(m.(*alkira.AlkiraClient))
@@ -224,33 +233,41 @@ func resourcePolicyRuleUpdate(d *schema.ResourceData, m interface{}) error {
 	request := generatePolicyRuleRequest(d, m)
 
 	// Send update request
-	provisionState, err := api.Update(d.Id(), request)
+	provState, err, provErr := api.Update(d.Id(), request)
 
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	// Set provision state
 	if client.Provision == true {
-		d.Set("provision_state", provisionState)
+		d.Set("provision_state", provState)
+
+		if provErr != nil {
+			return diag.Diagnostics{{
+				Severity: diag.Warning,
+				Summary:  "PROVISION FAILED",
+				Detail:   fmt.Sprintf("%s", provErr),
+			}}
+		}
 	}
 
-	return resourcePolicyRuleRead(d, m)
+	return resourcePolicyRuleRead(ctx, d, m)
 }
 
-func resourcePolicyRuleDelete(d *schema.ResourceData, m interface{}) error {
+func resourcePolicyRuleDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 
 	client := m.(*alkira.AlkiraClient)
 	api := alkira.NewTrafficPolicyRule(m.(*alkira.AlkiraClient))
 
-	provisionState, err := api.Delete(d.Id())
+	provState, err, provErr := api.Delete(d.Id())
 
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
-	if client.Provision == true && provisionState != "SUCCESS" {
-		return fmt.Errorf("failed to delete policy_rule %s, provision failed", d.Id())
+	if client.Provision == true && provState != "SUCCESS" {
+		return diag.FromErr(provErr)
 	}
 
 	d.SetId("")

--- a/alkira/resource_alkira_policy_rule_list.go
+++ b/alkira/resource_alkira_policy_rule_list.go
@@ -95,7 +95,7 @@ func resourcePolicyRuleList(ctx context.Context, d *schema.ResourceData, m inter
 		if provErr != nil {
 			return diag.Diagnostics{{
 				Severity: diag.Warning,
-				Summary:  "PROVISION FAILED",
+				Summary:  "PROVISION (CREATE) FAILED",
 				Detail:   fmt.Sprintf("%s", provErr),
 			}}
 		}
@@ -153,7 +153,7 @@ func resourcePolicyRuleListUpdate(ctx context.Context, d *schema.ResourceData, m
 		if provErr != nil {
 			return diag.Diagnostics{{
 				Severity: diag.Warning,
-				Summary:  "PROVISION FAILED",
+				Summary:  "PROVISION (UPDATE) FAILED",
 				Detail:   fmt.Sprintf("%s", provErr),
 			}}
 		}
@@ -174,7 +174,11 @@ func resourcePolicyRuleListDelete(ctx context.Context, d *schema.ResourceData, m
 	}
 
 	if client.Provision == true && provState != "SUCCESS" {
-		return diag.FromErr(provErr)
+		return diag.Diagnostics{{
+			Severity: diag.Warning,
+			Summary:  "PROVISION (DELETE) FAILED",
+			Detail:   fmt.Sprintf("%s", provErr),
+		}}
 	}
 
 	d.SetId("")

--- a/alkira/resource_alkira_policy_rule_list.go
+++ b/alkira/resource_alkira_policy_rule_list.go
@@ -5,15 +5,17 @@ import (
 	"fmt"
 
 	"github.com/alkiranet/alkira-client-go/alkira"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 func resourceAlkiraPolicyRuleList() *schema.Resource {
 	return &schema.Resource{
-		Create: resourcePolicyRuleList,
-		Read:   resourcePolicyRuleListRead,
-		Update: resourcePolicyRuleListUpdate,
-		Delete: resourcePolicyRuleListDelete,
+		CreateContext: resourcePolicyRuleList,
+		ReadContext:   resourcePolicyRuleListRead,
+		UpdateContext: resourcePolicyRuleListUpdate,
+		DeleteContext: resourcePolicyRuleListDelete,
 		CustomizeDiff: func(ctx context.Context, d *schema.ResourceDiff, m interface{}) error {
 			client := m.(*alkira.AlkiraClient)
 
@@ -26,7 +28,7 @@ func resourceAlkiraPolicyRuleList() *schema.Resource {
 			return nil
 		},
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 
 		Schema: map[string]*schema.Schema{
@@ -65,7 +67,7 @@ func resourceAlkiraPolicyRuleList() *schema.Resource {
 	}
 }
 
-func resourcePolicyRuleList(d *schema.ResourceData, m interface{}) error {
+func resourcePolicyRuleList(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 
 	client := m.(*alkira.AlkiraClient)
 	api := alkira.NewPolicyRuleList(m.(*alkira.AlkiraClient))
@@ -74,34 +76,43 @@ func resourcePolicyRuleList(d *schema.ResourceData, m interface{}) error {
 	request, err := generatePolicyRuleListRequest(d, m)
 
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	// Send create request
-	response, provisionState, err := api.Create(request)
+	response, provState, err, provErr := api.Create(request)
 
 	if err != nil {
-		return err
-	}
-
-	// Set provision state
-	if client.Provision == true {
-		d.Set("provision_state", provisionState)
+		return diag.FromErr(err)
 	}
 
 	d.SetId(string(response.Id))
-	return resourcePolicyRuleListRead(d, m)
+
+	// Set provision state
+	if client.Provision == true {
+		d.Set("provision_state", provState)
+
+		if provErr != nil {
+			return diag.Diagnostics{{
+				Severity: diag.Warning,
+				Summary:  "PROVISION FAILED",
+				Detail:   fmt.Sprintf("%s", provErr),
+			}}
+		}
+	}
+
+	return resourcePolicyRuleListRead(ctx, d, m)
 }
 
-func resourcePolicyRuleListRead(d *schema.ResourceData, m interface{}) error {
+func resourcePolicyRuleListRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 
 	client := m.(*alkira.AlkiraClient)
 	api := alkira.NewPolicyRuleList(m.(*alkira.AlkiraClient))
 
-	ruleList, err := api.GetById(d.Id())
+	ruleList, provState, err := api.GetById(d.Id())
 
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	d.Set("name", ruleList.Name)
@@ -109,16 +120,14 @@ func resourcePolicyRuleListRead(d *schema.ResourceData, m interface{}) error {
 	d.Set("rules", ruleList.Rules)
 
 	// Set provision state
-	_, provisionState, err := api.GetByName(d.Get("name").(string))
-
-	if client.Provision == true && provisionState != "" {
-		d.Set("provision_state", provisionState)
+	if client.Provision == true && provState != "" {
+		d.Set("provision_state", provState)
 	}
 
 	return nil
 }
 
-func resourcePolicyRuleListUpdate(d *schema.ResourceData, m interface{}) error {
+func resourcePolicyRuleListUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 
 	client := m.(*alkira.AlkiraClient)
 	api := alkira.NewPolicyRuleList(m.(*alkira.AlkiraClient))
@@ -127,37 +136,45 @@ func resourcePolicyRuleListUpdate(d *schema.ResourceData, m interface{}) error {
 	request, err := generatePolicyRuleListRequest(d, m)
 
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	// Send update request
-	provisionState, err := api.Update(d.Id(), request)
+	provState, err, provErr := api.Update(d.Id(), request)
 
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	// Set provision state
 	if client.Provision == true {
-		d.Set("provision_state", provisionState)
+		d.Set("provision_state", provState)
+
+		if provErr != nil {
+			return diag.Diagnostics{{
+				Severity: diag.Warning,
+				Summary:  "PROVISION FAILED",
+				Detail:   fmt.Sprintf("%s", provErr),
+			}}
+		}
 	}
 
-	return resourcePolicyRuleListRead(d, m)
+	return resourcePolicyRuleListRead(ctx, d, m)
 }
 
-func resourcePolicyRuleListDelete(d *schema.ResourceData, m interface{}) error {
+func resourcePolicyRuleListDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 
 	client := m.(*alkira.AlkiraClient)
 	api := alkira.NewPolicyRuleList(m.(*alkira.AlkiraClient))
 
-	provisionState, err := api.Delete(d.Id())
+	provState, err, provErr := api.Delete(d.Id())
 
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
-	if client.Provision == true && provisionState != "SUCCESS" {
-		return fmt.Errorf("failed to delete policy_rule_list %s, provision failed", d.Id())
+	if client.Provision == true && provState != "SUCCESS" {
+		return diag.FromErr(provErr)
 	}
 
 	d.SetId("")

--- a/alkira/resource_alkira_segment.go
+++ b/alkira/resource_alkira_segment.go
@@ -5,16 +5,17 @@ import (
 	"fmt"
 
 	"github.com/alkiranet/alkira-client-go/alkira"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 func resourceAlkiraSegment() *schema.Resource {
 	return &schema.Resource{
-		Description: "Provides segment resource.",
-		Create:      resourceSegment,
-		Read:        resourceSegmentRead,
-		Update:      resourceSegmentUpdate,
-		Delete:      resourceSegmentDelete,
+		Description:   "Provides segment resource.",
+		CreateContext: resourceSegment,
+		ReadContext:   resourceSegmentRead,
+		UpdateContext: resourceSegmentUpdate,
+		DeleteContext: resourceSegmentDelete,
 		CustomizeDiff: func(ctx context.Context, d *schema.ResourceDiff, m interface{}) error {
 			client := m.(*alkira.AlkiraClient)
 
@@ -27,7 +28,7 @@ func resourceAlkiraSegment() *schema.Resource {
 			return nil
 		},
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 		Schema: map[string]*schema.Schema{
 			"name": {
@@ -95,7 +96,7 @@ func resourceAlkiraSegment() *schema.Resource {
 	}
 }
 
-func resourceSegment(d *schema.ResourceData, m interface{}) error {
+func resourceSegment(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 
 	client := m.(*alkira.AlkiraClient)
 	api := alkira.NewSegment(client)
@@ -104,35 +105,45 @@ func resourceSegment(d *schema.ResourceData, m interface{}) error {
 	segment, err := generateSegmentRequest(d)
 
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	// Send create request
-	response, provisionState, err := api.Create(segment)
+	response, provState, err, provErr := api.Create(segment)
 
 	if err != nil {
-		return err
-	}
-
-	// Set provision state
-	if client.Provision == true {
-		d.Set("provision_state", provisionState)
+		return diag.FromErr(err)
 	}
 
 	d.SetId(string(response.Id))
-	return resourceSegmentRead(d, m)
+
+	// Set provision state
+	if client.Provision == true {
+		d.Set("provision_state", provState)
+
+		if provState == "FAILED" {
+			return diag.Diagnostics{{
+				Severity: diag.Warning,
+				Summary:  "PROVISION FAILED",
+				Detail:   fmt.Sprintf("%s", provErr),
+			}}
+		}
+	}
+
+	return resourceSegmentRead(ctx, d, m)
 }
 
-func resourceSegmentRead(d *schema.ResourceData, m interface{}) error {
+func resourceSegmentRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 
+	// Init
 	client := m.(*alkira.AlkiraClient)
 	api := alkira.NewSegment(client)
 
 	// Get the resource
-	segment, err := api.GetById(d.Id())
+	segment, provState, err := api.GetById(d.Id())
 
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	d.Set("asn", segment.Asn)
@@ -150,16 +161,14 @@ func resourceSegmentRead(d *schema.ResourceData, m interface{}) error {
 	setCidrsSegmentRead(d, segment)
 
 	// Set provision state
-	_, provisionState, err := api.GetByName(d.Get("name").(string))
-
-	if client.Provision == true && provisionState != "" {
-		d.Set("provision_state", provisionState)
+	if client.Provision == true && provState != "" {
+		d.Set("provision_state", provState)
 	}
 
 	return nil
 }
 
-func resourceSegmentUpdate(d *schema.ResourceData, m interface{}) error {
+func resourceSegmentUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 
 	client := m.(*alkira.AlkiraClient)
 	api := alkira.NewSegment(client)
@@ -168,37 +177,45 @@ func resourceSegmentUpdate(d *schema.ResourceData, m interface{}) error {
 	segment, err := generateSegmentRequest(d)
 
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	// Send update request
-	provisionState, err := api.Update(d.Id(), segment)
+	provState, err, provErr := api.Update(d.Id(), segment)
 
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	// Set provision state
 	if client.Provision == true {
-		d.Set("provision_state", provisionState)
+		d.Set("provision_state", provState)
+
+		if provErr != nil {
+			return diag.Diagnostics{{
+				Severity: diag.Warning,
+				Summary:  "PROVISION FAILED",
+				Detail:   fmt.Sprintf("%s", provErr),
+			}}
+		}
 	}
 
-	return resourceSegmentRead(d, m)
+	return resourceSegmentRead(ctx, d, m)
 }
 
-func resourceSegmentDelete(d *schema.ResourceData, m interface{}) error {
+func resourceSegmentDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 
 	client := m.(*alkira.AlkiraClient)
 	api := alkira.NewSegment(client)
 
-	provisionState, err := api.Delete(d.Id())
+	provState, err, provErr := api.Delete(d.Id())
 
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
-	if client.Provision == true && provisionState != "SUCCESS" {
-		return fmt.Errorf("failed to delete segment %s, provision failed", d.Id())
+	if client.Provision == true && provState != "SUCCESS" {
+		return diag.FromErr(provErr)
 	}
 
 	d.SetId("")

--- a/alkira/resource_alkira_segment_helper.go
+++ b/alkira/resource_alkira_segment_helper.go
@@ -11,7 +11,7 @@ import (
 func getSegmentNameById(id string, m interface{}) (string, error) {
 
 	segmentApi := alkira.NewSegment(m.(*alkira.AlkiraClient))
-	segment, err := segmentApi.GetById(id)
+	segment, _, err := segmentApi.GetById(id)
 
 	if err != nil {
 		return "", err

--- a/alkira/resource_alkira_segment_resource.go
+++ b/alkira/resource_alkira_segment_resource.go
@@ -5,16 +5,18 @@ import (
 	"fmt"
 
 	"github.com/alkiranet/alkira-client-go/alkira"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 func resourceAlkiraSegmentResource() *schema.Resource {
 	return &schema.Resource{
-		Description: "Manage segment resource.",
-		Create:      resourceSegmentResource,
-		Read:        resourceSegmentResourceRead,
-		Update:      resourceSegmentResourceUpdate,
-		Delete:      resourceSegmentResourceDelete,
+		Description:   "Manage segment resource.",
+		CreateContext: resourceSegmentResource,
+		ReadContext:   resourceSegmentResourceRead,
+		UpdateContext: resourceSegmentResourceUpdate,
+		DeleteContext: resourceSegmentResourceDelete,
 		CustomizeDiff: func(ctx context.Context, d *schema.ResourceDiff, m interface{}) error {
 			client := m.(*alkira.AlkiraClient)
 
@@ -27,7 +29,7 @@ func resourceAlkiraSegmentResource() *schema.Resource {
 			return nil
 		},
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 
 		Schema: map[string]*schema.Schema{
@@ -73,8 +75,9 @@ func resourceAlkiraSegmentResource() *schema.Resource {
 	}
 }
 
-func resourceSegmentResource(d *schema.ResourceData, m interface{}) error {
+func resourceSegmentResource(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 
+	// Init
 	client := m.(*alkira.AlkiraClient)
 	api := alkira.NewSegmentResource(m.(*alkira.AlkiraClient))
 
@@ -82,35 +85,44 @@ func resourceSegmentResource(d *schema.ResourceData, m interface{}) error {
 	request, err := generateSegmentResourceRequest(d, m)
 
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	// Send create request
-	response, provisionState, err := api.Create(request)
+	response, provState, err, provErr := api.Create(request)
 
 	if err != nil {
-		return err
-	}
-
-	// Set provision state
-	if client.Provision == true {
-		d.Set("provision_state", provisionState)
+		return diag.FromErr(err)
 	}
 
 	d.SetId(string(response.Id))
-	return resourceSegmentResourceRead(d, m)
+
+	// Set provision state
+	if client.Provision == true {
+		d.Set("provision_state", provState)
+
+		if provErr != nil {
+			return diag.Diagnostics{{
+				Severity: diag.Warning,
+				Summary:  "PROVISION FAILED",
+				Detail:   fmt.Sprintf("%s", provErr),
+			}}
+		}
+	}
+
+	return resourceSegmentResourceRead(ctx, d, m)
 }
 
-func resourceSegmentResourceRead(d *schema.ResourceData, m interface{}) error {
+func resourceSegmentResourceRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 
 	client := m.(*alkira.AlkiraClient)
 	api := alkira.NewSegmentResource(m.(*alkira.AlkiraClient))
 
 	// Get resource
-	resource, err := api.GetById(d.Id())
+	resource, provState, err := api.GetById(d.Id())
 
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	d.Set("name", resource.Name)
@@ -122,7 +134,7 @@ func resourceSegmentResourceRead(d *schema.ResourceData, m interface{}) error {
 	segmentId, err := getSegmentIdByName(resource.Segment, m)
 
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	d.Set("segment_id", segmentId)
@@ -143,16 +155,14 @@ func resourceSegmentResourceRead(d *schema.ResourceData, m interface{}) error {
 	d.Set("group_prefix", prefixes)
 
 	// Set provision state
-	_, provisionState, err := api.GetByName(d.Get("name").(string))
-
-	if client.Provision == true && provisionState != "" {
-		d.Set("provision_state", provisionState)
+	if client.Provision == true && provState != "" {
+		d.Set("provision_state", provState)
 	}
 
 	return nil
 }
 
-func resourceSegmentResourceUpdate(d *schema.ResourceData, m interface{}) error {
+func resourceSegmentResourceUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 
 	client := m.(*alkira.AlkiraClient)
 	api := alkira.NewSegmentResource(m.(*alkira.AlkiraClient))
@@ -161,37 +171,45 @@ func resourceSegmentResourceUpdate(d *schema.ResourceData, m interface{}) error 
 	request, err := generateSegmentResourceRequest(d, m)
 
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	// Send update request
-	provisionState, err := api.Update(d.Id(), request)
+	provState, err, provErr := api.Update(d.Id(), request)
 
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	// Set provision state
 	if client.Provision == true {
-		d.Set("provision_state", provisionState)
+		d.Set("provision_state", provState)
+
+		if provErr != nil {
+			return diag.Diagnostics{{
+				Severity: diag.Warning,
+				Summary:  "PROVISION FAILED",
+				Detail:   fmt.Sprintf("%s", provErr),
+			}}
+		}
 	}
 
 	return nil
 }
 
-func resourceSegmentResourceDelete(d *schema.ResourceData, m interface{}) error {
+func resourceSegmentResourceDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 
 	client := m.(*alkira.AlkiraClient)
 	api := alkira.NewSegmentResource(m.(*alkira.AlkiraClient))
 
-	provisionState, err := api.Delete(d.Id())
+	provState, err, provErr := api.Delete(d.Id())
 
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
-	if client.Provision == true && provisionState != "SUCCESS" {
-		return fmt.Errorf("failed to delete segment_resource %s, provision failed", d.Id())
+	if client.Provision == true && provState != "SUCCESS" {
+		return diag.FromErr(provErr)
 	}
 
 	d.SetId("")

--- a/alkira/resource_alkira_segment_resource.go
+++ b/alkira/resource_alkira_segment_resource.go
@@ -77,7 +77,7 @@ func resourceAlkiraSegmentResource() *schema.Resource {
 
 func resourceSegmentResource(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 
-	// Init
+	// INIT
 	client := m.(*alkira.AlkiraClient)
 	api := alkira.NewSegmentResource(m.(*alkira.AlkiraClient))
 
@@ -104,7 +104,7 @@ func resourceSegmentResource(ctx context.Context, d *schema.ResourceData, m inte
 		if provErr != nil {
 			return diag.Diagnostics{{
 				Severity: diag.Warning,
-				Summary:  "PROVISION FAILED",
+				Summary:  "PROVISION (CREATE) FAILED",
 				Detail:   fmt.Sprintf("%s", provErr),
 			}}
 		}
@@ -188,7 +188,7 @@ func resourceSegmentResourceUpdate(ctx context.Context, d *schema.ResourceData, 
 		if provErr != nil {
 			return diag.Diagnostics{{
 				Severity: diag.Warning,
-				Summary:  "PROVISION FAILED",
+				Summary:  "PROVISION (UPDATE) FAILED",
 				Detail:   fmt.Sprintf("%s", provErr),
 			}}
 		}
@@ -208,11 +208,16 @@ func resourceSegmentResourceDelete(ctx context.Context, d *schema.ResourceData, 
 		return diag.FromErr(err)
 	}
 
+	d.SetId("")
+
 	if client.Provision == true && provState != "SUCCESS" {
-		return diag.FromErr(provErr)
+		return diag.Diagnostics{{
+			Severity: diag.Warning,
+			Summary:  "PROVISION (DELETE) FAILED",
+			Detail:   fmt.Sprintf("%s", provErr),
+		}}
 	}
 
-	d.SetId("")
 	return nil
 }
 

--- a/alkira/resource_alkira_segment_resource_share.go
+++ b/alkira/resource_alkira_segment_resource_share.go
@@ -126,7 +126,7 @@ func resourceSegmentResourceShare(ctx context.Context, d *schema.ResourceData, m
 		if provErr != nil {
 			return diag.Diagnostics{{
 				Severity: diag.Warning,
-				Summary:  "PROVISION FAILED",
+				Summary:  "PROVISION (CREATE) FAILED",
 				Detail:   fmt.Sprintf("%s", provErr),
 			}}
 		}
@@ -189,7 +189,7 @@ func resourceSegmentResourceShareUpdate(ctx context.Context, d *schema.ResourceD
 		if provErr != nil {
 			return diag.Diagnostics{{
 				Severity: diag.Warning,
-				Summary:  "PROVISION FAILED",
+				Summary:  "PROVISION (UPDATE) FAILED",
 				Detail:   fmt.Sprintf("%s", provErr),
 			}}
 		}
@@ -209,11 +209,16 @@ func resourceSegmentResourceShareDelete(ctx context.Context, d *schema.ResourceD
 		return diag.FromErr(err)
 	}
 
+	d.SetId("")
+
 	if client.Provision == true && provState != "SUCCESS" {
-		return diag.FromErr(provErr)
+		return diag.Diagnostics{{
+			Severity: diag.Warning,
+			Summary:  "PROVISION (DELETE) FAILED",
+			Detail:   fmt.Sprintf("%s", provErr),
+		}}
 	}
 
-	d.SetId("")
 	return nil
 }
 

--- a/alkira/resource_alkira_segment_resource_share.go
+++ b/alkira/resource_alkira_segment_resource_share.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 
 	"github.com/alkiranet/alkira-client-go/alkira"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
@@ -14,10 +16,10 @@ func resourceAlkiraSegmentResourceShare() *schema.Resource {
 		Description: "Manages segment resource share.\n\n" +
 			"Select resources to share between Resource End-A " +
 			"in a segment and Resource End-B in another segment.",
-		Create: resourceSegmentResourceShare,
-		Read:   resourceSegmentResourceShareRead,
-		Update: resourceSegmentResourceShareUpdate,
-		Delete: resourceSegmentResourceShareDelete,
+		CreateContext: resourceSegmentResourceShare,
+		ReadContext:   resourceSegmentResourceShareRead,
+		UpdateContext: resourceSegmentResourceShareUpdate,
+		DeleteContext: resourceSegmentResourceShareDelete,
 		CustomizeDiff: func(ctx context.Context, d *schema.ResourceDiff, m interface{}) error {
 			client := m.(*alkira.AlkiraClient)
 
@@ -30,7 +32,7 @@ func resourceAlkiraSegmentResourceShare() *schema.Resource {
 			return nil
 		},
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 
 		Schema: map[string]*schema.Schema{
@@ -96,7 +98,7 @@ func resourceAlkiraSegmentResourceShare() *schema.Resource {
 	}
 }
 
-func resourceSegmentResourceShare(d *schema.ResourceData, m interface{}) error {
+func resourceSegmentResourceShare(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 
 	client := m.(*alkira.AlkiraClient)
 	api := alkira.NewSegmentResourceShare(m.(*alkira.AlkiraClient))
@@ -105,34 +107,43 @@ func resourceSegmentResourceShare(d *schema.ResourceData, m interface{}) error {
 	request, err := generateSegmentResourceShareRequest(d, m)
 
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	// Send create request
-	response, provisionState, err := api.Create(request)
+	response, provState, err, provErr := api.Create(request)
 
 	if err != nil {
-		return err
-	}
-
-	// Set provision state
-	if client.Provision == true {
-		d.Set("provision_state", provisionState)
+		return diag.FromErr(err)
 	}
 
 	d.SetId(string(response.Id))
-	return resourceSegmentResourceShareRead(d, m)
+
+	// Set provision state
+	if client.Provision == true {
+		d.Set("provision_state", provState)
+
+		if provErr != nil {
+			return diag.Diagnostics{{
+				Severity: diag.Warning,
+				Summary:  "PROVISION FAILED",
+				Detail:   fmt.Sprintf("%s", provErr),
+			}}
+		}
+	}
+
+	return resourceSegmentResourceShareRead(ctx, d, m)
 }
 
-func resourceSegmentResourceShareRead(d *schema.ResourceData, m interface{}) error {
+func resourceSegmentResourceShareRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 
 	client := m.(*alkira.AlkiraClient)
 	api := alkira.NewSegmentResourceShare(m.(*alkira.AlkiraClient))
 
-	share, err := api.GetById(d.Id())
+	share, provState, err := api.GetById(d.Id())
 
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	d.Set("name", share.Name)
@@ -145,16 +156,14 @@ func resourceSegmentResourceShareRead(d *schema.ResourceData, m interface{}) err
 	d.Set("traffic_direction", share.Direction)
 
 	// Set provision state
-	_, provisionState, err := api.GetByName(d.Get("name").(string))
-
-	if client.Provision == true && provisionState != "" {
-		d.Set("provision_state", provisionState)
+	if client.Provision == true && provState != "" {
+		d.Set("provision_state", provState)
 	}
 
 	return nil
 }
 
-func resourceSegmentResourceShareUpdate(d *schema.ResourceData, m interface{}) error {
+func resourceSegmentResourceShareUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 
 	client := m.(*alkira.AlkiraClient)
 	api := alkira.NewSegmentResourceShare(m.(*alkira.AlkiraClient))
@@ -163,37 +172,45 @@ func resourceSegmentResourceShareUpdate(d *schema.ResourceData, m interface{}) e
 	request, err := generateSegmentResourceShareRequest(d, m)
 
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	// Send update request
-	provisionState, err := api.Update(d.Id(), request)
+	provState, err, provErr := api.Update(d.Id(), request)
 
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	// Set provision state
 	if client.Provision == true {
-		d.Set("provision_state", provisionState)
+		d.Set("provision_state", provState)
+
+		if provErr != nil {
+			return diag.Diagnostics{{
+				Severity: diag.Warning,
+				Summary:  "PROVISION FAILED",
+				Detail:   fmt.Sprintf("%s", provErr),
+			}}
+		}
 	}
 
-	return resourceSegmentResourceShareRead(d, m)
+	return resourceSegmentResourceShareRead(ctx, d, m)
 }
 
-func resourceSegmentResourceShareDelete(d *schema.ResourceData, m interface{}) error {
+func resourceSegmentResourceShareDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 
 	client := m.(*alkira.AlkiraClient)
 	api := alkira.NewSegmentResourceShare(m.(*alkira.AlkiraClient))
 
-	provisionState, err := api.Delete(d.Id())
+	provState, err, provErr := api.Delete(d.Id())
 
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
-	if client.Provision == true && provisionState != "SUCCESS" {
-		return fmt.Errorf("failed to delete segment_resource_share %s, provision failed", d.Id())
+	if client.Provision == true && provState != "SUCCESS" {
+		return diag.FromErr(provErr)
 	}
 
 	d.SetId("")

--- a/alkira/resource_alkira_service_checkpoint.go
+++ b/alkira/resource_alkira_service_checkpoint.go
@@ -298,7 +298,7 @@ func resourceCheckpoint(ctx context.Context, d *schema.ResourceData, m interface
 		if provErr != nil {
 			return diag.Diagnostics{{
 				Severity: diag.Warning,
-				Summary:  "PROVISION FAILED",
+				Summary:  "PROVISION (CREATE) FAILED",
 				Detail:   fmt.Sprintf("%s", provErr),
 			}}
 		}
@@ -379,7 +379,7 @@ func resourceCheckpointUpdate(ctx context.Context, d *schema.ResourceData, m int
 		if provErr != nil {
 			return diag.Diagnostics{{
 				Severity: diag.Warning,
-				Summary:  "PROVISION FAILED",
+				Summary:  "PROVISION (UPDATE) FAILED",
 				Detail:   fmt.Sprintf("%s", provErr),
 			}}
 		}
@@ -399,11 +399,16 @@ func resourceCheckpointDelete(ctx context.Context, d *schema.ResourceData, m int
 		return diag.FromErr(err)
 	}
 
+	d.SetId("")
+
 	if client.Provision == true && provState != "SUCCESS" {
-		return diag.FromErr(provErr)
+		return diag.Diagnostics{{
+			Severity: diag.Warning,
+			Summary:  "PROVISION (DELETE) FAILED",
+			Detail:   fmt.Sprintf("%s", provErr),
+		}}
 	}
 
-	d.SetId("")
 	return nil
 }
 

--- a/alkira/resource_alkira_service_checkpoint.go
+++ b/alkira/resource_alkira_service_checkpoint.go
@@ -6,17 +6,19 @@ import (
 	"log"
 
 	"github.com/alkiranet/alkira-client-go/alkira"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
 
 func resourceAlkiraCheckpoint() *schema.Resource {
 	return &schema.Resource{
-		Description: "Manage checkpoint services",
-		Create:      resourceCheckpoint,
-		Read:        resourceCheckpointRead,
-		Update:      resourceCheckpointUpdate,
-		Delete:      resourceCheckpointDelete,
+		Description:   "Manage checkpoint services",
+		CreateContext: resourceCheckpoint,
+		ReadContext:   resourceCheckpointRead,
+		UpdateContext: resourceCheckpointUpdate,
+		DeleteContext: resourceCheckpointDelete,
 		CustomizeDiff: func(ctx context.Context, d *schema.ResourceDiff, m interface{}) error {
 			client := m.(*alkira.AlkiraClient)
 
@@ -29,7 +31,7 @@ func resourceAlkiraCheckpoint() *schema.Resource {
 			return nil
 		},
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 
 		Schema: map[string]*schema.Schema{
@@ -268,7 +270,7 @@ func resourceAlkiraCheckpoint() *schema.Resource {
 	}
 }
 
-func resourceCheckpoint(d *schema.ResourceData, m interface{}) error {
+func resourceCheckpoint(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 
 	client := m.(*alkira.AlkiraClient)
 	api := alkira.NewServiceCheckpoint(m.(*alkira.AlkiraClient))
@@ -277,47 +279,57 @@ func resourceCheckpoint(d *schema.ResourceData, m interface{}) error {
 	request, err := generateCheckpointRequest(d, m)
 
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	// Send create request
-	response, provisionState, err := api.Create(request)
+	response, provState, err, provErr := api.Create(request)
 
 	if err != nil {
-		return err
-	}
-
-	// Set provision state
-	if client.Provision == true {
-		d.Set("provision_state", provisionState)
+		return diag.FromErr(err)
 	}
 
 	d.SetId(string(response.Id))
-	return resourceCheckpointRead(d, m)
+
+	// Set provision state
+	if client.Provision == true {
+		d.Set("provision_state", provState)
+
+		if provErr != nil {
+			return diag.Diagnostics{{
+				Severity: diag.Warning,
+				Summary:  "PROVISION FAILED",
+				Detail:   fmt.Sprintf("%s", provErr),
+			}}
+		}
+	}
+
+	return resourceCheckpointRead(ctx, d, m)
 }
 
-func resourceCheckpointRead(d *schema.ResourceData, m interface{}) error {
+func resourceCheckpointRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 
 	client := m.(*alkira.AlkiraClient)
 	api := alkira.NewServiceCheckpoint(m.(*alkira.AlkiraClient))
 
-	checkpoint, err := api.GetById(d.Id())
+	checkpoint, provState, err := api.GetById(d.Id())
 
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	// Get segment
 	numOfSegments := len(checkpoint.Segments)
+
 	if numOfSegments == 1 {
 		segmentId, err := getSegmentIdByName(checkpoint.Segments[0], m)
 
 		if err != nil {
-			return err
+			return diag.FromErr(err)
 		}
 		d.Set("segment_id", segmentId)
 	} else {
-		return fmt.Errorf("the number of segments are invalid %n", numOfSegments)
+		return diag.FromErr(fmt.Errorf("the number of segments are invalid %n", numOfSegments))
 	}
 
 	d.Set("auto_scale", checkpoint.AutoScale)
@@ -338,16 +350,14 @@ func resourceCheckpointRead(d *schema.ResourceData, m interface{}) error {
 	d.Set("version", checkpoint.Version)
 
 	// Set provision state
-	_, provisionState, err := api.GetByName(d.Get("name").(string))
-
-	if client.Provision == true && provisionState != "" {
-		d.Set("provision_state", provisionState)
+	if client.Provision == true && provState != "" {
+		d.Set("provision_state", provState)
 	}
 
 	return nil
 }
 
-func resourceCheckpointUpdate(d *schema.ResourceData, m interface{}) error {
+func resourceCheckpointUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 
 	client := m.(*alkira.AlkiraClient)
 	api := alkira.NewServiceCheckpoint(m.(*alkira.AlkiraClient))
@@ -356,33 +366,41 @@ func resourceCheckpointUpdate(d *schema.ResourceData, m interface{}) error {
 	request, err := generateCheckpointRequest(d, m)
 
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	// Send update request
-	provisionState, err := api.Update(d.Id(), request)
+	provState, err, provErr := api.Update(d.Id(), request)
 
 	// Set provision state
 	if client.Provision == true {
-		d.Set("provision_state", provisionState)
+		d.Set("provision_state", provState)
+
+		if provErr != nil {
+			return diag.Diagnostics{{
+				Severity: diag.Warning,
+				Summary:  "PROVISION FAILED",
+				Detail:   fmt.Sprintf("%s", provErr),
+			}}
+		}
 	}
 
-	return err
+	return diag.FromErr(err)
 }
 
-func resourceCheckpointDelete(d *schema.ResourceData, m interface{}) error {
+func resourceCheckpointDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 
 	client := m.(*alkira.AlkiraClient)
 	api := alkira.NewServiceCheckpoint(m.(*alkira.AlkiraClient))
 
-	provisionState, err := api.Delete(d.Id())
+	provState, err, provErr := api.Delete(d.Id())
 
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
-	if client.Provision == true && provisionState != "SUCCESS" {
-		return fmt.Errorf("failed to delete service_checkpoint %s, provision failed", d.Id())
+	if client.Provision == true && provState != "SUCCESS" {
+		return diag.FromErr(provErr)
 	}
 
 	d.SetId("")

--- a/alkira/resource_alkira_service_cisco_ftdv.go
+++ b/alkira/resource_alkira_service_cisco_ftdv.go
@@ -255,7 +255,7 @@ func resourceServiceCiscoFTDvCreate(ctx context.Context, d *schema.ResourceData,
 		if provState == "FAILED" {
 			return diag.Diagnostics{{
 				Severity: diag.Warning,
-				Summary:  "PROVISION FAILED",
+				Summary:  "PROVISION (CREATE) FAILED",
 				Detail:   fmt.Sprintf("%s", provErr),
 			}}
 		}
@@ -325,7 +325,7 @@ func resourceServiceCiscoFTDvUpdate(ctx context.Context, d *schema.ResourceData,
 		if provState == "FAILED" {
 			return diag.Diagnostics{{
 				Severity: diag.Warning,
-				Summary:  "PROVISION FAILED",
+				Summary:  "PROVISION (UPDATE) FAILED",
 				Detail:   fmt.Sprintf("%s", provErr),
 			}}
 		}
@@ -346,11 +346,16 @@ func resourceServiceCiscoFTDvDelete(ctx context.Context, d *schema.ResourceData,
 		return diag.FromErr(err)
 	}
 
+	d.SetId("")
+
 	if client.Provision == true && provState != "SUCCESS" {
-		return diag.FromErr(provErr)
+		return diag.Diagnostics{{
+			Severity: diag.Warning,
+			Summary:  "PROVISION (DELETE) FAILED",
+			Detail:   fmt.Sprintf("%s", provErr),
+		}}
 	}
 
-	d.SetId("")
 	return nil
 }
 

--- a/alkira/resource_alkira_service_cisco_ftdv.go
+++ b/alkira/resource_alkira_service_cisco_ftdv.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 
 	"github.com/alkiranet/alkira-client-go/alkira"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
@@ -13,10 +15,10 @@ func resourceAlkiraServiceCiscoFTDv() *schema.Resource {
 	return &schema.Resource{
 		Description: "Manage Cisco FTDv Service. (**BETA**)",
 
-		Create: resourceServiceCiscoFTDvCreate,
-		Read:   resourceServiceCiscoFTDvRead,
-		Update: resourceServiceCiscoFTDvUpdate,
-		Delete: resourceServiceCiscoFTDvDelete,
+		CreateContext: resourceServiceCiscoFTDvCreate,
+		ReadContext:   resourceServiceCiscoFTDvRead,
+		UpdateContext: resourceServiceCiscoFTDvUpdate,
+		DeleteContext: resourceServiceCiscoFTDvDelete,
 		CustomizeDiff: func(ctx context.Context, d *schema.ResourceDiff, m interface{}) error {
 			client := m.(*alkira.AlkiraClient)
 
@@ -30,7 +32,7 @@ func resourceAlkiraServiceCiscoFTDv() *schema.Resource {
 		},
 
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 		Schema: map[string]*schema.Schema{
 			"name": {
@@ -225,7 +227,7 @@ func resourceAlkiraServiceCiscoFTDv() *schema.Resource {
 }
 
 // resourceServiceCiscoFTDvCreate create a Cisco FTDv service
-func resourceServiceCiscoFTDvCreate(d *schema.ResourceData, m interface{}) error {
+func resourceServiceCiscoFTDvCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 
 	client := m.(*alkira.AlkiraClient)
 	api := alkira.NewServiceCiscoFTDv(m.(*alkira.AlkiraClient))
@@ -234,35 +236,44 @@ func resourceServiceCiscoFTDvCreate(d *schema.ResourceData, m interface{}) error
 	request, err := generateServiceCiscoFTDvRequest(d, m)
 
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	// Send create request
-	response, provisionState, err := api.Create(request)
+	response, provState, err, provErr := api.Create(request)
 
 	if err != nil {
-		return err
-	}
-
-	// Set provision state
-	if client.Provision == true {
-		d.Set("provision_state", provisionState)
+		return diag.FromErr(err)
 	}
 
 	d.SetId(string(response.Id))
-	return resourceServiceCiscoFTDvRead(d, m)
+
+	// Set provision state
+	if client.Provision == true {
+		d.Set("provision_state", provState)
+
+		if provState == "FAILED" {
+			return diag.Diagnostics{{
+				Severity: diag.Warning,
+				Summary:  "PROVISION FAILED",
+				Detail:   fmt.Sprintf("%s", provErr),
+			}}
+		}
+	}
+
+	return resourceServiceCiscoFTDvRead(ctx, d, m)
 }
 
 // resourceServiceCiscoFTDvRead get and save a Cisco FTDv services
-func resourceServiceCiscoFTDvRead(d *schema.ResourceData, m interface{}) error {
+func resourceServiceCiscoFTDvRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 
 	client := m.(*alkira.AlkiraClient)
 	api := alkira.NewServiceCiscoFTDv(m.(*alkira.AlkiraClient))
 
-	service, err := api.GetById(d.Id())
+	service, provState, err := api.GetById(d.Id())
 
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	d.Set("auto_scale", service.AutoScale)
@@ -280,17 +291,15 @@ func resourceServiceCiscoFTDvRead(d *schema.ResourceData, m interface{}) error {
 	d.Set("tunnel_protocol", service.TunnelProtocol)
 
 	// Set provision state
-	_, provisionState, err := api.GetByName(d.Get("name").(string))
-
-	if client.Provision == true && provisionState != "" {
-		d.Set("provision_state", provisionState)
+	if client.Provision == true && provState != "" {
+		d.Set("provision_state", provState)
 	}
 
 	return nil
 }
 
 // resourceServiceCiscoFTDvUpdate update a Cisco FTDv service
-func resourceServiceCiscoFTDvUpdate(d *schema.ResourceData, m interface{}) error {
+func resourceServiceCiscoFTDvUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 
 	client := m.(*alkira.AlkiraClient)
 	api := alkira.NewServiceCiscoFTDv(m.(*alkira.AlkiraClient))
@@ -299,38 +308,46 @@ func resourceServiceCiscoFTDvUpdate(d *schema.ResourceData, m interface{}) error
 	request, err := generateServiceCiscoFTDvRequest(d, m)
 
 	if err != nil {
-		return fmt.Errorf("UpdateServiceCiscoFTDv: failed to marshal: %v", err)
+		return diag.FromErr(fmt.Errorf("UpdateServiceCiscoFTDv: failed to marshal: %v", err))
 	}
 
 	// Send update request
-	provisionState, err := api.Update(d.Id(), request)
+	provState, err, provErr := api.Update(d.Id(), request)
 
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	// Set provision state
 	if client.Provision == true {
-		d.Set("provision_state", provisionState)
+		d.Set("provision_state", provState)
+
+		if provState == "FAILED" {
+			return diag.Diagnostics{{
+				Severity: diag.Warning,
+				Summary:  "PROVISION FAILED",
+				Detail:   fmt.Sprintf("%s", provErr),
+			}}
+		}
 	}
 
-	return resourceServiceCiscoFTDvRead(d, m)
+	return resourceServiceCiscoFTDvRead(ctx, d, m)
 }
 
 // resourceServiceCiscoFTDvDelete delete
-func resourceServiceCiscoFTDvDelete(d *schema.ResourceData, m interface{}) error {
+func resourceServiceCiscoFTDvDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 
 	client := m.(*alkira.AlkiraClient)
 	api := alkira.NewServiceCiscoFTDv(m.(*alkira.AlkiraClient))
 
-	provisionState, err := api.Delete((d.Id()))
+	provState, err, provErr := api.Delete((d.Id()))
 
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
-	if client.Provision == true && provisionState != "SUCCESS" {
-		return fmt.Errorf("failed to delete service_cisco_ftdv %s, provision failed", d.Id())
+	if client.Provision == true && provState != "SUCCESS" {
+		return diag.FromErr(provErr)
 	}
 
 	d.SetId("")

--- a/alkira/resource_alkira_service_fortinet.go
+++ b/alkira/resource_alkira_service_fortinet.go
@@ -252,7 +252,7 @@ func resourceFortinetCreate(ctx context.Context, d *schema.ResourceData, m inter
 		if provState == "FAILED" {
 			return diag.Diagnostics{{
 				Severity: diag.Warning,
-				Summary:  "PROVISION FAILED",
+				Summary:  "PROVISION (CREATE) FAILED",
 				Detail:   fmt.Sprintf("%s", provErr),
 			}}
 		}
@@ -336,7 +336,7 @@ func resourceFortinetUpdate(ctx context.Context, d *schema.ResourceData, m inter
 		if provState == "FAILED" {
 			return diag.Diagnostics{{
 				Severity: diag.Warning,
-				Summary:  "PROVISION FAILED",
+				Summary:  "PROVISION (UPDATE) FAILED",
 				Detail:   fmt.Sprintf("%s", provErr),
 			}}
 		}
@@ -356,17 +356,22 @@ func resourceFortinetDelete(ctx context.Context, d *schema.ResourceData, m inter
 		return diag.FromErr(err)
 	}
 
+	d.SetId("")
+
 	if client.Provision == true && provState != "SUCCESS" {
-		return diag.FromErr(provErr)
+		return diag.Diagnostics{{
+			Severity: diag.Warning,
+			Summary:  "PROVISION (DELETE) FAILED",
+			Detail:   fmt.Sprintf("%s", provErr),
+		}}
 	}
 
-	d.SetId("")
 	return nil
 }
 
 func generateFortinetRequest(d *schema.ResourceData, m interface{}) (*alkira.ServiceFortinet, error) {
-	client := m.(*alkira.AlkiraClient)
 
+	client := m.(*alkira.AlkiraClient)
 	fortinetCredId := d.Get("credential_id").(string)
 
 	if 0 == len(fortinetCredId) {

--- a/alkira/resource_alkira_service_infoblox.go
+++ b/alkira/resource_alkira_service_infoblox.go
@@ -262,7 +262,7 @@ func resourceInfoblox(ctx context.Context, d *schema.ResourceData, m interface{}
 		if provState == "FAILED" {
 			return diag.Diagnostics{{
 				Severity: diag.Warning,
-				Summary:  "PROVISION FAILED",
+				Summary:  "PROVISION (CREATE) FAILED",
 				Detail:   fmt.Sprintf("%s", provErr),
 			}}
 		}
@@ -294,7 +294,7 @@ func resourceInfobloxRead(ctx context.Context, d *schema.ResourceData, m interfa
 
 func resourceInfobloxUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 
-	// Init
+	// INIT
 	client := m.(*alkira.AlkiraClient)
 	api := alkira.NewServiceInfoblox(m.(*alkira.AlkiraClient))
 
@@ -319,7 +319,7 @@ func resourceInfobloxUpdate(ctx context.Context, d *schema.ResourceData, m inter
 		if provState == "FAILED" {
 			return diag.Diagnostics{{
 				Severity: diag.Warning,
-				Summary:  "PROVISION FAILED",
+				Summary:  "PROVISION (UPDATE) FAILED",
 				Detail:   fmt.Sprintf("%s", provErr),
 			}}
 		}
@@ -339,11 +339,16 @@ func resourceInfobloxDelete(ctx context.Context, d *schema.ResourceData, m inter
 		return diag.FromErr(err)
 	}
 
+	d.SetId("")
+
 	if client.Provision == true && provState != "SUCCESS" {
-		return diag.FromErr(provErr)
+		return diag.Diagnostics{{
+			Severity: diag.Warning,
+			Summary:  "PROVISION (DELETE) FAILED",
+			Detail:   fmt.Sprintf("%s", provErr),
+		}}
 	}
 
-	d.SetId("")
 	return nil
 }
 

--- a/alkira/resource_alkira_service_pan.go
+++ b/alkira/resource_alkira_service_pan.go
@@ -369,7 +369,7 @@ func resourceAlkiraServicePan() *schema.Resource {
 
 func resourceServicePanCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 
-	// Init
+	// INIT
 	client := m.(*alkira.AlkiraClient)
 	api := alkira.NewServicePan(client)
 
@@ -395,7 +395,7 @@ func resourceServicePanCreate(ctx context.Context, d *schema.ResourceData, m int
 		if provState == "FAILED" {
 			return diag.Diagnostics{{
 				Severity: diag.Warning,
-				Summary:  "PROVISION FAILED",
+				Summary:  "PROVISION (CREATE) FAILED",
 				Detail:   fmt.Sprintf("%s", provErr),
 			}}
 		}
@@ -406,7 +406,7 @@ func resourceServicePanCreate(ctx context.Context, d *schema.ResourceData, m int
 
 func resourceServicePanRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 
-	// Init
+	// INIT
 	client := m.(*alkira.AlkiraClient)
 	api := alkira.NewServicePan(client)
 
@@ -455,7 +455,7 @@ func resourceServicePanRead(ctx context.Context, d *schema.ResourceData, m inter
 
 func resourceServicePanUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 
-	// Init
+	// INIT
 	client := m.(*alkira.AlkiraClient)
 	api := alkira.NewServicePan(client)
 
@@ -480,7 +480,7 @@ func resourceServicePanUpdate(ctx context.Context, d *schema.ResourceData, m int
 		if provState == "FAILED" {
 			return diag.Diagnostics{{
 				Severity: diag.Warning,
-				Summary:  "PROVISION FAILED",
+				Summary:  "PROVISION (UPDATE) FAILED",
 				Detail:   fmt.Sprintf("%s", provErr),
 			}}
 		}
@@ -491,23 +491,28 @@ func resourceServicePanUpdate(ctx context.Context, d *schema.ResourceData, m int
 
 func resourceServicePanDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 
-	// Init
+	// INIT
 	client := m.(*alkira.AlkiraClient)
 	api := alkira.NewServicePan(client)
 
-	// Delete resource
+	// DELETE
 	provState, err, provErr := api.Delete(d.Id())
 
 	if err != nil {
 		return diag.FromErr(err)
 	}
 
+	d.SetId("")
+
 	// Check provision state
 	if client.Provision == true && provState != "SUCCESS" {
-		return diag.FromErr(provErr)
+		return diag.Diagnostics{{
+			Severity: diag.Warning,
+			Summary:  "PROVISION (DELETE) FAILED",
+			Detail:   fmt.Sprintf("%s", provErr),
+		}}
 	}
 
-	d.SetId("")
 	return nil
 }
 

--- a/alkira/resource_alkira_service_zscaler.go
+++ b/alkira/resource_alkira_service_zscaler.go
@@ -229,7 +229,7 @@ func resourceZscaler(ctx context.Context, d *schema.ResourceData, m interface{})
 		if provState == "FAILED" {
 			return diag.Diagnostics{{
 				Severity: diag.Warning,
-				Summary:  "PROVISION FAILED",
+				Summary:  "PROVISION (CREATE) FAILED",
 				Detail:   fmt.Sprintf("%s", provErr),
 			}}
 		}
@@ -302,7 +302,7 @@ func resourceZscalerUpdate(ctx context.Context, d *schema.ResourceData, m interf
 		if provState == "FAILED" {
 			return diag.Diagnostics{{
 				Severity: diag.Warning,
-				Summary:  "PROVISION FAILED",
+				Summary:  "PROVISION (UPDATE) FAILED",
 				Detail:   fmt.Sprintf("%s", provErr),
 			}}
 		}
@@ -322,11 +322,16 @@ func resourceZscalerDelete(ctx context.Context, d *schema.ResourceData, m interf
 		return diag.FromErr(err)
 	}
 
+	d.SetId("")
+
 	if client.Provision == true && provState != "SUCCESS" {
-		return diag.FromErr(provErr)
+		return diag.Diagnostics{{
+			Severity: diag.Warning,
+			Summary:  "PROVISION (DELETE) FAILED",
+			Detail:   fmt.Sprintf("%s", provErr),
+		}}
 	}
 
-	d.SetId("")
 	return nil
 }
 

--- a/alkira/resource_alkira_tenant_network.go
+++ b/alkira/resource_alkira_tenant_network.go
@@ -1,19 +1,22 @@
 package alkira
 
 import (
+	"context"
 	"log"
 
 	"github.com/alkiranet/alkira-client-go/alkira"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 func resourceAlkiraTenantNetwork() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceTenantNetworkCreate,
-		Read:   resourceTenantNetworkRead,
-		Update: resourceTenantNetworkUpdate,
-		Delete: resourceTenantNetworkDelete,
+		CreateContext: resourceTenantNetworkCreate,
+		ReadContext:   resourceTenantNetworkRead,
+		UpdateContext: resourceTenantNetworkUpdate,
+		DeleteContext: resourceTenantNetworkDelete,
 
 		Schema: map[string]*schema.Schema{
 			"connectors": &schema.Schema{
@@ -35,14 +38,14 @@ func resourceAlkiraTenantNetwork() *schema.Resource {
 	}
 }
 
-func resourceTenantNetworkCreate(d *schema.ResourceData, m interface{}) error {
+func resourceTenantNetworkCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*alkira.AlkiraClient)
 
 	state, err := client.ProvisionTenantNetwork()
 
 	if err != nil {
 		log.Printf("[ERROR] Failed to provision tenant network: %s", state)
-		return err
+		return diag.FromErr(err)
 	}
 
 	// Wait for tenant network provisoning to finish
@@ -70,25 +73,25 @@ func resourceTenantNetworkCreate(d *schema.ResourceData, m interface{}) error {
 	}
 
 	d.SetId(client.TenantNetworkId)
-	return resourceTenantNetworkRead(d, m)
+	return resourceTenantNetworkRead(ctx, d, m)
 }
 
-func resourceTenantNetworkRead(d *schema.ResourceData, m interface{}) error {
+func resourceTenantNetworkRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	return nil
 }
 
-func resourceTenantNetworkUpdate(d *schema.ResourceData, m interface{}) error {
-	return resourceTenantNetworkRead(d, m)
+func resourceTenantNetworkUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	return resourceTenantNetworkRead(ctx, d, m)
 }
 
-func resourceTenantNetworkDelete(d *schema.ResourceData, m interface{}) error {
+func resourceTenantNetworkDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*alkira.AlkiraClient)
 
 	state, err := client.ProvisionTenantNetwork()
 
 	if err != nil {
 		log.Printf("[ERROR] Failed to deprovision tenant network: %s", state)
-		return err
+		return diag.FromErr(err)
 	}
 
 	stateConf := &resource.StateChangeConf{
@@ -111,7 +114,7 @@ func resourceTenantNetworkDelete(d *schema.ResourceData, m interface{}) error {
 	_, err = stateConf.WaitForState()
 
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	log.Printf("[INFO] Tenant Network %s deprovisioned", client.TenantNetworkId)

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.18
 replace github.com/hashicorp/go-getter => github.com/hashicorp/go-getter v1.6.1
 
 require (
-	github.com/alkiranet/alkira-client-go v1.37.7
+	github.com/alkiranet/alkira-client-go v1.37.8
 	github.com/hashicorp/terraform-plugin-sdk v1.15.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.1.0
 	github.com/stretchr/testify v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -43,8 +43,8 @@ github.com/agext/levenshtein v1.2.2/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki
 github.com/agl/ed25519 v0.0.0-20170116200512-5312a6153412/go.mod h1:WPjqKcmVOxf0XSf3YxCJs6N6AOSrOx3obionmG7T0y0=
 github.com/alcortesm/tgz v0.0.0-20161220082320-9c5fe88206d7 h1:uSoVVbwJiQipAclBbw+8quDsfcvFjOpI5iCf4p/cqCs=
 github.com/alcortesm/tgz v0.0.0-20161220082320-9c5fe88206d7/go.mod h1:6zEj6s6u/ghQa61ZWa/C2Aw3RkjiTBOix7dkqa1VLIs=
-github.com/alkiranet/alkira-client-go v1.37.7 h1:u7USUH+mg7d7U8S/rxa+K29vlfF6PibRfgpagsVP9KI=
-github.com/alkiranet/alkira-client-go v1.37.7/go.mod h1:wZZ6wETqhS7ED5JfTosY3fzXhslH0avHOiWr1I+wm8k=
+github.com/alkiranet/alkira-client-go v1.37.8 h1:XYUHt+iiT+QTwIgeyQDFY0S11zDtx/ZNwo8oXQJUD74=
+github.com/alkiranet/alkira-client-go v1.37.8/go.mod h1:wZZ6wETqhS7ED5JfTosY3fzXhslH0avHOiWr1I+wm8k=
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239 h1:kFOfPq6dUM1hTo4JG6LR5AXSUEsOjtdm0kw0FtQtMJA=
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239/go.mod h1:2FmKhYUyUczH0OGQWaF5ceTx0UBShxjsH6f8oGKYe2c=
 github.com/apparentlymart/go-cidr v1.0.1 h1:NmIwLZ/KdsjIUlhf+/Np40atNXm/+lZ5txfTJ/SpF+U=

--- a/vendor/github.com/alkiranet/alkira-client-go/alkira/api.go
+++ b/vendor/github.com/alkiranet/alkira-client-go/alkira/api.go
@@ -87,7 +87,7 @@ func (a *AlkiraAPI[T]) GetById(id string) (*T, string, error) {
 	err = json.Unmarshal([]byte(data), &result)
 
 	if err != nil {
-		return nil, provState, fmt.Errorf("Get: failed to unmarshal: %v", err)
+		return nil, provState, fmt.Errorf("api-get-all: failed to unmarshal: %v", err)
 	}
 
 	return &result, provState, nil
@@ -97,7 +97,7 @@ func (a *AlkiraAPI[T]) GetById(id string) (*T, string, error) {
 func (a *AlkiraAPI[T]) GetByName(name string) (*T, string, error) {
 
 	if len(name) == 0 {
-		return nil, "", fmt.Errorf("GetByName: Invalid resource name")
+		return nil, "", fmt.Errorf("api-get-by-name: Invalid resource name")
 	}
 
 	// Construct single resource URI
@@ -113,11 +113,11 @@ func (a *AlkiraAPI[T]) GetByName(name string) (*T, string, error) {
 	err = json.Unmarshal([]byte(data), &result)
 
 	if err != nil {
-		return nil, state, fmt.Errorf("GetbyName: failed to unmarshal: %v", err)
+		return nil, state, fmt.Errorf("api-get-by-name: failed to unmarshal: %v", err)
 	}
 
 	if len(result) != 1 {
-		return nil, state, fmt.Errorf("GetbyName: failed to get resource by name: %s", name)
+		return nil, state, fmt.Errorf("api-get-by-name: failed to get resource by name: %s", name)
 	}
 
 	return &result[0], state, nil

--- a/vendor/github.com/alkiranet/alkira-client-go/alkira/api.go
+++ b/vendor/github.com/alkiranet/alkira-client-go/alkira/api.go
@@ -15,33 +15,33 @@ type AlkiraAPI[T any] struct {
 }
 
 // Create create a resource
-func (a *AlkiraAPI[T]) Create(resource *T) (*T, string, error) {
+func (a *AlkiraAPI[T]) Create(resource *T) (*T, string, error, error) {
 
 	// Construct the request
 	body, err := json.Marshal(resource)
 
 	if err != nil {
-		return nil, "", fmt.Errorf("Create: failed to marshal: %v", err)
+		return nil, "", fmt.Errorf("api-create: failed to marshal: %v", err), nil
 	}
 
-	data, state, err := a.Client.create(a.Uri, body, a.Provision)
+	data, state, err, errProv := a.Client.create(a.Uri, body, a.Provision)
 
 	if err != nil {
-		return nil, state, err
+		return nil, state, err, errProv
 	}
 
 	var result T
 	err = json.Unmarshal([]byte(data), &result)
 
 	if err != nil {
-		return nil, state, fmt.Errorf("Create: failed to unmarshal: %v", err)
+		return nil, state, fmt.Errorf("api-create: failed to unmarshal: %v", err), errProv
 	}
 
-	return &result, state, nil
+	return &result, state, nil, errProv
 }
 
 // Delete delete a resource by its ID
-func (a *AlkiraAPI[T]) Delete(id string) (string, error) {
+func (a *AlkiraAPI[T]) Delete(id string) (string, error, error) {
 
 	// Construct single resource URI
 	uri := fmt.Sprintf("%s/%s", a.Uri, id)
@@ -50,7 +50,7 @@ func (a *AlkiraAPI[T]) Delete(id string) (string, error) {
 }
 
 // Update update a resource by its ID
-func (a *AlkiraAPI[T]) Update(id string, resource *T) (string, error) {
+func (a *AlkiraAPI[T]) Update(id string, resource *T) (string, error, error) {
 
 	// Construct single resource URI
 	uri := fmt.Sprintf("%s/%s", a.Uri, id)
@@ -59,7 +59,7 @@ func (a *AlkiraAPI[T]) Update(id string, resource *T) (string, error) {
 	body, err := json.Marshal(resource)
 
 	if err != nil {
-		return "", fmt.Errorf("Update: failed to marshal: %v", err)
+		return "", fmt.Errorf("api-update: failed to marshal: %v", err), nil
 	}
 
 	return a.Client.update(uri, body, a.Provision)
@@ -67,30 +67,30 @@ func (a *AlkiraAPI[T]) Update(id string, resource *T) (string, error) {
 
 // GetAll get all resources
 func (a *AlkiraAPI[T]) GetAll() (string, error) {
-	data, err := a.Client.get(a.Uri)
+	data, _, err := a.Client.get(a.Uri)
 	return string(data), err
 }
 
 // GetById get a resource by its ID
-func (a *AlkiraAPI[T]) GetById(id string) (*T, error) {
+func (a *AlkiraAPI[T]) GetById(id string) (*T, string, error) {
 
 	// Construct single resource URI
 	uri := fmt.Sprintf("%s/%s", a.Uri, id)
 
-	data, err := a.Client.get(uri)
+	data, provState, err := a.Client.get(uri)
 
 	if err != nil {
-		return nil, err
+		return nil, provState, err
 	}
 
 	var result T
 	err = json.Unmarshal([]byte(data), &result)
 
 	if err != nil {
-		return nil, fmt.Errorf("Get: failed to unmarshal: %v", err)
+		return nil, provState, fmt.Errorf("Get: failed to unmarshal: %v", err)
 	}
 
-	return &result, nil
+	return &result, provState, nil
 }
 
 // GetByName get a resource by its name

--- a/vendor/github.com/alkiranet/alkira-client-go/alkira/client.go
+++ b/vendor/github.com/alkiranet/alkira-client-go/alkira/client.go
@@ -395,7 +395,7 @@ func (ac *AlkiraClient) delete(uri string, provision bool) (string, error, error
 		provisionRequestId := response.Header.Get("x-provision-request-id")
 
 		if provisionRequestId == "" {
-			return "", nil, fmt.Errorf("client-delete(%s): failed to get provision request ID", requestId)
+			return "FAILED", nil, fmt.Errorf("client-delete(%s): failed to get provision request ID", requestId)
 		}
 
 		err := wait.Poll(10*time.Second, 120*time.Minute, func() (bool, error) {
@@ -471,7 +471,7 @@ func (ac *AlkiraClient) update(uri string, body []byte, provision bool) (string,
 		provisionRequestId := response.Header.Get("x-provision-request-id")
 
 		if provisionRequestId == "" {
-			return "", nil, fmt.Errorf("client-update(%s): failed to get provision request ID", requestId)
+			return "FAILED", nil, fmt.Errorf("client-update(%s): failed to get provision request ID", requestId)
 		}
 
 		err := wait.Poll(10*time.Second, 120*time.Minute, func() (bool, error) {

--- a/vendor/github.com/alkiranet/alkira-client-go/alkira/client.go
+++ b/vendor/github.com/alkiranet/alkira-client-go/alkira/client.go
@@ -183,7 +183,7 @@ func NewAlkiraClientInternal(url string, username string, password string, timeo
 }
 
 // get retrieve a resource by sending a GET request
-func (ac *AlkiraClient) get(uri string) ([]byte, error) {
+func (ac *AlkiraClient) get(uri string) ([]byte, string, error) {
 	logf("DEBUG", "client-get URI: %s\n", uri)
 
 	requestId := "client-" + uuid.New().String()
@@ -195,7 +195,7 @@ func (ac *AlkiraClient) get(uri string) ([]byte, error) {
 	response, err := ac.Client.Do(request)
 
 	if err != nil {
-		return nil, fmt.Errorf("client-get %s failed, %v", requestId, err)
+		return nil, "", fmt.Errorf("client-get %s failed, %v", requestId, err)
 	}
 
 	defer response.Body.Close()
@@ -203,10 +203,15 @@ func (ac *AlkiraClient) get(uri string) ([]byte, error) {
 	logf("DEBUG", "client-get(%s) RSP: %s\n", requestId, string(data))
 
 	if response.StatusCode != 200 {
-		return nil, fmt.Errorf("%s(%d): %s", requestId, response.StatusCode, string(data))
+		return nil, "", fmt.Errorf("%s(%d): %s", requestId, response.StatusCode, string(data))
 	}
 
-	return data, nil
+	//
+	// If provision is enabled, try to grab the provisioning status
+	//
+	provisionState := response.Header.Get("x-provision-request-state")
+
+	return data, provisionState, nil
 }
 
 // get retrieve a resource by sending a GET request
@@ -245,7 +250,7 @@ func (ac *AlkiraClient) getByName(uri string) ([]byte, string, error) {
 }
 
 // create send a POST request to create resource
-func (ac *AlkiraClient) create(uri string, body []byte, provision bool) ([]byte, string, error) {
+func (ac *AlkiraClient) create(uri string, body []byte, provision bool) ([]byte, string, error, error) {
 	logf("DEBUG", "client-create REQ: %s\n", string(body))
 
 	//
@@ -267,7 +272,7 @@ func (ac *AlkiraClient) create(uri string, body []byte, provision bool) ([]byte,
 	response, err := ac.Client.Do(request)
 
 	if err != nil {
-		return nil, "", fmt.Errorf("client-create(%s): failed to send request, %v", requestId, err)
+		return nil, "", fmt.Errorf("client-create(%s): failed to send request, %v", requestId, err), nil
 	}
 
 	defer response.Body.Close()
@@ -276,7 +281,7 @@ func (ac *AlkiraClient) create(uri string, body []byte, provision bool) ([]byte,
 	logf("DEBUG", "client-create(%s) RSP: %s\n", requestId, string(data))
 
 	if response.StatusCode != 201 && response.StatusCode != 200 {
-		return nil, "", fmt.Errorf("%s(%d) %s", requestId, response.StatusCode, string(data))
+		return nil, "", fmt.Errorf("%s(%d) %s", requestId, response.StatusCode, string(data)), nil
 	}
 
 	//
@@ -287,7 +292,7 @@ func (ac *AlkiraClient) create(uri string, body []byte, provision bool) ([]byte,
 		provisionRequestId := response.Header.Get("x-provision-request-id")
 
 		if provisionRequestId == "" {
-			return data, "FAILED", fmt.Errorf("client-create(%s): failed to get provision request ID", requestId)
+			return data, "FAILED", nil, fmt.Errorf("client-create(%s): failed to get provision request ID", requestId)
 		}
 
 		err := wait.Poll(10*time.Second, 120*time.Minute, func() (bool, error) {
@@ -308,21 +313,21 @@ func (ac *AlkiraClient) create(uri string, body []byte, provision bool) ([]byte,
 		})
 
 		if err == wait.ErrWaitTimeout {
-			return data, "FAILED", fmt.Errorf("client-create(%s): provision request %s timed out", requestId, provisionRequestId)
+			return data, "FAILED", nil, fmt.Errorf("client-create(%s): provision request %s timed out", requestId, provisionRequestId)
 		}
 
 		if err != nil {
-			return data, "FAILED", err
+			return data, "FAILED", nil, err
 		}
 
-		return data, "SUCCESS", nil
+		return data, "SUCCESS", nil, nil
 	}
 
-	return data, "", nil
+	return data, "", nil, nil
 }
 
 // delete send a DELETE request to delete a resource
-func (ac *AlkiraClient) delete(uri string, provision bool) (string, error) {
+func (ac *AlkiraClient) delete(uri string, provision bool) (string, error, error) {
 	logf("DEBUG", "client-delete: URI %s\n", uri)
 
 	//
@@ -344,7 +349,7 @@ func (ac *AlkiraClient) delete(uri string, provision bool) (string, error) {
 	response, err := ac.Client.Do(request)
 
 	if err != nil {
-		return "", fmt.Errorf("client-delete(%s): failed, %v", requestId, err)
+		return "", fmt.Errorf("client-delete(%s): failed, %v", requestId, err), nil
 	}
 
 	defer response.Body.Close()
@@ -355,7 +360,7 @@ func (ac *AlkiraClient) delete(uri string, provision bool) (string, error) {
 	if response.StatusCode != 200 && response.StatusCode != 202 {
 		if response.StatusCode == 404 {
 			logf("INFO", "client-delete(%s): resource was already deleted.\n", requestId)
-			return "", nil
+			return "", nil, nil
 		}
 
 		// Retry several more times and see if the delete goes through
@@ -376,11 +381,11 @@ func (ac *AlkiraClient) delete(uri string, provision bool) (string, error) {
 		})
 
 		if err == wait.ErrWaitTimeout {
-			return "", fmt.Errorf("client-delete(%s): retry timeout, %s", requestId, string(data))
+			return "", fmt.Errorf("client-delete(%s): retry timeout, %s", requestId, string(data)), nil
 		}
 
 		if err != nil {
-			return "", fmt.Errorf("%s(%d): %s", requestId, response.StatusCode, string(data))
+			return "", fmt.Errorf("%s(%d): %s", requestId, response.StatusCode, string(data)), nil
 		}
 	}
 
@@ -390,7 +395,7 @@ func (ac *AlkiraClient) delete(uri string, provision bool) (string, error) {
 		provisionRequestId := response.Header.Get("x-provision-request-id")
 
 		if provisionRequestId == "" {
-			return "", fmt.Errorf("client-delete(%s): failed to get provision request ID", requestId)
+			return "", nil, fmt.Errorf("client-delete(%s): failed to get provision request ID", requestId)
 		}
 
 		err := wait.Poll(10*time.Second, 120*time.Minute, func() (bool, error) {
@@ -411,17 +416,21 @@ func (ac *AlkiraClient) delete(uri string, provision bool) (string, error) {
 		})
 
 		if err == wait.ErrWaitTimeout {
-			return "FAILED", fmt.Errorf("client-delete(%s): provision request %s timed out", requestId, provisionRequestId)
+			return "FAILED", nil, fmt.Errorf("client-delete(%s): provision request %s timed out", requestId, provisionRequestId)
 		}
 
-		return "SUCCESS", err
+		if err != nil {
+			return "FAILED", nil, err
+		}
+
+		return "SUCCESS", nil, nil
 	}
 
-	return "", nil
+	return "", nil, nil
 }
 
 // update send a PUT request to update a resource
-func (ac *AlkiraClient) update(uri string, body []byte, provision bool) (string, error) {
+func (ac *AlkiraClient) update(uri string, body []byte, provision bool) (string, error, error) {
 	logf("DEBUG", "client-update: REQUEST: %s\n", string(body))
 
 	//
@@ -443,7 +452,7 @@ func (ac *AlkiraClient) update(uri string, body []byte, provision bool) (string,
 	response, err := ac.Client.Do(request)
 
 	if err != nil {
-		return "", fmt.Errorf("client-update(%s): failed, %v", requestId, err)
+		return "", fmt.Errorf("client-update(%s): failed, %v", requestId, err), nil
 	}
 
 	defer response.Body.Close()
@@ -452,7 +461,7 @@ func (ac *AlkiraClient) update(uri string, body []byte, provision bool) (string,
 	logf("DEBUG", "client-update(%s): RSP: %s\n", requestId, string(data))
 
 	if response.StatusCode != 200 && response.StatusCode != 202 {
-		return "", fmt.Errorf("%s(%d) %s", requestId, response.StatusCode, string(data))
+		return "", fmt.Errorf("%s(%d) %s", requestId, response.StatusCode, string(data)), nil
 	}
 
 	//
@@ -462,7 +471,7 @@ func (ac *AlkiraClient) update(uri string, body []byte, provision bool) (string,
 		provisionRequestId := response.Header.Get("x-provision-request-id")
 
 		if provisionRequestId == "" {
-			return "", fmt.Errorf("client-update(%s): failed to get provision request ID", requestId)
+			return "", nil, fmt.Errorf("client-update(%s): failed to get provision request ID", requestId)
 		}
 
 		err := wait.Poll(10*time.Second, 120*time.Minute, func() (bool, error) {
@@ -483,11 +492,15 @@ func (ac *AlkiraClient) update(uri string, body []byte, provision bool) (string,
 		})
 
 		if err == wait.ErrWaitTimeout {
-			return "FAILED", fmt.Errorf("client-update(%s): provision request %s timed out", requestId, provisionRequestId)
+			return "FAILED", nil, fmt.Errorf("client-update(%s): provision request %s timed out", requestId, provisionRequestId)
 		}
 
-		return "SUCCESS", err
+		if err != nil {
+			return "FAILED", nil, err
+		}
+
+		return "SUCCESS", nil, nil
 	}
 
-	return "", nil
+	return "", nil, nil
 }

--- a/vendor/github.com/alkiranet/alkira-client-go/alkira/credentials.go
+++ b/vendor/github.com/alkiranet/alkira-client-go/alkira/credentials.go
@@ -204,7 +204,7 @@ func (ac *AlkiraClient) CreateCredential(name string, ctype CredentialType, cred
 		return "", fmt.Errorf("CreateCredential: failed to marshal: %v", err)
 	}
 
-	data, _, err := ac.create(uri, body, false)
+	data, _, err, _ := ac.create(uri, body, false)
 
 	if err != nil {
 		return "", err
@@ -219,7 +219,7 @@ func (ac *AlkiraClient) CreateCredential(name string, ctype CredentialType, cred
 // DeleteCredential delete credential by its Id
 func (ac *AlkiraClient) DeleteCredential(id string, ctype CredentialType) error {
 	uri := fmt.Sprintf("%s/api/credentials/%s/%s", ac.URI, ctype, id)
-	_, err := ac.delete(uri, false)
+	_, err, _ := ac.delete(uri, false)
 	return err
 }
 
@@ -242,7 +242,7 @@ func (ac *AlkiraClient) UpdateCredential(id string, name string, ctype Credentia
 		return fmt.Errorf("UpdateCredential: failed to marshal: %v", err)
 	}
 
-	_, err = ac.update(uri, body, false)
+	_, err, _ = ac.update(uri, body, false)
 
 	return err
 }
@@ -251,7 +251,7 @@ func (ac *AlkiraClient) UpdateCredential(id string, name string, ctype Credentia
 func (ac *AlkiraClient) GetCredentials() (string, error) {
 	uri := fmt.Sprintf("%s/api/credentials/", ac.URI)
 
-	data, err := ac.get(uri)
+	data, _, err := ac.get(uri)
 	return string(data), err
 }
 
@@ -261,7 +261,7 @@ func (ac *AlkiraClient) GetCredentialById(id string) (CredentialResponseDetail, 
 
 	var credential CredentialResponseDetail
 
-	data, err := ac.get(uri)
+	data, _, err := ac.get(uri)
 
 	if err != nil {
 		return credential, err

--- a/vendor/github.com/alkiranet/alkira-client-go/alkira/tenant_networks.go
+++ b/vendor/github.com/alkiranet/alkira-client-go/alkira/tenant_networks.go
@@ -35,7 +35,7 @@ type TenantNetworkProvisionRequest struct {
 func (ac *AlkiraClient) GetTenantNetworks() (string, error) {
 	uri := fmt.Sprintf("%s/tenantnetworks", ac.URI)
 
-	data, err := ac.get(uri)
+	data, _, err := ac.get(uri)
 
 	if err != nil {
 		return "", err
@@ -49,7 +49,7 @@ func (ac *AlkiraClient) GetTenantNetworkId() (string, error) {
 
 	uri := fmt.Sprintf("%s/tenantnetworks", ac.URI)
 
-	data, err := ac.get(uri)
+	data, _, err := ac.get(uri)
 
 	if err != nil {
 		return "", err
@@ -69,7 +69,7 @@ func (ac *AlkiraClient) GetTenantNetworkId() (string, error) {
 func (ac *AlkiraClient) GetTenantNetworkState() (string, error) {
 	uri := fmt.Sprintf("%s/tenantnetworks/%s", ac.URI, ac.TenantNetworkId)
 
-	data, err := ac.get(uri)
+	data, _, err := ac.get(uri)
 
 	if err != nil {
 		return "", err
@@ -89,7 +89,7 @@ func (ac *AlkiraClient) GetTenantNetworkState() (string, error) {
 func (ac *AlkiraClient) GetTenantNetworkConnectorState(id string) (string, error) {
 	uri := fmt.Sprintf("%s/tenantnetworks/%s/connectors/%s", ac.URI, ac.TenantNetworkId, id)
 
-	data, err := ac.get(uri)
+	data, _, err := ac.get(uri)
 
 	if err != nil {
 		return "", err
@@ -109,7 +109,7 @@ func (ac *AlkiraClient) GetTenantNetworkConnectorState(id string) (string, error
 func (ac *AlkiraClient) GetTenantNetworkServiceState(id string) (string, error) {
 	uri := fmt.Sprintf("%s/tenantnetworks/%s/services/%s", ac.URI, ac.TenantNetworkId, id)
 
-	data, err := ac.get(uri)
+	data, _, err := ac.get(uri)
 
 	if err != nil {
 		return "", err
@@ -129,7 +129,7 @@ func (ac *AlkiraClient) GetTenantNetworkServiceState(id string) (string, error) 
 func (ac *AlkiraClient) GetTenantNetworkProvisionRequest(id string) (*TenantNetworkProvisionRequest, error) {
 	uri := fmt.Sprintf("%s/tenantnetworks/%s/provision-requests/%s", ac.URI, ac.TenantNetworkId, id)
 
-	data, err := ac.get(uri)
+	data, _, err := ac.get(uri)
 
 	if err != nil {
 		return nil, err
@@ -149,7 +149,7 @@ func (ac *AlkiraClient) GetTenantNetworkProvisionRequest(id string) (*TenantNetw
 func (ac *AlkiraClient) ProvisionTenantNetwork() (string, error) {
 	uri := fmt.Sprintf("%s/tenantnetworks/%s/provision", ac.URI, ac.TenantNetworkId)
 
-	data, _, err := ac.create(uri, nil, false)
+	data, _, err, _ := ac.create(uri, nil, false)
 
 	if err != nil {
 		return "", err

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -13,7 +13,7 @@ cloud.google.com/go/storage
 # github.com/agext/levenshtein v1.2.2
 ## explicit
 github.com/agext/levenshtein
-# github.com/alkiranet/alkira-client-go v1.37.7
+# github.com/alkiranet/alkira-client-go v1.37.8
 ## explicit; go 1.18
 github.com/alkiranet/alkira-client-go/alkira
 # github.com/apparentlymart/go-cidr v1.0.1


### PR DESCRIPTION
Handle provisioning state separately from all CRUD operations.

+ Use diag packages across all resources to have better error handling.
+ Track provisioning failures as a "WARNING" instead of failing and stopping entire TF execution.
+ Update error messages with better information.
+ Update alkira-client-go to v1.37.8 to pick up corresponding changes from client functions.