### PR TITLE
AK-46447 Update acceptance tests to pass after REL49 upgrade

### DIFF
--- a/acceptance/lists.tf
+++ b/acceptance/lists.tf
@@ -37,7 +37,7 @@ resource "alkira_list_as_path" "test" {
 resource "alkira_list_global_cidr" "ciscofdtv" {
   name        = "acceptance-test"
   description = "terraform test global cidr list for cisco ftdv"
-  values      = ["192.168.0.0/25"]
+  values      = ["192.168.0.0/24"]
   cxp         = var.cxp
   tags        = ["CISCO_FTDV_FW"]
 }

--- a/acceptance/service_cisco_fdtv.tf
+++ b/acceptance/service_cisco_fdtv.tf
@@ -23,7 +23,7 @@ resource "alkira_service_cisco_ftdv" "cisco_ftdv_test" {
     admin_password       = "Test@2018"
     fmc_registration_key = "abcd12345"
     ftdv_nat_id          = "abcd1234"
-    version              = "7.2.1-40"
+    version              = "7.2.7-500"
     license_type         = "BRING_YOUR_OWN"
   }
 

--- a/alkira/resource_alkira_segment.go
+++ b/alkira/resource_alkira_segment.go
@@ -59,13 +59,6 @@ func resourceAlkiraSegment() *schema.Resource {
 				Type:        schema.TypeString,
 				Computed:    true,
 			},
-			"enable_overlapping_route_validation": {
-				Description: "Enable overlapping route validation. Default " +
-					"value is `false`. (**BETA**)",
-				Type:     schema.TypeBool,
-				Optional: true,
-				Default:  false,
-			},
 			"enable_ipv6_to_ipv4_translation": {
 				Description: "Enable IPv6 to IPv4 translation in the " +
 					"segment for internet application traffic. Default " +
@@ -182,7 +175,6 @@ func resourceSegmentRead(ctx context.Context, d *schema.ResourceData, m interfac
 	d.Set("asn", segment.Asn)
 	d.Set("description", segment.Description)
 	d.Set("enable_ipv6_to_ipv4_translation", segment.EnableIpv6ToIpv4Translation)
-	d.Set("enable_overlapping_route_validation", segment.OverlappingRouteValidationEnabled)
 	d.Set("enterprise_dns_server_ip", segment.EnterpriseDNSServerIP)
 	d.Set("name", segment.Name)
 	d.Set("reserve_public_ips", segment.ReservePublicIPsForUserAndSiteConnectivity)
@@ -298,7 +290,6 @@ func generateSegmentRequest(d *schema.ResourceData) (*alkira.Segment, error) {
 	seg := &alkira.Segment{
 		Asn:                               d.Get("asn").(int),
 		Description:                       d.Get("description").(string),
-		OverlappingRouteValidationEnabled: d.Get("enable_overlapping_route_validation").(bool),
 		EnableIpv6ToIpv4Translation:       d.Get("enable_ipv6_to_ipv4_translation").(bool),
 		EnterpriseDNSServerIP:             d.Get("enterprise_dns_server_ip").(string),
 		Name:                              d.Get("name").(string),
@@ -318,7 +309,10 @@ func setCidrsSegmentRead(d *schema.ResourceData, segment *alkira.Segment) {
 	if segment.IpBlock == "" || stringInSlice(segment.IpBlock, segment.IpBlocks.Values) {
 		d.Set("cidrs", segment.IpBlocks.Values)
 	} else {
-		// segment.IpBlocks.Values could be empty doesn't matter we just get an empty slice to append to
+		//
+		// segment.IpBlocks.Values could be empty doesn't matter we
+		// just get an empty slice to append to
+		//
 		c := segment.IpBlocks.Values[0:]
 		c = append(c, segment.IpBlock)
 		d.Set("cidrs", c)

--- a/alkira/resource_alkira_service_checkpoint_helper.go
+++ b/alkira/resource_alkira_service_checkpoint_helper.go
@@ -185,10 +185,10 @@ func setCheckpointInstances(d *schema.ResourceData, c []alkira.CheckpointInstanc
 		for _, ins := range c {
 			if cfg["id"].(int) == ins.Id || cfg["name"].(string) == ins.Name {
 				instance := map[string]interface{}{
-					"credential_id": ins.CredentialId,
-					"name":          ins.Name,
-					"id":            ins.Id,
-					"sic_key":       cfg["sic_key"].(string),
+					"credential_id":  ins.CredentialId,
+					"name":           ins.Name,
+					"id":             ins.Id,
+					"sic_key":        cfg["sic_key"].(string),
 					"enable_traffic": ins.TrafficEnabled,
 				}
 				instances = append(instances, instance)

--- a/alkira/resource_alkira_service_cisco_ftdv_helper.go
+++ b/alkira/resource_alkira_service_cisco_ftdv_helper.go
@@ -210,7 +210,7 @@ func setCiscoFTDvInstances(d *schema.ResourceData, c []alkira.CiscoFTDvInstance)
 					"id":                   ins.Id,
 					"license_type":         ins.LicenseType,
 					"version":              ins.Version,
-					"enable_traffic":        ins.TrafficEnabled,
+					"enable_traffic":       ins.TrafficEnabled,
 				}
 				instances = append(instances, instance)
 				break
@@ -235,11 +235,11 @@ func setCiscoFTDvInstances(d *schema.ResourceData, c []alkira.CiscoFTDvInstance)
 		// this will generate a diff
 		if new {
 			instance := map[string]interface{}{
-				"credential_id": instance.CredentialId,
-				"hostname":      instance.Hostname,
-				"id":            instance.Id,
-				"license_type":  instance.LicenseType,
-				"version":       instance.Version,
+				"credential_id":  instance.CredentialId,
+				"hostname":       instance.Hostname,
+				"id":             instance.Id,
+				"license_type":   instance.LicenseType,
+				"version":        instance.Version,
 				"enable_traffic": instance.TrafficEnabled,
 			}
 

--- a/alkira/resource_alkira_service_pan_helper.go
+++ b/alkira/resource_alkira_service_pan_helper.go
@@ -203,11 +203,11 @@ func setPanInstances(d *schema.ResourceData, c []alkira.ServicePanInstance) []ma
 		for _, ins := range c {
 			if cfg["id"].(int) == ins.Id || cfg["name"].(string) == ins.Name {
 				instance := map[string]interface{}{
-					"name":          ins.Name,
-					"id":            ins.Id,
-					"credential_id": ins.CredentialId,
-					"auth_key":      cfg["auth_key"].(string),
-					"auth_code":     cfg["auth_code"].(string),
+					"name":           ins.Name,
+					"id":             ins.Id,
+					"credential_id":  ins.CredentialId,
+					"auth_key":       cfg["auth_key"].(string),
+					"auth_code":      cfg["auth_code"].(string),
 					"enable_traffic": ins.TrafficEnabled,
 				}
 				instances = append(instances, instance)
@@ -233,9 +233,9 @@ func setPanInstances(d *schema.ResourceData, c []alkira.ServicePanInstance) []ma
 		// this will generate a diff
 		if new {
 			instance := map[string]interface{}{
-				"credential_id": instance.CredentialId,
-				"name":          instance.Name,
-				"id":            instance.Id,
+				"credential_id":  instance.CredentialId,
+				"name":           instance.Name,
+				"id":             instance.Id,
 				"enable_traffic": instance.TrafficEnabled,
 			}
 

--- a/docs/resources/connector_azure_expressroute.md
+++ b/docs/resources/connector_azure_expressroute.md
@@ -82,7 +82,7 @@ Optional:
 
 Read-Only:
 
-- `id` (Number)
+- `id` (Number) The ID of this resource.
 
 
 <a id="nestedblock--segment_options"></a>

--- a/docs/resources/segment.md
+++ b/docs/resources/segment.md
@@ -36,7 +36,6 @@ resource "alkira_segment" "test" {
 - `asn` (Number) The BGP ASN for the segment. Default value is `65514`.
 - `description` (String) The description of the segment.
 - `enable_ipv6_to_ipv4_translation` (Boolean) Enable IPv6 to IPv4 translation in the segment for internet application traffic. Default is `false`. (**BETA**)
-- `enable_overlapping_route_validation` (Boolean) Enable overlapping route validation. Default value is `false`. (**BETA**)
 - `enterprise_dns_server_ip` (String) The IP of the DNS server used within the segment. This DNS server may be used by the Alkira CXP to resolve the names of LDAP servers for example which are configured on the Remote Access Connector. (**BETA**)
 - `reserve_public_ips` (Boolean) Default value is `false`. When this is set to `true`. Alkira reserves public IPs which can be used to create underlay tunnels between an external service and Alkira. For example the reserved public IPs may be used to create tunnels to the Akamai Prolexic. (**BETA**)
 - `reserve_public_ips_for_cxps` (Set of String) Alkira reserves public IPs which can be used to create underlay tunnels between an external service to the specified Alkira CXPs. (**BETA**)

--- a/docs/resources/service_pan.md
+++ b/docs/resources/service_pan.md
@@ -133,9 +133,9 @@ resource "alkira_service_pan" "test1" {
 
 Optional:
 
-- `enable_traffic` (Boolean) Enable traffic on the PAN instance. Default is `true`
 - `auth_code` (String) PAN instance auth code. Only required when `license_type` is `BRING_YOUR_OWN`.
 - `auth_key` (String) PAN instance auth key. This is only required when `panorama_enabled` is set to `true`.
+- `enable_traffic` (Boolean) Enable traffic on the PAN instance. Default is `true`
 - `global_protect_segment_options` (Block Set) These options should be set only when global protect is enabled on service. These are set per segment. It is expected that on a segment where global protect is enabled at least 1 instance should be set with portal_enabled and at least one with gateway_enabled. It can be on the same instance or a different instance under the segment. (see [below for nested schema](#nestedblock--instance--global_protect_segment_options))
 - `name` (String) The name of the PAN instance.
 


### PR DESCRIPTION
Update acceptance tests to adapt new validations after new REL49 upgrade.

+ Update Cisco FDTV version.
+ Update global CIDR list for FDTV.
+ Disable overlapping validation in segment.