### PR TITLE
AK-56066 - make tcp probe schema consistent with other probe types.

### DIFF
--- a/alkira/resource_alkira_probe_tcp.go
+++ b/alkira/resource_alkira_probe_tcp.go
@@ -31,26 +31,10 @@ func resourceAlkiraProbeTCP() *schema.Resource {
 				Optional:    true,
 				Default:     true,
 			},
-			"network_entity": {
-				Description: "Network entity configuration.",
-				Type:        schema.TypeList,
+			"network_entity_id": {
+				Description: "The ID of the internet application network entity to probe.",
+				Type:        schema.TypeString,
 				Required:    true,
-				MaxItems:    1,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"type": {
-							Description: "The type of network entity to probe." +
-								" Only `INTERNET_APPLICATION` supported for now.",
-							Type:     schema.TypeString,
-							Required: true,
-						},
-						"id": {
-							Description: "The ID of the network entity.",
-							Type:        schema.TypeString,
-							Required:    true,
-						},
-					},
-				},
 			},
 			"port": {
 				Description: "The TCP port to probe.",

--- a/alkira/resource_alkira_probe_tcp_helper.go
+++ b/alkira/resource_alkira_probe_tcp_helper.go
@@ -20,8 +20,10 @@ func generateTCPProbeRequest(d *schema.ResourceData) (*alkira.Probe, error) {
 	}
 
 	// Network Entity
-	networkEntity := expandNetworkEntityTCP(d.Get("network_entity").([]interface{}))
-	probe.NetworkEntity = *networkEntity
+	probe.NetworkEntity = alkira.ProbeNetworkEntity{
+		Type: "INTERNET_APPLICATION", // Hardcode type
+		ID:   d.Get("network_entity_id").(string),
+	}
 
 	// TCP Parameters
 	tcpParams := &alkira.TcpProbe{
@@ -40,9 +42,7 @@ func setTCPProbeState(probe *alkira.Probe, d *schema.ResourceData) error {
 	d.Set("success_threshold", probe.SuccessThreshold)
 	d.Set("period_seconds", probe.PeriodSeconds)
 	d.Set("timeout_seconds", probe.TimeoutSeconds)
-
-	// Network Entity
-	d.Set("network_entity", flattenNetworkEntityTCP(&probe.NetworkEntity))
+	d.Set("network_entity_id", &probe.NetworkEntity.ID)
 
 	// TCP Parameters
 	var params alkira.TcpProbe
@@ -53,23 +53,4 @@ func setTCPProbeState(probe *alkira.Probe, d *schema.ResourceData) error {
 	d.Set("port", params.Port)
 
 	return nil
-}
-
-func expandNetworkEntityTCP(input []interface{}) *alkira.ProbeNetworkEntity {
-	if len(input) == 0 {
-		return nil
-	}
-
-	entity := input[0].(map[string]interface{})
-	return &alkira.ProbeNetworkEntity{
-		Type: entity["type"].(string),
-		ID:   entity["id"].(string),
-	}
-}
-
-func flattenNetworkEntityTCP(entity *alkira.ProbeNetworkEntity) []interface{} {
-	return []interface{}{map[string]interface{}{
-		"type": entity.Type,
-		"id":   entity.ID,
-	}}
 }

--- a/docs/resources/probe_http.md
+++ b/docs/resources/probe_http.md
@@ -34,21 +34,10 @@ resource "alkira_probe_http" "basic_http" {
 This example demonstrates a more advanced HTTP probe with custom headers and response validation:
 ```terraform
 resource "alkira_probe_http" "advanced_http" {
-  name    = "http-with-validators"
-  enabled = true
-
-  network_entity {
-    type = "INTERNET_APPLICATION"
-    id   = alkira_internet_application.example_application.id
-  }
-
-  uri = "www.alkira.net/api/health"
-
-  headers = {
-    "Authorization" = "Bearer token123"
-    "Content-Type"  = "application/json"
-    "Accept"        = "application/json"
-  }
+  name              = "http-with-validators"
+  enabled           = true
+  network_entity_id = alkira_internet_application.example_application.id
+  uri               = "www.alkira.net/api/health"
 
   validators {
     type        = "STATUS_CODE"

--- a/docs/resources/probe_https.md
+++ b/docs/resources/probe_https.md
@@ -38,13 +38,9 @@ resource "alkira_probe_https" "custom_cert_https" {
   name    = "https-custom-cert"
   enabled = true
 
-  network_entity {
-    type = "INTERNET_APPLICATION"
-    id   = alkira_internet_application.example_application.id
-  }
-
-  uri         = "www.alkira.net/secure/endpoint"
-  server_name = "api.example.com"
+  network_entity_id = alkira_internet_application.example_application.id
+  uri               = "www.alkira.net/secure/endpoint"
+  server_name       = "api.example.com"
 
   # we can either pass the path of the file 
   # ca_certificate = file("${path.module}/certs/exmaple_ca.pem")
@@ -71,10 +67,7 @@ resource "alkira_probe_https" "no_cert_validation" {
   name    = "https-no-cert-validation"
   enabled = true
 
-  network_entity {
-    type = "INTERNET_APPLICATION"
-    id   = alkira_internet_application.example_application.id
-  }
+  network_entity_id = alkira_internet_application.example_application.id
 
   uri                     = "www.alkira.net/api/dashboard"
   disable_cert_validation = true

--- a/docs/resources/probe_tcp.md
+++ b/docs/resources/probe_tcp.md
@@ -23,14 +23,9 @@ When used with InternetApplication both the EIPs associated with the network ent
 This example demonstrates a simple TCP probe that verifies web server connectivity:
 ```terraform
 resource "alkira_probe_tcp" "basic_tcp" {
-  name = "basic-tcp-probe"
-
-  network_entity {
-    type = "INTERNET_APPLICATION"
-    id   = alkira_internet_application.example_application.id
-  }
-
-  port = 80
+  name              = "basic-tcp-probe"
+  network_entity_id = alkira_internet_application.example_application.id
+  port              = 80
 }
 ```
 
@@ -38,14 +33,9 @@ resource "alkira_probe_tcp" "basic_tcp" {
 This example shows a TCP probe with custom thresholds and timing parameters:
 ```terraform
 resource "alkira_probe_tcp" "full_tcp" {
-  name    = "tcp-full-options"
-  enabled = true
-
-  network_entity {
-    type = "INTERNET_APPLICATION"
-    id   = alkira_internet_application.example_application.id
-  }
-
+  name              = "tcp-full-options"
+  enabled           = true
+  network_entity_id = alkira_internet_application.example_application.id
   port              = 443
   failure_threshold = 5
   success_threshold = 3
@@ -59,7 +49,7 @@ resource "alkira_probe_tcp" "full_tcp" {
 ### Required
 
 - `name` (String) The name of the TCP probe.
-- `network_entity` (Block List, Min: 1, Max: 1) Network entity configuration. (see [below for nested schema](#nestedblock--network_entity))
+- `network_entity_id` (String) The ID of the internet application network entity to probe.
 - `port` (Number) The TCP port to probe.
 
 ### Optional
@@ -73,13 +63,5 @@ resource "alkira_probe_tcp" "full_tcp" {
 ### Read-Only
 
 - `id` (String) The ID of this resource.
-
-<a id="nestedblock--network_entity"></a>
-### Nested Schema for `network_entity`
-
-Required:
-
-- `id` (String) The ID of the network entity.
-- `type` (String) The type of network entity to probe. Only `INTERNET_APPLICATION` supported for now.
 
 

--- a/examples/resources/alkira_probe_http/resource1.tf
+++ b/examples/resources/alkira_probe_http/resource1.tf
@@ -1,19 +1,8 @@
 resource "alkira_probe_http" "advanced_http" {
-  name    = "http-with-validators"
-  enabled = true
-
-  network_entity {
-    type = "INTERNET_APPLICATION"
-    id   = alkira_internet_application.example_application.id
-  }
-
-  uri = "www.alkira.net/api/health"
-
-  headers = {
-    "Authorization" = "Bearer token123"
-    "Content-Type"  = "application/json"
-    "Accept"        = "application/json"
-  }
+  name              = "http-with-validators"
+  enabled           = true
+  network_entity_id = alkira_internet_application.example_application.id
+  uri               = "www.alkira.net/api/health"
 
   validators {
     type        = "STATUS_CODE"

--- a/examples/resources/alkira_probe_https/resource1.tf
+++ b/examples/resources/alkira_probe_https/resource1.tf
@@ -2,13 +2,9 @@ resource "alkira_probe_https" "custom_cert_https" {
   name    = "https-custom-cert"
   enabled = true
 
-  network_entity {
-    type = "INTERNET_APPLICATION"
-    id   = alkira_internet_application.example_application.id
-  }
-
-  uri         = "www.alkira.net/secure/endpoint"
-  server_name = "api.example.com"
+  network_entity_id = alkira_internet_application.example_application.id
+  uri               = "www.alkira.net/secure/endpoint"
+  server_name       = "api.example.com"
 
   # we can either pass the path of the file 
   # ca_certificate = file("${path.module}/certs/exmaple_ca.pem")

--- a/examples/resources/alkira_probe_https/resource2.tf
+++ b/examples/resources/alkira_probe_https/resource2.tf
@@ -2,10 +2,7 @@ resource "alkira_probe_https" "no_cert_validation" {
   name    = "https-no-cert-validation"
   enabled = true
 
-  network_entity {
-    type = "INTERNET_APPLICATION"
-    id   = alkira_internet_application.example_application.id
-  }
+  network_entity_id = alkira_internet_application.example_application.id
 
   uri                     = "www.alkira.net/api/dashboard"
   disable_cert_validation = true

--- a/examples/resources/alkira_probe_tcp/resource.tf
+++ b/examples/resources/alkira_probe_tcp/resource.tf
@@ -1,10 +1,5 @@
 resource "alkira_probe_tcp" "basic_tcp" {
-  name = "basic-tcp-probe"
-
-  network_entity {
-    type = "INTERNET_APPLICATION"
-    id   = alkira_internet_application.example_application.id
-  }
-
-  port = 80
+  name              = "basic-tcp-probe"
+  network_entity_id = alkira_internet_application.example_application.id
+  port              = 80
 }

--- a/examples/resources/alkira_probe_tcp/resource1.tf
+++ b/examples/resources/alkira_probe_tcp/resource1.tf
@@ -1,12 +1,7 @@
 resource "alkira_probe_tcp" "full_tcp" {
-  name    = "tcp-full-options"
-  enabled = true
-
-  network_entity {
-    type = "INTERNET_APPLICATION"
-    id   = alkira_internet_application.example_application.id
-  }
-
+  name              = "tcp-full-options"
+  enabled           = true
+  network_entity_id = alkira_internet_application.example_application.id
   port              = 443
   failure_threshold = 5
   success_threshold = 3


### PR DESCRIPTION
make tcp probe schema consistent with other probes. also fix examples and docs.