### PR TITLE
AK-46148 - add tunnel_protocol support for Cisco SDWAN

### DIFF
--- a/alkira/resource_alkira_connector_cisco_sdwan.go
+++ b/alkira/resource_alkira_connector_cisco_sdwan.go
@@ -192,8 +192,7 @@ func resourceAlkiraConnectorCiscoSdwan() *schema.Resource {
 			},
 			"tunnel_protocol": {
 				Description: "The tunnel protocol for the " +
-					"connector one of `IPSEC` or `GRE`. " +
-					"Default value is `IPSEC`.",
+					"connector one of `IPSEC` or `GRE`. ",
 				Type:     schema.TypeString,
 				Optional: true,
 				ValidateFunc: validation.StringInSlice(

--- a/alkira/resource_alkira_connector_cisco_sdwan.go
+++ b/alkira/resource_alkira_connector_cisco_sdwan.go
@@ -190,6 +190,16 @@ func resourceAlkiraConnectorCiscoSdwan() *schema.Resource {
 				},
 				Required: true,
 			},
+			"tunnel_protocol": {
+				Description: "The tunnel protocol for the " +
+					"connector one of `IPSEC` or `GRE`. " +
+					"Default value is `IPSEC`.",
+				Type:     schema.TypeString,
+				Optional: true,
+				ValidateFunc: validation.StringInSlice(
+					[]string{"IPSEC", "GRE"},
+					false),
+			},
 		},
 	}
 }
@@ -256,6 +266,7 @@ func resourceConnectorCiscoSdwanRead(ctx context.Context, d *schema.ResourceData
 	d.Set("name", connector.Name)
 	d.Set("size", connector.Size)
 	d.Set("type", connector.Type)
+	d.Set("tunnel_protocol", connector.TunnelProtocol)
 
 	// Set vedge
 	setVedge(d, connector)
@@ -368,6 +379,7 @@ func generateConnectorCiscoSdwanRequest(d *schema.ResourceData, m interface{}) (
 		Size:                 d.Get("size").(string),
 		Type:                 d.Get("type").(string),
 		Version:              d.Get("version").(string),
+		TunnelProtocol:       d.Get("tunnel_protocol").(string),
 	}
 
 	return connector, nil

--- a/docs/resources/connector_cisco_sdwan.md
+++ b/docs/resources/connector_cisco_sdwan.md
@@ -50,6 +50,7 @@ resource "alkira_connector_cisco_sdwan" "test" {
 - `billing_tag_ids` (Set of Number) Billing Tag IDs to be associated with the connector.
 - `enabled` (Boolean) Is the connector enabled. Default is `true`.
 - `group` (String) The group of the connector.
+- `tunnel_protocol` (String) The tunnel protocol for the connector one of `IPSEC` or `GRE`. Default value is `IPSEC`.
 - `type` (String) The type of Cisco SD-WAN. Default value is `VEDGE`.
 
 ### Read-Only

--- a/docs/resources/service_pan.md
+++ b/docs/resources/service_pan.md
@@ -136,7 +136,6 @@ Optional:
 
 - `auth_code` (String) PAN instance auth code. Only required when `license_type` is `BRING_YOUR_OWN`.
 - `auth_key` (String) PAN instance auth key. This is only required when `panorama_enabled` is set to `true`.
-- `enable_traffic` (Boolean) Enable traffic on the PAN instance. Default is `true`
 - `global_protect_segment_options` (Block Set) These options should be set only when global protect is enabled on service. These are set per segment. It is expected that on a segment where global protect is enabled at least 1 instance should be set with portal_enabled and at least one with gateway_enabled. It can be on the same instance or a different instance under the segment. (see [below for nested schema](#nestedblock--instance--global_protect_segment_options))
 - `name` (String) The name of the PAN instance.
 

--- a/vendor/github.com/alkiranet/alkira-client-go/alkira/connector_cisco_sdwan.go
+++ b/vendor/github.com/alkiranet/alkira-client-go/alkira/connector_cisco_sdwan.go
@@ -25,18 +25,19 @@ type CiscoSdwanEdgeInfo struct {
 }
 
 type ConnectorCiscoSdwan struct {
-	BillingTags          []int                      `json:"billingTags"`
-	CiscoEdgeInfo        []CiscoSdwanEdgeInfo       `json:"ciscoEdgeInfo"`
-	CiscoEdgeVrfMappings []CiscoSdwanEdgeVrfMapping `json:"ciscoEdgeVRFMappings"`
+	Name                 string                     `json:"name"`
 	Cxp                  string                     `json:"cxp"`
 	Group                string                     `json:"group,omitempty"`
-	Enabled              bool                       `json:"enabled"`
-	Name                 string                     `json:"name"`
-	Id                   json.Number                `json:"id,omitempty"`              // response only
-	ImplicitGroupId      int                        `json:"implicitGroupId,omitempty"` // response only
+	Id                   json.Number                `json:"id,omitempty"`
 	Size                 string                     `json:"size"`
 	Type                 string                     `json:"type,omitempty"`
 	Version              string                     `json:"version"`
+	TunnelProtocol       string                     `json:"tunnelProtocol,omitempty"`
+	CiscoEdgeInfo        []CiscoSdwanEdgeInfo       `json:"ciscoEdgeInfo"`
+	CiscoEdgeVrfMappings []CiscoSdwanEdgeVrfMapping `json:"ciscoEdgeVRFMappings"`
+	BillingTags          []int                      `json:"billingTags"`
+	ImplicitGroupId      int                        `json:"implicitGroupId,omitempty"`
+	Enabled              bool                       `json:"enabled"`
 }
 
 // NewConnectorCiscoSdwan initialize a new connector


### PR DESCRIPTION
add tunnel_protocol support for Cisco SDWAN

update docs.
removed `enable_traffic` field from PAN docs.