### PR TITLE
AK-54865 - remove default value for `ike_version`.

### DIFF
--- a/alkira/resource_alkira_connector_azure_expressroute.go
+++ b/alkira/resource_alkira_connector_azure_expressroute.go
@@ -212,7 +212,6 @@ func resourceAlkiraConnectorAzureExpressRoute() *schema.Resource {
 																Description: "The IKE protocol version. Currently, only `IKEv2` is supported.",
 																Type:        schema.TypeString,
 																Optional:    true,
-																Default:     "IKEv2",
 															},
 															"pre_shared_key": {
 																Description: "The pre-shared key for tunnel authentication. " +

--- a/docs/resources/connector_azure_expressroute.md
+++ b/docs/resources/connector_azure_expressroute.md
@@ -379,7 +379,7 @@ Read-Only:
 Required:
 
 - `customer_asn` (Number) ASN on the customer premise side.
-- `segment_id` (Number) The ID of the segment.
+- `segment_id` (String) The ID of the segment.
 
 Optional:
 


### PR DESCRIPTION
If `ike_version` is sent in the payload, other fields like remote auth are required by the API.