### PR TITLE
Cleanup udr in azure vnet connector.

### DIFF
--- a/alkira/resource_alkira_connector_azure_vnet_helper.go
+++ b/alkira/resource_alkira_connector_azure_vnet_helper.go
@@ -221,10 +221,7 @@ func constructVnetRouting(d *schema.ResourceData) (*alkira.ConnectorVnetRouting,
 		ExportOptions: exportOptions,
 		ImportOptions: importOptions,
 		ServiceRoutes: serviceRoutes,
-	}
-
-	if len(udrLists.Subnets) > 0 || len(udrLists.Cidrs) > 0 {
-		vnetRouting.UdrLists = udrLists
+		UdrLists:      udrLists,
 	}
 
 	return &vnetRouting, nil


### PR DESCRIPTION
Revert changes to azure vnet connector UDR.
The backend now handles the nil values.
Also this code did not do anything as the UdrLists struct would be initalized with nil (default values) values when nothing was passed by the helper function.