### PR TITLE
AK-35228 Make advertise_default_route consistent across all related r…

### DIFF
--- a/acceptance/connector_ipsec.tf
+++ b/acceptance/connector_ipsec.tf
@@ -5,12 +5,6 @@ resource "alkira_connector_ipsec" "test" {
   size       = "SMALL"
   vpn_mode   = "ROUTE_BASED"
 
-  # segment_options {
-  #   name = "seg1"
-  #   disable_internet_exit = false
-  #   disable_advertise_on_prem_routes = false
-  # }
-
   routing_options {
     type                 = "DYNAMIC"
     customer_gateway_asn = "65512"

--- a/alkira/resource_alkira_connector_aruba_edge.go
+++ b/alkira/resource_alkira_connector_aruba_edge.go
@@ -41,6 +41,14 @@ func resourceAlkiraConnectorArubaEdge() *schema.Resource {
 				Type: schema.TypeSet,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
+						"advertise_defult_route": {
+							Description: "Enables or disables access to the internet " +
+								"when traffic arrives via this connector. The default " +
+								"value is `false`.",
+							Type:     schema.TypeBool,
+							Optional: true,
+							Default:  false,
+						},
 						"advertise_on_prem_routes": {
 							Description: "Allow routes from the branch/premises " +
 								"to be advertised to the cloud. The default " +
@@ -59,14 +67,6 @@ func resourceAlkiraConnectorArubaEdge() *schema.Resource {
 							Description: "The segment ID of the Aruba Edge connector.",
 							Type:        schema.TypeString,
 							Required:    true,
-						},
-						"disable_internet_exit": {
-							Description: "Enables or disables access to the internet " +
-								"when traffic arrives via this connector. The default " +
-								"value is False.",
-							Type:     schema.TypeBool,
-							Optional: true,
-							Default:  false,
 						},
 						"gateway_gbp_asn": {
 							Description: "The gateway BGP ASN.",

--- a/alkira/resource_alkira_connector_aruba_edge_helper.go
+++ b/alkira/resource_alkira_connector_aruba_edge_helper.go
@@ -92,7 +92,7 @@ func deflateArubaEdgeVrfMapping(vrf []alkira.ArubaEdgeVRFMapping, m interface{})
 			"advertise_on_prem_routes":      vrfmapping.AdvertiseOnPremRoutes,
 			"segment_id":                    strconv.Itoa(vrfmapping.AlkiraSegmentId),
 			"aruba_edge_connect_segment_id": arcSeg.Id,
-			"disable_internet_exit":         vrfmapping.DisableInternetExit,
+			"advertise_default_route":       !vrfmapping.DisableInternetExit,
 			"gateway_gbp_asn":               vrfmapping.GatewayBgpAsn,
 		}
 		mappings = append(mappings, i)
@@ -131,8 +131,8 @@ func expandArubaEdgeVrfMappings(in *schema.Set, m interface{}) ([]alkira.ArubaEd
 
 			arubaEdgeVRFMapping.ArubaEdgeConnectSegmentName = segment.Name
 		}
-		if v, ok := m["disable_internet_exit"].(bool); ok {
-			arubaEdgeVRFMapping.DisableInternetExit = v
+		if v, ok := m["advertise_default_route"].(bool); ok {
+			arubaEdgeVRFMapping.DisableInternetExit = !v
 		}
 		if v, ok := m["gateway_gbp_asn"].(int); ok {
 			arubaEdgeVRFMapping.GatewayBgpAsn = v

--- a/alkira/resource_alkira_connector_cisco_sdwan.go
+++ b/alkira/resource_alkira_connector_cisco_sdwan.go
@@ -147,16 +147,18 @@ func resourceAlkiraConnectorCiscoSdwan() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"advertise_on_prem_routes": {
-							Description: "Advertise On Prem Routes.",
-							Type:        schema.TypeBool,
-							Optional:    true,
-							Default:     false,
+							Description: "Advertise On Prem Routes. Default value " +
+								"is `false`.",
+							Type:     schema.TypeBool,
+							Optional: true,
+							Default:  false,
 						},
-						"allow_nat_exit": {
-							Description: "Allow NAT exit.",
-							Type:        schema.TypeBool,
-							Optional:    true,
-							Default:     true,
+						"advertise_default_route": {
+							Description: "Whether advertise default route of " +
+								"internet connector. Default value is `false`.",
+							Type:     schema.TypeBool,
+							Optional: true,
+							Default:  false,
 						},
 						"customer_asn": {
 							Description: "BGP ASN on the customer premise side. A typical value for 2 byte segment " +
@@ -254,7 +256,7 @@ func resourceConnectorCiscoSdwanRead(ctx context.Context, d *schema.ResourceData
 	for _, m := range connector.CiscoEdgeVrfMappings {
 		mapping := map[string]interface{}{
 			"advertise_on_prem_routes": m.AdvertiseOnPremRoutes,
-			"allow_nat_exit":           m.DisableInternetExit,
+			"advertise_default_route":  !m.DisableInternetExit,
 			"customer_asn":             m.CustomerAsn,
 			"segment_id":               m.SegmentId,
 			"vrf_id":                   m.Vrf,
@@ -377,8 +379,8 @@ func expandCiscoSdwanVrfMappings(in *schema.Set) []alkira.CiscoSdwanEdgeVrfMappi
 		if v, ok := t["advertise_on_prem_routes"].(bool); ok {
 			r.AdvertiseOnPremRoutes = v
 		}
-		if v, ok := t["allow_nat_exit"].(bool); ok {
-			r.DisableInternetExit = v
+		if v, ok := t["advertise_default_route"].(bool); ok {
+			r.DisableInternetExit = !v
 		}
 		if v, ok := t["customer_asn"].(int); ok {
 			r.CustomerAsn = v

--- a/alkira/resource_alkira_connector_ipsec.go
+++ b/alkira/resource_alkira_connector_ipsec.go
@@ -336,18 +336,21 @@ func resourceAlkiraConnectorIPSec() *schema.Resource {
 							Type:        schema.TypeString,
 							Required:    true,
 						},
-						"allow_nat_exit": {
-							Description: "Enable or disable access to the internet when traffic arrives via this connector. Default is `true`.",
-							Type:        schema.TypeBool,
-							Optional:    true,
-							Default:     true,
+						"advertise_default_route": {
+							Description: "Enable or disable access to the internet " +
+								"when traffic arrives via this connector. Default " +
+								"is `false`.",
+							Type:     schema.TypeBool,
+							Optional: true,
+							Default:  false,
 						},
 
 						"advertise_on_prem_routes": {
-							Description: "Additional options for each segment associated with the connector. Default is `false`.",
-							Type:        schema.TypeBool,
-							Optional:    true,
-							Default:     false,
+							Description: "Additional options for each segment " +
+								"associated with the connector. Default is `false`.",
+							Type:     schema.TypeBool,
+							Optional: true,
+							Default:  false,
 						},
 					},
 				},

--- a/alkira/resource_alkira_connector_ipsec_helper.go
+++ b/alkira/resource_alkira_connector_ipsec_helper.go
@@ -156,7 +156,7 @@ func expandConnectorIPSecSegmentOptions(in *schema.Set) (interface{}, error) {
 		segmentName, _ := segmentOptionsInput["name"].(string)
 		var segmentOption alkira.ConnectorIPSecSegmentOptions
 
-		if v, ok := segmentOptionsInput["allow_nat_exit"].(bool); ok {
+		if v, ok := segmentOptionsInput["advertise_default_route"].(bool); ok {
 			t := !v
 			segmentOption.DisableInternetExit = &t
 		}

--- a/alkira/resource_alkira_connector_vmware_sdwan.go
+++ b/alkira/resource_alkira_connector_vmware_sdwan.go
@@ -135,16 +135,18 @@ func resourceAlkiraConnectorVmwareSdwan() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"advertise_on_prem_routes": {
-							Description: "Advertise On Prem Routes.",
-							Type:        schema.TypeBool,
-							Optional:    true,
-							Default:     false,
+							Description: "Whether advertising On Prem Routes. " +
+								"Default value is `false`.",
+							Type:     schema.TypeBool,
+							Optional: true,
+							Default:  false,
 						},
-						"allow_nat_exit": {
-							Description: "Allow NAT exit.",
-							Type:        schema.TypeBool,
-							Optional:    true,
-							Default:     true,
+						"advertise_default_route": {
+							Description: "Whether advertise default route of " +
+								"internet connector. Default value is `false`.",
+							Type:     schema.TypeBool,
+							Optional: true,
+							Default:  false,
 						},
 						"gateway_bgp_asn": {
 							Description: "BGP ASN on the customer premise side. " +
@@ -246,7 +248,7 @@ func resourceConnectorVmwareSdwanRead(ctx context.Context, d *schema.ResourceDat
 	for _, m := range connector.VmWareSdWanVRFMappings {
 		mapping := map[string]interface{}{
 			"advertise_on_prem_routes":   m.AdvertiseOnPremRoutes,
-			"allow_nat_exit":             m.DisableInternetExit,
+			"advertise_default_route":    !m.DisableInternetExit,
 			"gateway_bgp_asn":            m.GatewayBgpAsn,
 			"segment_id":                 m.SegmentId,
 			"vmware_sdwang_segment_name": m.VmWareSdWanSegmentName,

--- a/alkira/resource_alkira_connector_vmware_sdwan_helper.go
+++ b/alkira/resource_alkira_connector_vmware_sdwan_helper.go
@@ -86,7 +86,7 @@ func expandVmwareSdwanVrfMappings(in *schema.Set) []alkira.VmwareSdwanVrfMapping
 		if v, ok := t["advertise_on_prem_routes"].(bool); ok {
 			r.AdvertiseOnPremRoutes = v
 		}
-		if v, ok := t["allow_nat_exit"].(bool); ok {
+		if v, ok := t["advertise_default_route"].(bool); ok {
 			r.DisableInternetExit = !v
 		}
 		if v, ok := t["gateway_bgp_asn"].(int); ok {

--- a/docs/resources/connector_aruba_edge.md
+++ b/docs/resources/connector_aruba_edge.md
@@ -102,7 +102,7 @@ Required:
 
 Optional:
 
+- `advertise_defult_route` (Boolean) Enables or disables access to the internet when traffic arrives via this connector. The default value is `false`.
 - `advertise_on_prem_routes` (Boolean) Allow routes from the branch/premises to be advertised to the cloud. The default value is False.
-- `disable_internet_exit` (Boolean) Enables or disables access to the internet when traffic arrives via this connector. The default value is False.
 
 

--- a/docs/resources/connector_cisco_sdwan.md
+++ b/docs/resources/connector_cisco_sdwan.md
@@ -89,8 +89,8 @@ Required:
 
 Optional:
 
-- `advertise_on_prem_routes` (Boolean) Advertise On Prem Routes.
-- `allow_nat_exit` (Boolean) Allow NAT exit.
+- `advertise_default_route` (Boolean) Whether advertise default route of internet connector. Default value is `false`.
+- `advertise_on_prem_routes` (Boolean) Advertise On Prem Routes. Default value is `false`.
 
 ## Import
 

--- a/docs/resources/connector_ipsec.md
+++ b/docs/resources/connector_ipsec.md
@@ -194,8 +194,8 @@ Required:
 
 Optional:
 
+- `advertise_default_route` (Boolean) Enable or disable access to the internet when traffic arrives via this connector. Default is `false`.
 - `advertise_on_prem_routes` (Boolean) Additional options for each segment associated with the connector. Default is `false`.
-- `allow_nat_exit` (Boolean) Enable or disable access to the internet when traffic arrives via this connector. Default is `true`.
 
 ## Import
 

--- a/docs/resources/connector_vmware_sdwan.md
+++ b/docs/resources/connector_vmware_sdwan.md
@@ -68,8 +68,8 @@ Required:
 
 Optional:
 
-- `advertise_on_prem_routes` (Boolean) Advertise On Prem Routes.
-- `allow_nat_exit` (Boolean) Allow NAT exit.
+- `advertise_default_route` (Boolean) Whether advertise default route of internet connector. Default value is `false`.
+- `advertise_on_prem_routes` (Boolean) Whether advertising On Prem Routes. Default value is `false`.
 - `gateway_bgp_asn` (Number) BGP ASN on the customer premise side. A typical value for 2 byte segment is `64523` and `4200064523` for 4 byte segment.
 
 


### PR DESCRIPTION
…esources

Make field advertise_default_route consistent across all related resources and be consistent with portal.

+ Make advertise_default_route across connector_aruba_edge, connector_cisco_sdwan, connector_ipsec and connector_vmware_sdwan.
+ The default value of `advertise_default_route` is `false`.
+ Update documentations.