### PR TITLE
AK-33142 Fix passing empty err to diag function

### DIFF
--- a/alkira/resource_alkira_connector_aruba_edge.go
+++ b/alkira/resource_alkira_connector_aruba_edge.go
@@ -280,7 +280,7 @@ func resourceConnectorArubaEdgeRead(ctx context.Context, d *schema.ResourceData,
 		d.Set("provision_state", provState)
 	}
 
-	return diag.FromErr(err)
+	return nil
 }
 
 func resourceConnectorArubaEdgeUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {

--- a/alkira/resource_alkira_connector_gcp_vpc.go
+++ b/alkira/resource_alkira_connector_gcp_vpc.go
@@ -37,7 +37,7 @@ func resourceAlkiraConnectorGcpVpc() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"billing_tag_ids": {
-				Description: "Tags for billing.",
+				Description: "IDs of billing tags associated with the connector.",
 				Type:        schema.TypeList,
 				Optional:    true,
 				Elem:        &schema.Schema{Type: schema.TypeInt},
@@ -263,7 +263,7 @@ func resourceConnectorGcpVpcRead(ctx context.Context, d *schema.ResourceData, m 
 		d.Set("provision_state", provState)
 	}
 
-	return diag.FromErr(err)
+	return nil
 }
 
 func resourceConnectorGcpVpcUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {

--- a/alkira/resource_alkira_connector_internet_exit.go
+++ b/alkira/resource_alkira_connector_internet_exit.go
@@ -240,7 +240,7 @@ func resourceConnectorInternetExitUpdate(ctx context.Context, d *schema.Resource
 		}
 	}
 
-	return diag.FromErr(err)
+	return nil
 }
 
 func resourceConnectorInternetExitDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {

--- a/alkira/resource_alkira_connector_oci_vcn.go
+++ b/alkira/resource_alkira_connector_oci_vcn.go
@@ -288,7 +288,7 @@ func resourceConnectorOciVcnUpdate(ctx context.Context, d *schema.ResourceData, 
 		}
 	}
 
-	return diag.FromErr(err)
+	return nil
 }
 
 func resourceConnectorOciVcnDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {

--- a/alkira/resource_alkira_service_checkpoint.go
+++ b/alkira/resource_alkira_service_checkpoint.go
@@ -389,7 +389,7 @@ func resourceCheckpointUpdate(ctx context.Context, d *schema.ResourceData, m int
 		}
 	}
 
-	return diag.FromErr(err)
+	return nil
 }
 
 func resourceCheckpointDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {

--- a/alkira/resource_alkira_service_fortinet.go
+++ b/alkira/resource_alkira_service_fortinet.go
@@ -346,7 +346,7 @@ func resourceFortinetUpdate(ctx context.Context, d *schema.ResourceData, m inter
 		}
 	}
 
-	return diag.FromErr(err)
+	return nil
 }
 
 func resourceFortinetDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {

--- a/docs/resources/connector_gcp_vpc.md
+++ b/docs/resources/connector_gcp_vpc.md
@@ -107,7 +107,7 @@ resource "alkira_connector_gcp_vpc" "gcp_subnet" {
 
 ### Optional
 
-- `billing_tag_ids` (List of Number) Tags for billing.
+- `billing_tag_ids` (List of Number) IDs of billing tags associated with the connector.
 - `enabled` (Boolean) Is the connector enabled. Default is `true`.
 - `failover_cxps` (List of String) A list of additional CXPs where the connector should be provisioned for failover.
 - `gcp_project_id` (String) GCP Project ID.


### PR DESCRIPTION
Avoid sending empty error to diag.FromErr function that cause a crash.