### PR TITLE
AK-55832 - add new fields to route policy for branch connectors.

### DIFF
--- a/alkira/resource_alkira_policy_routing.go
+++ b/alkira/resource_alkira_policy_routing.go
@@ -208,6 +208,13 @@ func resourceAlkiraPolicyRouting() *schema.Resource {
 							Type:     schema.TypeString,
 							Optional: true,
 						},
+						"set_as_path_replace_with_segment_asn": {
+							Description: "ASNs that will be replaced with the local segment ASN. " +
+								"Accepts a comma-separated string of ASNs or 'ALL'. Can be null. " +
+								"This option can be applied only to USERS_AND_SITES connectors.",
+							Type:     schema.TypeString,
+							Optional: true,
+						},
 						"set_extended_community": {
 							Description: "Allows to add one or more extended " +
 								"community attributes to the existing extended " +

--- a/alkira/resource_alkira_policy_routing_helper.go
+++ b/alkira/resource_alkira_policy_routing_helper.go
@@ -70,6 +70,9 @@ func expandPolicyRoutingRuleSet(in map[string]interface{}) (*alkira.RoutePolicyR
 	if v, ok := in["set_extended_community"].(string); ok {
 		set.ExtendedCommunity = v
 	}
+	if v, ok := in["set_as_path_replace_with_segment_asn"].(string); ok {
+		set.AsPathReplaceWithSegmentAsn = v
+	}
 
 	return &set, nil
 }
@@ -195,6 +198,9 @@ func setPolicyRoutingRules(in []alkira.RoutePolicyRules, d *schema.ResourceData)
 			r["set_as_path_prepend"] = rule.Set.AsPathPrepend
 			r["set_community"] = rule.Set.Community
 			r["set_extended_community"] = rule.Set.ExtendedCommunity
+			if rule.Set.AsPathReplaceWithSegmentAsn != "" {
+				r["set_as_path_replace_with_segment_asn"] = rule.Set.AsPathReplaceWithSegmentAsn
+			}
 		}
 
 		if rule.InterCxpRoutesRedistribution != nil {

--- a/docs/resources/policy_routing.md
+++ b/docs/resources/policy_routing.md
@@ -84,6 +84,7 @@ Optional:
 - `routes_distribution_restricted_cxps` (List of String) List of cxps to which routes distribution is restricted. Should be used only with distributionType `RESTRICTED_CXPS`.
 - `routes_distribution_type` (String) Redistribute routes that match with this rule match codition to. The value could be `ALL`, `LOCAL_ONLY` and `RESTRICTED_CXPS`.
 - `set_as_path_prepend` (String) Allows to prepend one or more AS numbers to the current AS PATH. Each AS number can be a value from 0 through 65535. Example - 100 100 100.
+- `set_as_path_replace_with_segment_asn` (String) ASNs that will be replaced with the local segment ASN. Accepts a comma-separated string of ASNs or 'ALL'. Can be null. This option can be applied only to USERS_AND_SITES connectors.
 - `set_community` (String) Allows to add one or more community attributes to the existing communities on the route. Community attribute is specified in this format: `as-number:community-value`. as-number and community-value can be a value from `0` through `65535`. Example: `65512:20 65512:21`.
 - `set_extended_community` (String) Allows to add one or more extended community attributes to the existing extended communities on the route. Extended community attribute is specified in this format: `type:administrator:assigned-number`. Currently only type origin(soo) is supported.
 

--- a/vendor/github.com/alkiranet/alkira-client-go/alkira/policy_route.go
+++ b/vendor/github.com/alkiranet/alkira-client-go/alkira/policy_route.go
@@ -44,9 +44,10 @@ type RoutePolicyRulesMatch struct {
 }
 
 type RoutePolicyRulesSet struct {
-	AsPathPrepend     string `json:"asPathPrepend"`
-	Community         string `json:"community"`
-	ExtendedCommunity string `json:"extendedCommunity"`
+	AsPathPrepend               string `json:"asPathPrepend"`
+	Community                   string `json:"community"`
+	ExtendedCommunity           string `json:"extendedCommunity"`
+	AsPathReplaceWithSegmentAsn string `json:"asPathReplaceWithSegmentAsn,omitempty"`
 }
 
 type RoutePolicyRulesInterCxpRoutesRedistribution struct {


### PR DESCRIPTION
set.asPathReplaceWithSegmentAsn will accept comma separated string of ASNs or ALL - these are the ASNs that will be replaced with the local segment ASN. Can be null