### PR TITLE
AK-33453 Adjust the READ failure of all resources to be warning

### DIFF
--- a/alkira/resource_alkira_billing_tag.go
+++ b/alkira/resource_alkira_billing_tag.go
@@ -2,6 +2,7 @@ package alkira
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/alkiranet/alkira-client-go/alkira"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -64,7 +65,11 @@ func resourceBillingTagRead(ctx context.Context, d *schema.ResourceData, m inter
 	tag, _, err := api.GetById(d.Id())
 
 	if err != nil {
-		return diag.FromErr(err)
+		return diag.Diagnostics{{
+			Severity: diag.Warning,
+			Summary:  "FAILED TO GET RESOURCE",
+			Detail:   fmt.Sprintf("%s", err),
+		}}
 	}
 
 	d.Set("name", tag.Name)

--- a/alkira/resource_alkira_byoip_prefix.go
+++ b/alkira/resource_alkira_byoip_prefix.go
@@ -124,7 +124,11 @@ func resourceByoipPrefixRead(ctx context.Context, d *schema.ResourceData, m inte
 	byoip, provState, err := api.GetById(d.Id())
 
 	if err != nil {
-		return diag.FromErr(err)
+		return diag.Diagnostics{{
+			Severity: diag.Warning,
+			Summary:  "FAILED TO GET RESOURCE",
+			Detail:   fmt.Sprintf("%s", err),
+		}}
 	}
 
 	d.Set("prefix", byoip.Prefix)

--- a/alkira/resource_alkira_cloudvisor_account.go
+++ b/alkira/resource_alkira_cloudvisor_account.go
@@ -2,6 +2,7 @@ package alkira
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/alkiranet/alkira-client-go/alkira"
 
@@ -79,7 +80,11 @@ func resourceCloudVisorAccountRead(ctx context.Context, d *schema.ResourceData, 
 	account, _, err := api.GetById(d.Id())
 
 	if err != nil {
-		return diag.FromErr(err)
+		return diag.Diagnostics{{
+			Severity: diag.Warning,
+			Summary:  "FAILED TO GET RESOURCE",
+			Detail:   fmt.Sprintf("%s", err),
+		}}
 	}
 
 	d.Set("name", account.Name)

--- a/alkira/resource_alkira_connector_akamai_prolexic.go
+++ b/alkira/resource_alkira_connector_akamai_prolexic.go
@@ -224,7 +224,11 @@ func resourceConnectorAkamaiProlexicRead(ctx context.Context, d *schema.Resource
 	connector, provState, err := api.GetById(d.Id())
 
 	if err != nil {
-		return diag.FromErr(err)
+		return diag.Diagnostics{{
+			Severity: diag.Warning,
+			Summary:  "FAILED TO GET RESOURCE",
+			Detail:   fmt.Sprintf("%s", err),
+		}}
 	}
 
 	d.Set("akamai_bgp_asn", connector.AkamaiBgpAsn)

--- a/alkira/resource_alkira_connector_aruba_edge.go
+++ b/alkira/resource_alkira_connector_aruba_edge.go
@@ -242,7 +242,11 @@ func resourceConnectorArubaEdgeRead(ctx context.Context, d *schema.ResourceData,
 	connector, provState, err := api.GetById(d.Id())
 
 	if err != nil {
-		return diag.FromErr(err)
+		return diag.Diagnostics{{
+			Severity: diag.Warning,
+			Summary:  "FAILED TO GET RESOURCE",
+			Detail:   fmt.Sprintf("%s", err),
+		}}
 	}
 
 	arubaEdgeMappings, err := deflateArubaEdgeVrfMapping(connector.ArubaEdgeVrfMapping, m)

--- a/alkira/resource_alkira_connector_aws_vpc.go
+++ b/alkira/resource_alkira_connector_aws_vpc.go
@@ -247,7 +247,11 @@ func resourceConnectorAwsVpcRead(ctx context.Context, d *schema.ResourceData, m 
 	connector, provState, err := api.GetById(d.Id())
 
 	if err != nil {
-		return diag.FromErr(err)
+		return diag.Diagnostics{{
+			Severity: diag.Warning,
+			Summary:  "FAILED TO GET RESOURCE",
+			Detail:   fmt.Sprintf("%s", err),
+		}}
 	}
 
 	d.Set("aws_account_id", connector.VpcOwnerId)

--- a/alkira/resource_alkira_connector_azure_expressroute.go
+++ b/alkira/resource_alkira_connector_azure_expressroute.go
@@ -240,7 +240,11 @@ func resourceConnectorAzureExpressRouteRead(ctx context.Context, d *schema.Resou
 	connector, provState, err := api.GetById(d.Id())
 
 	if err != nil {
-		return diag.FromErr(err)
+		return diag.Diagnostics{{
+			Severity: diag.Warning,
+			Summary:  "FAILED TO GET RESOURCE",
+			Detail:   fmt.Sprintf("%s", err),
+		}}
 	}
 
 	d.Set("size", connector.Size)

--- a/alkira/resource_alkira_connector_azure_vnet.go
+++ b/alkira/resource_alkira_connector_azure_vnet.go
@@ -255,7 +255,11 @@ func resourceConnectorAzureVnetRead(ctx context.Context, d *schema.ResourceData,
 	connector, provState, err := api.GetById(d.Id())
 
 	if err != nil {
-		return diag.FromErr(err)
+		return diag.Diagnostics{{
+			Severity: diag.Warning,
+			Summary:  "FAILED TO GET RESOURCE",
+			Detail:   fmt.Sprintf("%s", err),
+		}}
 	}
 
 	d.Set("azure_vnet_id", connector.VnetId)

--- a/alkira/resource_alkira_connector_cisco_sdwan.go
+++ b/alkira/resource_alkira_connector_cisco_sdwan.go
@@ -229,7 +229,11 @@ func resourceConnectorCiscoSdwanRead(ctx context.Context, d *schema.ResourceData
 	connector, provState, err := api.GetById(d.Id())
 
 	if err != nil {
-		return diag.FromErr(err)
+		return diag.Diagnostics{{
+			Severity: diag.Warning,
+			Summary:  "FAILED TO GET RESOURCE",
+			Detail:   fmt.Sprintf("%s", err),
+		}}
 	}
 
 	d.Set("billing_tag_ids", connector.BillingTags)

--- a/alkira/resource_alkira_connector_gcp_vpc.go
+++ b/alkira/resource_alkira_connector_gcp_vpc.go
@@ -223,7 +223,11 @@ func resourceConnectorGcpVpcRead(ctx context.Context, d *schema.ResourceData, m 
 	connector, provState, err := api.GetById(d.Id())
 
 	if err != nil {
-		return diag.FromErr(err)
+		return diag.Diagnostics{{
+			Severity: diag.Warning,
+			Summary:  "FAILED TO GET RESOURCE",
+			Detail:   fmt.Sprintf("%s", err),
+		}}
 	}
 
 	d.Set("billing_tag_ids", connector.BillingTags)

--- a/alkira/resource_alkira_connector_internet_exit.go
+++ b/alkira/resource_alkira_connector_internet_exit.go
@@ -168,7 +168,11 @@ func resourceConnectorInternetExitRead(ctx context.Context, d *schema.ResourceDa
 	connector, provState, err := api.GetById(d.Id())
 
 	if err != nil {
-		return diag.FromErr(err)
+		return diag.Diagnostics{{
+			Severity: diag.Warning,
+			Summary:  "FAILED TO GET RESOURCE",
+			Detail:   fmt.Sprintf("%s", err),
+		}}
 	}
 
 	d.Set("billing_tag_ids", connector.BillingTags)

--- a/alkira/resource_alkira_connector_ipsec.go
+++ b/alkira/resource_alkira_connector_ipsec.go
@@ -420,7 +420,11 @@ func resourceConnectorIPSecRead(ctx context.Context, d *schema.ResourceData, m i
 	connector, provState, err := api.GetById(d.Id())
 
 	if err != nil {
-		return diag.FromErr(err)
+		return diag.Diagnostics{{
+			Severity: diag.Warning,
+			Summary:  "FAILED TO GET RESOURCE",
+			Detail:   fmt.Sprintf("%s", err),
+		}}
 	}
 
 	d.Set("billing_tag_ids", connector.BillingTags)

--- a/alkira/resource_alkira_connector_oci_vcn.go
+++ b/alkira/resource_alkira_connector_oci_vcn.go
@@ -219,7 +219,11 @@ func resourceConnectorOciVcnRead(ctx context.Context, d *schema.ResourceData, m 
 	connector, provState, err := api.GetById(d.Id())
 
 	if err != nil {
-		return diag.FromErr(err)
+		return diag.Diagnostics{{
+			Severity: diag.Warning,
+			Summary:  "FAILED TO GET RESOURCE",
+			Detail:   fmt.Sprintf("%s", err),
+		}}
 	}
 
 	d.Set("billing_tag_ids", connector.BillingTags)

--- a/alkira/resource_alkira_connector_vmware_sdwan.go
+++ b/alkira/resource_alkira_connector_vmware_sdwan.go
@@ -221,7 +221,11 @@ func resourceConnectorVmwareSdwanRead(ctx context.Context, d *schema.ResourceDat
 	connector, provState, err := api.GetById(d.Id())
 
 	if err != nil {
-		return diag.FromErr(err)
+		return diag.Diagnostics{{
+			Severity: diag.Warning,
+			Summary:  "FAILED TO GET RESOURCE",
+			Detail:   fmt.Sprintf("%s", err),
+		}}
 	}
 
 	d.Set("billing_tag_ids", connector.BillingTags)

--- a/alkira/resource_alkira_group.go
+++ b/alkira/resource_alkira_group.go
@@ -99,7 +99,11 @@ func resourceGroupRead(ctx context.Context, d *schema.ResourceData, m interface{
 	group, provState, err := api.GetById(d.Id())
 
 	if err != nil {
-		return diag.FromErr(err)
+		return diag.Diagnostics{{
+			Severity: diag.Warning,
+			Summary:  "FAILED TO GET RESOURCE",
+			Detail:   fmt.Sprintf("%s", err),
+		}}
 	}
 
 	d.Set("name", group.Name)

--- a/alkira/resource_alkira_group_user.go
+++ b/alkira/resource_alkira_group_user.go
@@ -2,6 +2,7 @@ package alkira
 
 import (
 	"context"
+	"fmt"
 	"log"
 
 	"github.com/alkiranet/alkira-client-go/alkira"
@@ -58,7 +59,11 @@ func resourceGroupUserRead(ctx context.Context, d *schema.ResourceData, m interf
 	group, _, err := api.GetById(d.Id())
 
 	if err != nil {
-		return diag.FromErr(err)
+		return diag.Diagnostics{{
+			Severity: diag.Warning,
+			Summary:  "FAILED TO GET RESOURCE",
+			Detail:   fmt.Sprintf("%s", err),
+		}}
 	}
 
 	d.Set("name", group.Name)

--- a/alkira/resource_alkira_internet_applications.go
+++ b/alkira/resource_alkira_internet_applications.go
@@ -208,7 +208,11 @@ func resourceInternetApplicationRead(ctx context.Context, d *schema.ResourceData
 	app, provState, err := api.GetById(d.Id())
 
 	if err != nil {
-		return diag.FromErr(err)
+		return diag.Diagnostics{{
+			Severity: diag.Warning,
+			Summary:  "FAILED TO GET RESOURCE",
+			Detail:   fmt.Sprintf("%s", err),
+		}}
 	}
 
 	d.Set("billing_tag_ids", app.BillingTags)

--- a/alkira/resource_alkira_list_as_path.go
+++ b/alkira/resource_alkira_list_as_path.go
@@ -106,7 +106,11 @@ func resourceListAsPathRead(ctx context.Context, d *schema.ResourceData, m inter
 	list, provState, err := api.GetById(d.Id())
 
 	if err != nil {
-		return diag.FromErr(err)
+		return diag.Diagnostics{{
+			Severity: diag.Warning,
+			Summary:  "FAILED TO GET RESOURCE",
+			Detail:   fmt.Sprintf("%s", err),
+		}}
 	}
 
 	d.Set("name", list.Name)

--- a/alkira/resource_alkira_list_community.go
+++ b/alkira/resource_alkira_list_community.go
@@ -103,7 +103,11 @@ func resourceListCommunityRead(ctx context.Context, d *schema.ResourceData, m in
 	list, provState, err := api.GetById(d.Id())
 
 	if err != nil {
-		return diag.FromErr(err)
+		return diag.Diagnostics{{
+			Severity: diag.Warning,
+			Summary:  "FAILED TO GET RESOURCE",
+			Detail:   fmt.Sprintf("%s", err),
+		}}
 	}
 
 	d.Set("name", list.Name)

--- a/alkira/resource_alkira_list_extended_community.go
+++ b/alkira/resource_alkira_list_extended_community.go
@@ -107,7 +107,11 @@ func resourceListExtendedCommunityRead(ctx context.Context, d *schema.ResourceDa
 	list, provState, err := api.GetById(d.Id())
 
 	if err != nil {
-		return diag.FromErr(err)
+		return diag.Diagnostics{{
+			Severity: diag.Warning,
+			Summary:  "FAILED TO GET RESOURCE",
+			Detail:   fmt.Sprintf("%s", err),
+		}}
 	}
 
 	d.Set("name", list.Name)

--- a/alkira/resource_alkira_list_global_cidr.go
+++ b/alkira/resource_alkira_list_global_cidr.go
@@ -112,7 +112,11 @@ func resourceListGlobalCidrRead(ctx context.Context, d *schema.ResourceData, m i
 	list, provState, err := api.GetById(d.Id())
 
 	if err != nil {
-		return diag.FromErr(err)
+		return diag.Diagnostics{{
+			Severity: diag.Warning,
+			Summary:  "FAILED TO GET RESOURCE",
+			Detail:   fmt.Sprintf("%s", err),
+		}}
 	}
 
 	d.Set("name", list.Name)

--- a/alkira/resource_alkira_policy.go
+++ b/alkira/resource_alkira_policy.go
@@ -120,7 +120,11 @@ func resourcePolicyRead(ctx context.Context, d *schema.ResourceData, m interface
 	policy, provState, err := api.GetById(d.Id())
 
 	if err != nil {
-		return diag.FromErr(err)
+		return diag.Diagnostics{{
+			Severity: diag.Warning,
+			Summary:  "FAILED TO GET RESOURCE",
+			Detail:   fmt.Sprintf("%s", err),
+		}}
 	}
 
 	d.Set("description", policy.Description)

--- a/alkira/resource_alkira_policy_nat.go
+++ b/alkira/resource_alkira_policy_nat.go
@@ -123,7 +123,11 @@ func resourcePolicyNatRead(ctx context.Context, d *schema.ResourceData, m interf
 	policy, provState, err := api.GetById(d.Id())
 
 	if err != nil {
-		return diag.FromErr(err)
+		return diag.Diagnostics{{
+			Severity: diag.Warning,
+			Summary:  "FAILED TO GET RESOURCE",
+			Detail:   fmt.Sprintf("%s", err),
+		}}
 	}
 
 	d.Set("name", policy.Name)

--- a/alkira/resource_alkira_policy_nat_rule.go
+++ b/alkira/resource_alkira_policy_nat_rule.go
@@ -247,7 +247,11 @@ func resourcePolicyNatRuleRead(ctx context.Context, d *schema.ResourceData, m in
 	rule, provState, err := api.GetById(d.Id())
 
 	if err != nil {
-		return diag.FromErr(err)
+		return diag.Diagnostics{{
+			Severity: diag.Warning,
+			Summary:  "FAILED TO GET RESOURCE",
+			Detail:   fmt.Sprintf("%s", err),
+		}}
 	}
 
 	d.Set("name", rule.Name)

--- a/alkira/resource_alkira_policy_prefix_list.go
+++ b/alkira/resource_alkira_policy_prefix_list.go
@@ -129,7 +129,11 @@ func resourcePolicyPrefixListRead(ctx context.Context, d *schema.ResourceData, m
 	list, provState, err := api.GetById(d.Id())
 
 	if err != nil {
-		return diag.FromErr(err)
+		return diag.Diagnostics{{
+			Severity: diag.Warning,
+			Summary:  "FAILED TO GET RESOURCE",
+			Detail:   fmt.Sprintf("%s", err),
+		}}
 	}
 
 	d.Set("name", list.Name)

--- a/alkira/resource_alkira_policy_routing.go
+++ b/alkira/resource_alkira_policy_routing.go
@@ -271,7 +271,11 @@ func resourcePolicyRoutingRead(ctx context.Context, d *schema.ResourceData, m in
 	policy, provState, err := api.GetById(d.Id())
 
 	if err != nil {
-		return diag.FromErr(err)
+		return diag.Diagnostics{{
+			Severity: diag.Warning,
+			Summary:  "FAILED TO GET RESOURCE",
+			Detail:   fmt.Sprintf("%s", err),
+		}}
 	}
 
 	if policy.AdvertiseInternetExit != nil {

--- a/alkira/resource_alkira_policy_rule.go
+++ b/alkira/resource_alkira_policy_rule.go
@@ -189,7 +189,11 @@ func resourcePolicyRuleRead(ctx context.Context, d *schema.ResourceData, m inter
 	rule, provState, err := api.GetById(d.Id())
 
 	if err != nil {
-		return diag.FromErr(err)
+		return diag.Diagnostics{{
+			Severity: diag.Warning,
+			Summary:  "FAILED TO GET RESOURCE",
+			Detail:   fmt.Sprintf("%s", err),
+		}}
 	}
 
 	d.Set("name", rule.Name)

--- a/alkira/resource_alkira_policy_rule_list.go
+++ b/alkira/resource_alkira_policy_rule_list.go
@@ -112,7 +112,11 @@ func resourcePolicyRuleListRead(ctx context.Context, d *schema.ResourceData, m i
 	ruleList, provState, err := api.GetById(d.Id())
 
 	if err != nil {
-		return diag.FromErr(err)
+		return diag.Diagnostics{{
+			Severity: diag.Warning,
+			Summary:  "FAILED TO GET RESOURCE",
+			Detail:   fmt.Sprintf("%s", err),
+		}}
 	}
 
 	d.Set("name", ruleList.Name)

--- a/alkira/resource_alkira_segment.go
+++ b/alkira/resource_alkira_segment.go
@@ -145,7 +145,11 @@ func resourceSegmentRead(ctx context.Context, d *schema.ResourceData, m interfac
 	segment, provState, err := api.GetById(d.Id())
 
 	if err != nil {
-		return diag.FromErr(err)
+		return diag.Diagnostics{{
+			Severity: diag.Warning,
+			Summary:  "FAILED TO GET RESOURCE",
+			Detail:   fmt.Sprintf("%s", err),
+		}}
 	}
 
 	d.Set("asn", segment.Asn)

--- a/alkira/resource_alkira_segment_resource.go
+++ b/alkira/resource_alkira_segment_resource.go
@@ -122,7 +122,11 @@ func resourceSegmentResourceRead(ctx context.Context, d *schema.ResourceData, m 
 	resource, provState, err := api.GetById(d.Id())
 
 	if err != nil {
-		return diag.FromErr(err)
+		return diag.Diagnostics{{
+			Severity: diag.Warning,
+			Summary:  "FAILED TO GET RESOURCE",
+			Detail:   fmt.Sprintf("%s", err),
+		}}
 	}
 
 	d.Set("name", resource.Name)

--- a/alkira/resource_alkira_segment_resource_share.go
+++ b/alkira/resource_alkira_segment_resource_share.go
@@ -143,7 +143,11 @@ func resourceSegmentResourceShareRead(ctx context.Context, d *schema.ResourceDat
 	share, provState, err := api.GetById(d.Id())
 
 	if err != nil {
-		return diag.FromErr(err)
+		return diag.Diagnostics{{
+			Severity: diag.Warning,
+			Summary:  "FAILED TO GET RESOURCE",
+			Detail:   fmt.Sprintf("%s", err),
+		}}
 	}
 
 	d.Set("name", share.Name)

--- a/alkira/resource_alkira_service_checkpoint.go
+++ b/alkira/resource_alkira_service_checkpoint.go
@@ -315,7 +315,11 @@ func resourceCheckpointRead(ctx context.Context, d *schema.ResourceData, m inter
 	checkpoint, provState, err := api.GetById(d.Id())
 
 	if err != nil {
-		return diag.FromErr(err)
+		return diag.Diagnostics{{
+			Severity: diag.Warning,
+			Summary:  "FAILED TO GET RESOURCE",
+			Detail:   fmt.Sprintf("%s", err),
+		}}
 	}
 
 	// Get segment

--- a/alkira/resource_alkira_service_cisco_ftdv.go
+++ b/alkira/resource_alkira_service_cisco_ftdv.go
@@ -273,7 +273,11 @@ func resourceServiceCiscoFTDvRead(ctx context.Context, d *schema.ResourceData, m
 	service, provState, err := api.GetById(d.Id())
 
 	if err != nil {
-		return diag.FromErr(err)
+		return diag.Diagnostics{{
+			Severity: diag.Warning,
+			Summary:  "FAILED TO GET RESOURCE",
+			Detail:   fmt.Sprintf("%s", err),
+		}}
 	}
 
 	d.Set("auto_scale", service.AutoScale)

--- a/alkira/resource_alkira_service_fortinet.go
+++ b/alkira/resource_alkira_service_fortinet.go
@@ -269,7 +269,11 @@ func resourceFortinetRead(ctx context.Context, d *schema.ResourceData, m interfa
 	f, provState, err := api.GetById(d.Id())
 
 	if err != nil {
-		return diag.FromErr(err)
+		return diag.Diagnostics{{
+			Severity: diag.Warning,
+			Summary:  "FAILED TO GET RESOURCE",
+			Detail:   fmt.Sprintf("%s", err),
+		}}
 	}
 
 	d.Set("auto_scale", f.AutoScale)

--- a/alkira/resource_alkira_service_infoblox.go
+++ b/alkira/resource_alkira_service_infoblox.go
@@ -279,7 +279,11 @@ func resourceInfobloxRead(ctx context.Context, d *schema.ResourceData, m interfa
 	infoblox, provState, err := api.GetById(d.Id())
 
 	if err != nil {
-		return diag.FromErr(err)
+		return diag.Diagnostics{{
+			Severity: diag.Warning,
+			Summary:  "FAILED TO GET RESOURCE",
+			Detail:   fmt.Sprintf("%s", err),
+		}}
 	}
 
 	setAllInfobloxResourceFields(d, infoblox)

--- a/alkira/resource_alkira_service_pan.go
+++ b/alkira/resource_alkira_service_pan.go
@@ -414,7 +414,11 @@ func resourceServicePanRead(ctx context.Context, d *schema.ResourceData, m inter
 	pan, provState, err := api.GetById(d.Id())
 
 	if err != nil {
-		return diag.FromErr(err)
+		return diag.Diagnostics{{
+			Severity: diag.Warning,
+			Summary:  "FAILED TO GET RESOURCE",
+			Detail:   fmt.Sprintf("%s", err),
+		}}
 	}
 
 	d.Set("billing_tag_ids", pan.BillingTagIds)

--- a/alkira/resource_alkira_service_zscaler.go
+++ b/alkira/resource_alkira_service_zscaler.go
@@ -248,7 +248,11 @@ func resourceZscalerRead(ctx context.Context, d *schema.ResourceData, m interfac
 	z, provState, err := api.GetById(d.Id())
 
 	if err != nil {
-		return diag.FromErr(err)
+		return diag.Diagnostics{{
+			Severity: diag.Warning,
+			Summary:  "FAILED TO GET RESOURCE",
+			Detail:   fmt.Sprintf("%s", err),
+		}}
 	}
 
 	segmentIds, err := convertSegmentNamesToSegmentIds(z.Segments, m)


### PR DESCRIPTION
Adjust READ failures of all resources to be warning so one resource's failure won't halt the entire TF operations.