### PR TITLE
AK-47183 - Size Validations for some Cloud connectors

### DIFF
--- a/alkira/resource_alkira_connector_aws_vpc.go
+++ b/alkira/resource_alkira_connector_aws_vpc.go
@@ -115,10 +115,11 @@ func resourceAlkiraConnectorAwsVpc() *schema.Resource {
 				Required: true,
 			},
 			"size": {
-				Description: "The size of the connector, one of `SMALL`, `MEDIUM`, " +
+				Description: "The size of the connector, one of `5XSMALL`,`XSMALL`,`SMALL`, `MEDIUM`, " +
 					"`LARGE`, `2LARGE`, `5LARGE`, `10LARGE`, `20LARGE`.",
 				Type:     schema.TypeString,
 				Required: true,
+			},
 			"tgw_connect_enabled": {
 				Description: "When it's set to `true`, Alkira will use TGW Connect " +
 					"attachments to build connection to AWS Transit Gateway. " +

--- a/alkira/resource_alkira_connector_aws_vpc.go
+++ b/alkira/resource_alkira_connector_aws_vpc.go
@@ -119,10 +119,6 @@ func resourceAlkiraConnectorAwsVpc() *schema.Resource {
 					"`LARGE`, `2LARGE`, `5LARGE`, `10LARGE`, `20LARGE`.",
 				Type:     schema.TypeString,
 				Required: true,
-				ValidateFunc: validation.StringInSlice([]string{
-					"SMALL", "MEDIUM", "LARGE", "2LARGE",
-					"5LARGE", "10LARGE", "20LARGE"}, false),
-			},
 			"tgw_connect_enabled": {
 				Description: "When it's set to `true`, Alkira will use TGW Connect " +
 					"attachments to build connection to AWS Transit Gateway. " +

--- a/alkira/resource_alkira_connector_azure_vnet.go
+++ b/alkira/resource_alkira_connector_azure_vnet.go
@@ -230,9 +230,6 @@ func resourceAlkiraConnectorAzureVnet() *schema.Resource {
 					"`LARGE`, `2LARGE`, `5LARGE`.",
 				Type:     schema.TypeString,
 				Required: true,
-				ValidateFunc: validation.StringInSlice([]string{
-					"SMALL", "MEDIUM", "LARGE", `2LARGE`,
-					`5LARGE`}, false),
 			},
 			"customer_asn": {
 				Description: "A specific BGP ASN for the connector. This cannot be specified " +

--- a/alkira/resource_alkira_connector_azure_vnet.go
+++ b/alkira/resource_alkira_connector_azure_vnet.go
@@ -226,7 +226,7 @@ func resourceAlkiraConnectorAzureVnet() *schema.Resource {
 				Optional: true,
 			},
 			"size": {
-				Description: "The size of the connector, one of `SMALL`, `MEDIUM`, " +
+				Description: "The size of the connector, one of `5XSMALL`,`XSMALL`,`SMALL`, `MEDIUM`, " +
 					"`LARGE`, `2LARGE`, `5LARGE`.",
 				Type:     schema.TypeString,
 				Required: true,

--- a/alkira/resource_alkira_connector_gcp_vpc.go
+++ b/alkira/resource_alkira_connector_gcp_vpc.go
@@ -172,8 +172,6 @@ func resourceAlkiraConnectorGcpVpc() *schema.Resource {
 					"`MEDIUM`, `LARGE`.",
 				Type:     schema.TypeString,
 				Required: true,
-				ValidateFunc: validation.StringInSlice([]string{
-					"SMALL", "MEDIUM", "LARGE"}, false),
 			},
 			"customer_asn": {
 				Description: "A specific BGP ASN for the connector. This " +

--- a/alkira/resource_alkira_connector_gcp_vpc.go
+++ b/alkira/resource_alkira_connector_gcp_vpc.go
@@ -168,7 +168,7 @@ func resourceAlkiraConnectorGcpVpc() *schema.Resource {
 				Required: true,
 			},
 			"size": {
-				Description: "The size of the connector, one of `SMALL`, " +
+				Description: "The size of the connector, one of `5XSMALL`,`XSMALL`,`SMALL`, " +
 					"`MEDIUM`, `LARGE`.",
 				Type:     schema.TypeString,
 				Required: true,

--- a/alkira/resource_alkira_connector_oci_vcn.go
+++ b/alkira/resource_alkira_connector_oci_vcn.go
@@ -97,9 +97,8 @@ func resourceAlkiraConnectorOciVcn() *schema.Resource {
 			"size": {
 				Description: "The size of the connector, one of `SMALL`, " +
 					"`MEDIUM`, `LARGE`.",
-				Type:         schema.TypeString,
-				Required:     true,
-				ValidateFunc: validation.StringInSlice([]string{"SMALL", "MEDIUM", "LARGE"}, false),
+				Type:     schema.TypeString,
+				Required: true,
 			},
 			"vcn_id": {
 				Description: "The OCID of the VCN.",

--- a/alkira/resource_alkira_connector_oci_vcn.go
+++ b/alkira/resource_alkira_connector_oci_vcn.go
@@ -95,7 +95,7 @@ func resourceAlkiraConnectorOciVcn() *schema.Resource {
 				Required: true,
 			},
 			"size": {
-				Description: "The size of the connector, one of `SMALL`, " +
+				Description: "The size of the connector, one of `5XSMALL`,`XSMALL`,`SMALL`, " +
 					"`MEDIUM`, `LARGE`.",
 				Type:     schema.TypeString,
 				Required: true,

--- a/docs/resources/connector_aws_vpc.md
+++ b/docs/resources/connector_aws_vpc.md
@@ -102,7 +102,7 @@ resource "alkira_connector_aws_vpc" "connector" {
 - `cxp` (String) The CXP where the connector should be provisioned.
 - `name` (String) The name of the connector.
 - `segment_id` (String) The ID of segments associated with the connector. Currently, only `1` segment is allowed.
-- `size` (String) The size of the connector, one of `SMALL`, `MEDIUM`, `LARGE`, `2LARGE`, `5LARGE`, `10LARGE`, `20LARGE`.
+- `size` (String) The size of the connector, one of `5XSMALL`,`XSMALL`,`SMALL`, `MEDIUM`, `LARGE`, `2LARGE`, `5LARGE`, `10LARGE`, `20LARGE`.
 - `vpc_id` (String) The ID of the target VPC.
 
 ### Optional

--- a/docs/resources/connector_azure_expressroute.md
+++ b/docs/resources/connector_azure_expressroute.md
@@ -82,7 +82,7 @@ Optional:
 
 Read-Only:
 
-- `id` (Number) The ID of this resource.
+- `id` (Number)
 
 
 <a id="nestedblock--segment_options"></a>

--- a/docs/resources/connector_azure_vnet.md
+++ b/docs/resources/connector_azure_vnet.md
@@ -107,7 +107,7 @@ resource "alkira_connector_azure_vnet" "subnet" {
 - `cxp` (String) The CXP where the connector should be provisioned.
 - `name` (String) The name of the connector.
 - `segment_id` (String) The ID of the segment assoicated with the connector.
-- `size` (String) The size of the connector, one of `SMALL`, `MEDIUM`, `LARGE`, `2LARGE`, `5LARGE`.
+- `size` (String) The size of the connector, one of `5XSMALL`,`XSMALL`,`SMALL`, `MEDIUM`, `LARGE`, `2LARGE`, `5LARGE`.
 
 ### Optional
 

--- a/docs/resources/connector_gcp_vpc.md
+++ b/docs/resources/connector_gcp_vpc.md
@@ -99,7 +99,7 @@ resource "alkira_connector_gcp_vpc" "gcp_subnet" {
 - `gcp_vpc_name` (String) GCP VPC name.
 - `name` (String) The name of the connector.
 - `segment_id` (String) The ID of the segment associated with the connector.
-- `size` (String) The size of the connector, one of `SMALL`, `MEDIUM`, `LARGE`.
+- `size` (String) The size of the connector, one of `5XSMALL`,`XSMALL`,`SMALL`, `MEDIUM`, `LARGE`.
 
 ### Optional
 

--- a/docs/resources/connector_oci_vcn.md
+++ b/docs/resources/connector_oci_vcn.md
@@ -54,7 +54,7 @@ resource "alkira_connector_oci_vcn" "test" {
 - `name` (String) The name of the connector.
 - `oci_region` (String) OCI region of the VCN.
 - `segment_id` (String) The ID of segments associated with the connector. Currently, only `1` segment is allowed.
-- `size` (String) The size of the connector, one of `SMALL`, `MEDIUM`, `LARGE`.
+- `size` (String) The size of the connector, one of `5XSMALL`,`XSMALL`,`SMALL`, `MEDIUM`, `LARGE`.
 - `vcn_id` (String) The OCID of the VCN.
 
 ### Optional


### PR DESCRIPTION
AWS VPC, Azure VNET, GCP VPC and OCI VCN now support  `5XSMALL` and `XSMALL` sizes.

As discussed previously , removed size validations from the provider, the sizes will be validated in the back-end.
