### PR TITLE
AK-54500 and AK-54504 - properly set the segmentName for the global segmentOptions

### DIFF
--- a/alkira/resource_alkira_connector_azure_expressroute.go
+++ b/alkira/resource_alkira_connector_azure_expressroute.go
@@ -205,7 +205,7 @@ func resourceAlkiraConnectorAzureExpressRoute() *schema.Resource {
 																Description: "The ID of the IPSec Tunnel " +
 																	"Profile (`connector_ipsec_tunnel_profile`). ",
 																Type:     schema.TypeInt,
-																Optional: true,
+																Required: true,
 															},
 															"ike_version": {
 																Description: "The IKE protocol version. Currently, only `IKEv2` is supported.",
@@ -217,19 +217,19 @@ func resourceAlkiraConnectorAzureExpressRoute() *schema.Resource {
 																Description: "The pre-shared key for tunnel authentication. " +
 																	"This field is sensitive and will not be displayed in logs.",
 																Type:      schema.TypeString,
-																Optional:  true,
+																Required:  true,
 																Sensitive: true,
 															},
 															"remote_auth_type": {
 																Description: "The authentication type for the remote endpoint. " +
 																	"Only `FQDN` iscurrently supported.",
 																Type:     schema.TypeString,
-																Optional: true,
+																Required: true,
 															},
 															"remote_auth_value": {
 																Description: "The authentication value for the remote endpoint. This field is sensitive.",
 																Type:        schema.TypeString,
-																Optional:    true,
+																Required:    true,
 																Sensitive:   true,
 															},
 														},
@@ -361,8 +361,16 @@ func resourceConnectorAzureExpressRouteRead(ctx context.Context, d *schema.Resou
 
 	segments := make([]map[string]interface{}, len(connector.SegmentOptions))
 	for i, seg := range connector.SegmentOptions {
+		segmentId, err := getSegmentIdByName(seg.SegmentName, m)
+		if err != nil {
+			return diag.Diagnostics{{
+				Severity: diag.Warning,
+				Detail:   fmt.Sprintf("%s", err),
+			}}
+
+		}
 		segments[i] = map[string]interface{}{
-			"segment_id":               seg.SegmentId,
+			"segment_id":               segmentId,
 			"customer_asn":             seg.CustomerAsn,
 			"disable_internet_exit":    seg.DisableInternetExit,
 			"advertise_on_prem_routes": seg.AdvertiseOnPremRoutes,

--- a/alkira/resource_alkira_connector_azure_expressroute_helper.go
+++ b/alkira/resource_alkira_connector_azure_expressroute_helper.go
@@ -163,8 +163,12 @@ func expandAzureExpressRouteSegments(seg []interface{}, m interface{}) ([]alkira
 	for i, segment := range seg {
 		r := alkira.ConnectorAzureExpressRouteSegment{}
 		instanceCfg := segment.(map[string]interface{})
-		if v, ok := instanceCfg["segment_name"].(string); ok {
-			r.SegmentName = v
+		if v, ok := instanceCfg["segment_id"].(string); ok {
+			segmentName, err := getSegmentNameById(v, m)
+			if err != nil {
+				return nil, err
+			}
+			r.SegmentName = segmentName
 		}
 		if v, ok := instanceCfg["customer_asn"].(int); ok {
 			r.CustomerAsn = v

--- a/docs/resources/connector_azure_expressroute.md
+++ b/docs/resources/connector_azure_expressroute.md
@@ -355,15 +355,15 @@ Required:
 Required:
 
 - `name` (String) A unique name for the tunnel.
+- `pre_shared_key` (String, Sensitive) The pre-shared key for tunnel authentication. This field is sensitive and will not be displayed in logs.
+- `profile_id` (Number) The ID of the IPSec Tunnel Profile (`connector_ipsec_tunnel_profile`).
+- `remote_auth_type` (String) The authentication type for the remote endpoint. Only `FQDN` iscurrently supported.
+- `remote_auth_value` (String, Sensitive) The authentication value for the remote endpoint. This field is sensitive.
 
 Optional:
 
 - `ike_version` (String) The IKE protocol version. Currently, only `IKEv2` is supported.
 - `initiator` (Boolean) Whether this endpoint initiates the tunnel connection.
-- `pre_shared_key` (String, Sensitive) The pre-shared key for tunnel authentication. This field is sensitive and will not be displayed in logs.
-- `profile_id` (Number) The ID of the IPSec Tunnel Profile (`connector_ipsec_tunnel_profile`).
-- `remote_auth_type` (String) The authentication type for the remote endpoint. Only `FQDN` iscurrently supported.
-- `remote_auth_value` (String, Sensitive) The authentication value for the remote endpoint. This field is sensitive.
 
 Read-Only:
 


### PR DESCRIPTION
properly set the segmentName for the global segmentOptions.
Make all the fields required inside customer gateway tunnel.