### PR TITLE
AK-55863 - support new fields for route policy

### DIFF
--- a/alkira/resource_alkira_policy_routing.go
+++ b/alkira/resource_alkira_policy_routing.go
@@ -71,6 +71,19 @@ func resourceAlkiraPolicyRouting() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 			},
+			"target_connector_category": {
+				Description: "The category of connectors this policy targets. " +
+					"Value could be `USERS_AND_SITES` or `CLOUD`. Default is `USERS_AND_SITES`.",
+				Type:         schema.TypeString,
+				Optional:     true,
+				Default:      "USERS_AND_SITES",
+				ValidateFunc: validation.StringInSlice([]string{"USERS_AND_SITES", "CLOUD"}, false),
+			},
+			"source_routes_prefix_list_id": {
+				Description: "Prefix list ID to source routes from cloud connectors.",
+				Type:        schema.TypeInt,
+				Optional:    true,
+			},
 			"included_group_ids": {
 				Description: "Defines the scope for the policy. Connector associated " +
 					"with group IDs metioned here is where this policy would be applied. " +
@@ -198,6 +211,12 @@ func resourceAlkiraPolicyRouting() *schema.Resource {
 							Type:     schema.TypeString,
 							Optional: true,
 						},
+						"set_med": {
+							Description: "Multi Exit Discriminator. BGP attribute to suggest " +
+								"the preferred path into your network. Lower values are more preferred.",
+							Type:     schema.TypeInt,
+							Optional: true,
+						},
 						"set_community": {
 							Description: "Allows to add one or more community " +
 								"attributes to the existing communities on the " +
@@ -316,6 +335,8 @@ func resourcePolicyRoutingRead(ctx context.Context, d *schema.ResourceData, m in
 	d.Set("excluded_group_ids", policy.ExcludedGroups)
 	d.Set("included_group_ids", policy.IncludedGroups)
 	d.Set("name", policy.Name)
+	d.Set("target_connector_category", policy.TargetConnectorCategory)
+	d.Set("source_routes_prefix_list_id", policy.SourceRoutesPrefixListId)
 
 	//
 	// Set segment
@@ -454,6 +475,8 @@ func generatePolicyRoutingRequest(d *schema.ResourceData, m interface{}) (*alkir
 		AdvertiseOnPremRoutes:         d.Get("advertise_on_prem_routes").(bool),
 		EnableASOverride:              enableASOverride,
 		AdvertiseCustomRoutesPrefixId: d.Get("advertise_custom_routes_prefix_id").(int),
+		TargetConnectorCategory:       d.Get("target_connector_category").(string),
+		SourceRoutesPrefixListId:      d.Get("source_routes_prefix_list_id").(int),
 		Rules:                         rules,
 	}
 

--- a/alkira/resource_alkira_policy_routing_helper.go
+++ b/alkira/resource_alkira_policy_routing_helper.go
@@ -70,6 +70,9 @@ func expandPolicyRoutingRuleSet(in map[string]interface{}) (*alkira.RoutePolicyR
 	if v, ok := in["set_extended_community"].(string); ok {
 		set.ExtendedCommunity = v
 	}
+	if v, ok := in["set_med"].(int); ok {
+		set.Med = v
+	}
 
 	return &set, nil
 }
@@ -195,6 +198,7 @@ func setPolicyRoutingRules(in []alkira.RoutePolicyRules, d *schema.ResourceData)
 			r["set_as_path_prepend"] = rule.Set.AsPathPrepend
 			r["set_community"] = rule.Set.Community
 			r["set_extended_community"] = rule.Set.ExtendedCommunity
+			r["set_med"] = rule.Set.Med
 		}
 
 		if rule.InterCxpRoutesRedistribution != nil {

--- a/docs/resources/policy_routing.md
+++ b/docs/resources/policy_routing.md
@@ -56,6 +56,8 @@ resource "alkira_policy_routing" "test" {
 - `enabled` (Boolean) Whether the routing policy is enabled. By default, it is set to `false`.
 - `excluded_group_ids` (List of Number) Excludes given associated connector from `included_groups`. Implicit group ID of a branch/on-premise connector for which a user defined group is used in `included_groups` can be used here.
 - `rule` (Block List) (see [below for nested schema](#nestedblock--rule))
+- `source_routes_prefix_list_id` (Number) Prefix list ID to source routes from cloud connectors.
+- `target_connector_category` (String) The category of connectors this policy targets. Value could be `USERS_AND_SITES` or `CLOUD`. Default is `USERS_AND_SITES`.
 
 ### Read-Only
 
@@ -86,6 +88,7 @@ Optional:
 - `set_as_path_prepend` (String) Allows to prepend one or more AS numbers to the current AS PATH. Each AS number can be a value from 0 through 65535. Example - 100 100 100.
 - `set_community` (String) Allows to add one or more community attributes to the existing communities on the route. Community attribute is specified in this format: `as-number:community-value`. as-number and community-value can be a value from `0` through `65535`. Example: `65512:20 65512:21`.
 - `set_extended_community` (String) Allows to add one or more extended community attributes to the existing extended communities on the route. Extended community attribute is specified in this format: `type:administrator:assigned-number`. Currently only type origin(soo) is supported.
+- `set_med` (Number) Multi Exit Discriminator. BGP attribute to suggest the preferred path into your network. Lower values are more preferred.
 
 Read-Only:
 

--- a/vendor/github.com/alkiranet/alkira-client-go/alkira/policy_route.go
+++ b/vendor/github.com/alkiranet/alkira-client-go/alkira/policy_route.go
@@ -20,6 +20,8 @@ type RoutePolicy struct {
 	AdvertiseOnPremRoutes         bool               `json:"advertiseOnPremRoutes,omitempty"`
 	AdvertiseCustomRoutesPrefixId int                `json:"advertiseCustomRoutesPrefixId,omitempty"`
 	EnableASOverride              *bool              `json:"enableASOverride,omitempty"`
+	TargetConnectorCategory       string             `json:"targetConnectorCategory,omitempty"`
+	SourceRoutesPrefixListId      int                `json:"sourceRoutesPrefixListId,omitempty"`
 	Rules                         []RoutePolicyRules `json:"rules,omitempty"`
 }
 
@@ -47,6 +49,7 @@ type RoutePolicyRulesSet struct {
 	AsPathPrepend     string `json:"asPathPrepend"`
 	Community         string `json:"community"`
 	ExtendedCommunity string `json:"extendedCommunity"`
+	Med               int    `json:"med,omitempty"`
 }
 
 type RoutePolicyRulesInterCxpRoutesRedistribution struct {


### PR DESCRIPTION
targetConnectorCategory to differentiate between traditional (on-prem) and cloud-based route policies.

sourceRoutesPrefixListId used to source routes from cloud connectors 

set.med BGP attribute used to suggest the preferred path into a network. Lower values are more preferred.