### PR TITLE
AK-35713 Update default value of category in NAT policy resources

### DIFF
--- a/acceptance/policy_nat.tf
+++ b/acceptance/policy_nat.tf
@@ -1,0 +1,25 @@
+resource "alkira_policy_nat_rule" "test1" {
+  name          = "acceptance-basic"
+  description   = "acceptance basic NAT rule"
+  enabled       = false
+
+  match {
+    src_prefixes = ["any"]
+    dst_prefixes = ["any"]
+    protocol     = "any"
+  }
+
+  action {
+    src_addr_translation_type = "NONE"
+    dst_addr_translation_type = "NONE"
+  }
+}
+
+resource "alkira_policy_nat" "test1" {
+  name               = "acceptance-basic"
+  description        = "terraform test NAT policy"
+  type               = "INTRA_SEGMENT"
+  segment_id         = alkira_segment.test1.id
+  included_group_ids = [alkira_group.test1.id]
+  nat_rule_ids       = [alkira_policy_nat_rule.test1.id]
+}

--- a/alkira/resource_alkira_policy_nat.go
+++ b/alkira/resource_alkira_policy_nat.go
@@ -33,6 +33,16 @@ func resourceAlkiraPolicyNat() *schema.Resource {
 				Type:        schema.TypeString,
 				Optional:    true,
 			},
+			"category": {
+				Description: "The category of NAT policy. " +
+					"The vaule could be `DEFAULT` or " +
+					"`INTERNET_CONNECTOR`. Default value is " +
+					"`DEFAULT`.",
+				Type:         schema.TypeString,
+				Optional:     true,
+				Default:      "DEFAULT",
+				ValidateFunc: validation.StringInSlice([]string{"DEFAULT", "INTERNET_CONNECTOR"}, false),
+			},
 			"type": {
 				Description:  "The type of NAT policy, currently only `INTRA_SEGMENT`is supported.",
 				Type:         schema.TypeString,
@@ -66,13 +76,6 @@ func resourceAlkiraPolicyNat() *schema.Resource {
 				Type:        schema.TypeList,
 				Elem:        &schema.Schema{Type: schema.TypeInt},
 				Required:    true,
-			},
-			"category": {
-				Description: "The category of NAT policy, options are `DEFAULT` or `INTERNET_CONNECTOR`. A empty value in this field " +
-					"will be treated the same as a value of `DEFAULT`.",
-				Type:         schema.TypeString,
-				Optional:     true,
-				ValidateFunc: validation.StringInSlice([]string{"DEFAULT", "INTERNET_CONNECTOR"}, false),
 			},
 		},
 	}

--- a/alkira/resource_alkira_policy_nat_rule.go
+++ b/alkira/resource_alkira_policy_nat_rule.go
@@ -56,12 +56,12 @@ func resourceAlkiraPolicyNatRule() *schema.Resource {
 				Computed:    true,
 			},
 			"category": {
-				Description: "The category of NAT rule, options are " +
-					"`DEFAULT` or `INTERNET_CONNECTOR`. A empty " +
-					"value in this field will be treated the same " +
-					"as a value of `DEFAULT`.",
+				Description: "The category of NAT rule. The value could be " +
+					"`DEFAULT` or `INTERNET_CONNECTOR`. Default value is " +
+					"`DEFAULT`.",
 				Type:         schema.TypeString,
 				Optional:     true,
+				Default:      "DEFAULT",
 				ValidateFunc: validation.StringInSlice([]string{"DEFAULT", "INTERNET_CONNECTOR"}, false),
 			},
 			"match": {

--- a/docs/resources/policy_nat.md
+++ b/docs/resources/policy_nat.md
@@ -63,7 +63,7 @@ resource "alkira_policy_nat" "test" {
 
 ### Optional
 
-- `category` (String) The category of NAT policy, options are `DEFAULT` or `INTERNET_CONNECTOR`. A empty value in this field will be treated the same as a value of `DEFAULT`.
+- `category` (String) The category of NAT policy. The vaule could be `DEFAULT` or `INTERNET_CONNECTOR`. Default value is `DEFAULT`.
 - `description` (String) The description of the policy.
 - `excluded_group_ids` (List of Number) Excludes given associated connector from `included_groups`.Implicit group ID of a branch/on-premise connector for which a userdefined group is used in `included_groups` can be used here.
 

--- a/docs/resources/policy_nat_rule.md
+++ b/docs/resources/policy_nat_rule.md
@@ -27,7 +27,7 @@ This resource is usually used along with policy resources:`policy_nat_policy`.
 
 ### Optional
 
-- `category` (String) The category of NAT rule, options are `DEFAULT` or `INTERNET_CONNECTOR`. A empty value in this field will be treated the same as a value of `DEFAULT`.
+- `category` (String) The category of NAT rule. The value could be `DEFAULT` or `INTERNET_CONNECTOR`. Default value is `DEFAULT`.
 - `description` (String) The description of the policy rule.
 
 ### Read-Only


### PR DESCRIPTION
Update default value of category with "DEFAULT" in policy_nat and policy_nat_rule.

+ Update documentation with clearer descriptions.
+ Update acceptance tests with policy_nat.