### PR TITLE
AK-46000 - fixed aruba_edge_connect_segment.

### DIFF
--- a/alkira/resource_alkira_connector_aruba_edge.go
+++ b/alkira/resource_alkira_connector_aruba_edge.go
@@ -63,8 +63,8 @@ func resourceAlkiraConnectorArubaEdge() *schema.Resource {
 							Type:     schema.TypeString,
 							Required: true,
 						},
-						"aruba_edge_connect_segment_id": {
-							Description: "The segment ID of the Aruba Edge connector.",
+						"aruba_edge_connect_segment": {
+							Description: "The segment of the Aruba Edge connector.",
 							Type:        schema.TypeString,
 							Required:    true,
 						},

--- a/alkira/resource_alkira_connector_aruba_edge_helper.go
+++ b/alkira/resource_alkira_connector_aruba_edge_helper.go
@@ -79,21 +79,16 @@ func expandArubaEdgeInstances(in []interface{}, client *alkira.AlkiraClient) ([]
 }
 
 func deflateArubaEdgeVrfMapping(vrf []alkira.ArubaEdgeVRFMapping, m interface{}) ([]map[string]interface{}, error) {
-	api := alkira.NewSegment(m.(*alkira.AlkiraClient))
 
 	var mappings []map[string]interface{}
 	for _, vrfmapping := range vrf {
-		arcSeg, _, err := api.GetByName(vrfmapping.ArubaEdgeConnectSegmentName)
-		if err != nil {
-			return nil, err
-		}
 
 		i := map[string]interface{}{
-			"advertise_on_prem_routes":      vrfmapping.AdvertiseOnPremRoutes,
-			"segment_id":                    strconv.Itoa(vrfmapping.AlkiraSegmentId),
-			"aruba_edge_connect_segment_id": arcSeg.Id,
-			"advertise_default_route":       !vrfmapping.DisableInternetExit,
-			"gateway_gbp_asn":               vrfmapping.GatewayBgpAsn,
+			"advertise_on_prem_routes":   vrfmapping.AdvertiseOnPremRoutes,
+			"segment_id":                 strconv.Itoa(vrfmapping.AlkiraSegmentId),
+			"aruba_edge_connect_segment": vrfmapping.ArubaEdgeConnectSegmentName,
+			"advertise_default_route":    !vrfmapping.DisableInternetExit,
+			"gateway_gbp_asn":            vrfmapping.GatewayBgpAsn,
 		}
 		mappings = append(mappings, i)
 	}
@@ -102,8 +97,6 @@ func deflateArubaEdgeVrfMapping(vrf []alkira.ArubaEdgeVRFMapping, m interface{})
 }
 
 func expandArubaEdgeVrfMappings(in *schema.Set, m interface{}) ([]alkira.ArubaEdgeVRFMapping, error) {
-	api := alkira.NewSegment(m.(*alkira.AlkiraClient))
-
 	var mappings []alkira.ArubaEdgeVRFMapping
 	if in == nil || in.Len() == 0 {
 		return nil, errors.New("Invalid aruba edge mapping input: Cannot be nil or empty.")
@@ -123,13 +116,8 @@ func expandArubaEdgeVrfMappings(in *schema.Set, m interface{}) ([]alkira.ArubaEd
 			}
 			arubaEdgeVRFMapping.AlkiraSegmentId = i
 		}
-		if v, ok := m["aruba_edge_connect_segment_id"].(string); ok {
-			segment, _, err := api.GetById(v)
-			if err != nil {
-				return nil, err
-			}
-
-			arubaEdgeVRFMapping.ArubaEdgeConnectSegmentName = segment.Name
+		if v, ok := m["aruba_edge_connect_segment"].(string); ok {
+			arubaEdgeVRFMapping.ArubaEdgeConnectSegmentName = v
 		}
 		if v, ok := m["advertise_default_route"].(bool); ok {
 			arubaEdgeVRFMapping.DisableInternetExit = !v

--- a/docs/resources/connector_aruba_edge.md
+++ b/docs/resources/connector_aruba_edge.md
@@ -25,9 +25,9 @@ resource "alkira_connector_aruba_edge" "test1" {
   version         = "v668"
 
   aruba_edge_vrf_mapping {
-    segment_id                    = alkira_segment.test1.id
-    aruba_edge_connect_segment_id = "aruba_edge_segment_id"
-    gateway_gbp_asn               = 88
+    segment_id                 = alkira_segment.test1.id
+    aruba_edge_connect_segment = "aruba_edge_segment_name"
+    gateway_gbp_asn            = 88
   }
 
   instances {
@@ -97,7 +97,7 @@ Read-Only:
 
 Required:
 
-- `aruba_edge_connect_segment_id` (String) The segment ID of the Aruba Edge connector.
+- `aruba_edge_connect_segment` (String) The segment of the Aruba Edge connector.
 - `gateway_gbp_asn` (Number) The gateway BGP ASN.
 - `segment_id` (String) The segment ID associated with the Aruba Edge connector.
 

--- a/examples/resources/alkira_connector_aruba_edge/resource.tf
+++ b/examples/resources/alkira_connector_aruba_edge/resource.tf
@@ -10,9 +10,9 @@ resource "alkira_connector_aruba_edge" "test1" {
   version         = "v668"
 
   aruba_edge_vrf_mapping {
-    segment_id                    = alkira_segment.test1.id
-    aruba_edge_connect_segment_id = "aruba_edge_segment_id"
-    gateway_gbp_asn               = 88
+    segment_id                 = alkira_segment.test1.id
+    aruba_edge_connect_segment = "aruba_edge_segment_name"
+    gateway_gbp_asn            = 88
   }
 
   instances {


### PR DESCRIPTION
the aruba_edge_connect_segment used to take the id, instead of a name and it would then query the Alkira API to find the segment name of the Aruba segment, which would fail.
Now we take the aruba segment name and pass it onto the API.