### PR TITLE
AK-34849 Fix optional segment issues with service_checkpoint

### DIFF
--- a/acceptance/main.tf
+++ b/acceptance/main.tf
@@ -9,3 +9,7 @@ terraform {
 provider "alkira" {
   portal = "terraform.preprod.alkira3.net"
 }
+
+locals {
+  cxp = "US-WEST-1"
+}

--- a/acceptance/service_checkpoint.tf
+++ b/acceptance/service_checkpoint.tf
@@ -1,7 +1,7 @@
 resource "alkira_service_checkpoint" "test" {
   name       = "acceptance-checkpoint"
   auto_scale = "ON"
-  cxp        = "US-WEST-1"
+  cxp        = local.cxp
 
   license_type = "PAY_AS_YOU_GO"
   size         = "SMALL"
@@ -22,10 +22,11 @@ resource "alkira_service_checkpoint" "test" {
     global_cidr_list_id = alkira_list_global_cidr.checkpoint.id
     segment_id          = alkira_segment.test1.id
 
-    user_name                  = "checkpoint_user"
-    management_server_password = "abcd1234"
+    username = "checkpoint_user"
+    password = "abcd1234"
 
-    # domain only required when configuration_mode is AUTOMATED and when type is MDS.
+    # domain only required when configuration_mode is AUTOMATED and
+    # when type is MDS.
     domain = "test.alkira.com"
   }
 
@@ -37,5 +38,44 @@ resource "alkira_service_checkpoint" "test" {
   instance {
     name    = "ins2"
     sic_key = "abcd12345"
+  }
+}
+
+resource "alkira_service_checkpoint" "test2" {
+  name               = "acceptance-checkpoint-2"
+  auto_scale         = "OFF"
+  cxp                = local.cxp
+
+  billing_tag_ids    = [alkira_billing_tag.test1.id]
+  license_type       = "BRING_YOUR_OWN"
+  max_instance_count = 1
+  min_instance_count = 1
+
+  password           = "xxxxxxxx"
+  pdp_ips            = ["10.1.1.116"]
+  segment_id         = alkira_segment.test1.id
+  size               = "LARGE"
+  tunnel_protocol    = "IPSEC"
+  version            = "R81"
+
+  instance {
+    name          = "acceptance-checkpoint-2"
+    sic_key       = "ak12345678"
+  }
+
+  management_server {
+    configuration_mode         = "AUTOMATED"
+    global_cidr_list_id        = alkira_list_global_cidr.checkpoint.id
+    ips                        = ["54.69.129.30"]
+    username                   = "checkpoint_user"
+    password                   = "Alkira2023"
+    reachability               = "PUBLIC"
+    type                       = "SMS"
+  }
+
+  segment_options {
+    groups     = [alkira_group.test1.name]
+    segment_id = alkira_segment.test1.id
+    zone_name  = "DEFAULT"
   }
 }

--- a/alkira/resource_alkira_service_checkpoint.go
+++ b/alkira/resource_alkira_service_checkpoint.go
@@ -173,15 +173,15 @@ func resourceAlkiraCheckpoint() *schema.Resource {
 						"type": {
 							Description:  "The type of the management server. either `SMS` or `MDS`.",
 							Type:         schema.TypeString,
-							Optional:     true,
+							Required:     true,
 							ValidateFunc: validation.StringInSlice([]string{"SMS", "MDS"}, false),
 						},
-						"user_name": {
+						"username": {
 							Description: "The username of the management server.",
 							Type:        schema.TypeString,
 							Optional:    true,
 						},
-						"management_server_password": {
+						"password": {
 							Description: "The password of the management server.",
 							Type:        schema.TypeString,
 							Optional:    true,
@@ -423,7 +423,6 @@ func generateCheckpointRequest(d *schema.ResourceData, m interface{}) (*alkira.S
 	chpfwCredId := d.Get("credential_id").(string)
 
 	if 0 == len(chpfwCredId) {
-
 		log.Printf("[INFO] Creating Checkpoint Firewall Service Credentials")
 
 		chkpfwName := d.Get("name").(string) + "-" + randomNameSuffix()
@@ -434,7 +433,6 @@ func generateCheckpointRequest(d *schema.ResourceData, m interface{}) (*alkira.S
 			return nil, err
 		}
 		d.Set("credential_id", credentialId)
-
 	}
 
 	managementServer, err := expandCheckpointManagementServer(d.Get("name").(string), d.Get("management_server").(*schema.Set), m)

--- a/alkira/resource_alkira_service_checkpoint_helper.go
+++ b/alkira/resource_alkira_service_checkpoint_helper.go
@@ -29,7 +29,7 @@ func expandCheckpointManagementServer(name string, in *schema.Set, m interface{}
 		if v, ok := cfg["configuration_mode"].(string); ok {
 			mg.ConfigurationMode = v
 		}
-		if v, ok := cfg["management_server_password"].(string); ok {
+		if v, ok := cfg["password"].(string); ok {
 			manServerPass = v
 		}
 		if v, ok := cfg["credential_id"].(string); ok {
@@ -60,19 +60,20 @@ func expandCheckpointManagementServer(name string, in *schema.Set, m interface{}
 			mg.Reachability = v
 		}
 		if v, ok := cfg["segment_id"].(string); ok {
+			if v != "" {
+				segment, err := getSegmentNameById(v, m)
 
-			segment, err := getSegmentNameById(v, m)
+				if err != nil {
+					return nil, err
+				}
 
-			if err != nil {
-				return nil, err
+				mg.Segment = segment
 			}
-
-			mg.Segment = segment
 		}
 		if v, ok := cfg["type"].(string); ok {
 			mg.Type = v
 		}
-		if v, ok := cfg["user_name"].(string); ok {
+		if v, ok := cfg["username"].(string); ok {
 			mg.UserName = v
 		}
 	}

--- a/docs/resources/service_checkpoint.md
+++ b/docs/resources/service_checkpoint.md
@@ -114,15 +114,15 @@ Required:
 - `configuration_mode` (String) The configuration_mode specifies whether the firewall is to be automatically configured by Alkira or not. To automatically configure the firewall Alkira needs access to the CheckPoint management server. If you choose to use manual configuration Alkira will provide the customer information about the Checkpoint instances so that you can manually configure the firewall.
 - `global_cidr_list_id` (Number) The ID of the global cidr list to be associated with the management server.
 - `ips` (List of String) Management server IPs.
+- `type` (String) The type of the management server. either `SMS` or `MDS`.
 
 Optional:
 
 - `domain` (String) Management server domain.
-- `management_server_password` (String) The password of the management server.
+- `password` (String) The password of the management server.
 - `reachability` (String) Specifies whether the management server is publicly reachable or not. If the reachability is private then you need to provide the segment to be used to access the management server. Default value is `PUBLIC`.
 - `segment_id` (String) The IDs of the segment to be used to access the management server.
-- `type` (String) The type of the management server. either `SMS` or `MDS`.
-- `user_name` (String) The username of the management server.
+- `username` (String) The username of the management server.
 
 Read-Only:
 

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.18
 replace github.com/hashicorp/go-getter => github.com/hashicorp/go-getter v1.6.1
 
 require (
-	github.com/alkiranet/alkira-client-go v1.38.0
+	github.com/alkiranet/alkira-client-go v1.39.0
 	github.com/hashicorp/terraform-plugin-sdk v1.15.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.1.0
 	github.com/stretchr/testify v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -43,8 +43,8 @@ github.com/agext/levenshtein v1.2.2/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki
 github.com/agl/ed25519 v0.0.0-20170116200512-5312a6153412/go.mod h1:WPjqKcmVOxf0XSf3YxCJs6N6AOSrOx3obionmG7T0y0=
 github.com/alcortesm/tgz v0.0.0-20161220082320-9c5fe88206d7 h1:uSoVVbwJiQipAclBbw+8quDsfcvFjOpI5iCf4p/cqCs=
 github.com/alcortesm/tgz v0.0.0-20161220082320-9c5fe88206d7/go.mod h1:6zEj6s6u/ghQa61ZWa/C2Aw3RkjiTBOix7dkqa1VLIs=
-github.com/alkiranet/alkira-client-go v1.38.0 h1:PiUnq/vcRjYIl0XjUgmfyOGE3qaPoPzTfn39QEGTdN8=
-github.com/alkiranet/alkira-client-go v1.38.0/go.mod h1:wZZ6wETqhS7ED5JfTosY3fzXhslH0avHOiWr1I+wm8k=
+github.com/alkiranet/alkira-client-go v1.39.0 h1:/pHNBsSj+lSfIUml5v1T2SShS2oh4sChCn22GrDi5vY=
+github.com/alkiranet/alkira-client-go v1.39.0/go.mod h1:wZZ6wETqhS7ED5JfTosY3fzXhslH0avHOiWr1I+wm8k=
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239 h1:kFOfPq6dUM1hTo4JG6LR5AXSUEsOjtdm0kw0FtQtMJA=
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239/go.mod h1:2FmKhYUyUczH0OGQWaF5ceTx0UBShxjsH6f8oGKYe2c=
 github.com/apparentlymart/go-cidr v1.0.1 h1:NmIwLZ/KdsjIUlhf+/Np40atNXm/+lZ5txfTJ/SpF+U=

--- a/vendor/github.com/alkiranet/alkira-client-go/alkira/credentials.go
+++ b/vendor/github.com/alkiranet/alkira-client-go/alkira/credentials.go
@@ -61,6 +61,7 @@ type CredentialAzureVnet struct {
 	SecretKey      string `json:"secretKey"`
 	SubscriptionId string `json:"subscriptionId"`
 	TenantId       string `json:"tenantId"`
+	Environment    string `json:"environment,omitempty"`
 }
 
 type CredentialCheckPointFwService struct {

--- a/vendor/github.com/alkiranet/alkira-client-go/alkira/flow_collector.go
+++ b/vendor/github.com/alkiranet/alkira-client-go/alkira/flow_collector.go
@@ -1,0 +1,30 @@
+// Copyright (C) 2020-2023 Alkira Inc. All Rights Reserved.
+
+package alkira
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+type FlowCollector struct {
+	Id                   json.Number `json:"id"`
+	Name                 string      `json:"name"`
+	Description          string      `json:"description,omitempty"`
+	CollectorType        string      `json:"collectorType"`
+	Enabled              bool        `json:"enabled"`
+	DestinationIp        string      `json:"destinationIp,omitempty"`
+	DestinationFqdn      string      `json:"destinationFqdn,omitempty"`
+	DestinationPort      int         `json:"destinationPort"`
+	TransportProtocol    string      `json:"transportProtocol"`
+	ExportType           string      `json:"exportType"`
+	FlowRecordTemplateId int         `json:"flowRecordTemplateId"`
+	Cxps                 []string    `json:"cxps"`
+}
+
+// NewFlowCollector new flow collector
+func NewFlowCollector(ac *AlkiraClient) *AlkiraAPI[FlowCollector] {
+	uri := fmt.Sprintf("%s/tenantnetworks/%s/flow-collectors", ac.URI, ac.TenantNetworkId)
+	api := &AlkiraAPI[FlowCollector]{ac, uri, true}
+	return api
+}

--- a/vendor/github.com/alkiranet/alkira-client-go/alkira/policy_traffic_rules.go
+++ b/vendor/github.com/alkiranet/alkira-client-go/alkira/policy_traffic_rules.go
@@ -33,6 +33,7 @@ type PolicyRuleAction struct {
 	Action          string   `json:"action"`
 	ServiceTypeList []string `json:"serviceTypeList"`
 	ServiceList     []int    `json:"serviceList"`
+	FlowCollectors  []int    `json:"flowCollectors,omitempty"`
 }
 
 // NewTrafficPolicyRule new traffic policy rule

--- a/vendor/github.com/alkiranet/alkira-client-go/alkira/segment_resource.go
+++ b/vendor/github.com/alkiranet/alkira-client-go/alkira/segment_resource.go
@@ -10,6 +10,7 @@ import (
 type SegmentResource struct {
 	Id            json.Number                  `json:"id"`
 	Name          string                       `json:"name"`
+	Description   string                       `json:"description,omitempty"`
 	Segment       string                       `json:"segment"`
 	GroupId       int                          `json:"groupId,omitempty"` // response only
 	GroupPrefixes []SegmentResourceGroupPrefix `json:"groupPrefixes"`

--- a/vendor/github.com/alkiranet/alkira-client-go/alkira/service_checkpoint.go
+++ b/vendor/github.com/alkiranet/alkira-client-go/alkira/service_checkpoint.go
@@ -49,7 +49,7 @@ type CheckpointManagementServer struct {
 	GlobalCidrListId  int      `json:"globalCidrListId"`
 	Ips               []string `json:"ips"`
 	Reachability      string   `json:"reachability"`
-	Segment           string   `json:"segment"`
+	Segment           string   `json:"segment,omitempty"`
 	Type              string   `json:"type"`
 	UserName          string   `json:"userName"`
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -13,7 +13,7 @@ cloud.google.com/go/storage
 # github.com/agext/levenshtein v1.2.2
 ## explicit
 github.com/agext/levenshtein
-# github.com/alkiranet/alkira-client-go v1.38.0
+# github.com/alkiranet/alkira-client-go v1.39.0
 ## explicit; go 1.18
 github.com/alkiranet/alkira-client-go/alkira
 # github.com/apparentlymart/go-cidr v1.0.1


### PR DESCRIPTION
The segment in management_server of service_checkpoint is optional and it should be not sent in API.

+ Upgrade alkira-client-go to v1.39.0 to pick client fixes.
+ Rename "user_name" to "username" in management_server to be consistent.
+ Rename "management_server_password" to "password" to avoid duplicated name with block.
+ Update acceptance tests with new coverage case with management_server type as SMS.