### PR TITLE
AK-55834 - update nat rules policy

### DIFF
--- a/acceptance/lists.tf
+++ b/acceptance/lists.tf
@@ -35,7 +35,7 @@ resource "alkira_list_as_path" "test" {
 }
 
 resource "alkira_list_global_cidr" "ciscofdtv" {
-  name        = "acceptance-test"
+  name        = "acceptance-test-ciscofdtv"
   description = "terraform test global cidr list for cisco ftdv"
   values      = ["192.168.0.0/24"]
   cxp         = var.cxp

--- a/acceptance/service_checkpoint.tf
+++ b/acceptance/service_checkpoint.tf
@@ -22,7 +22,7 @@ resource "alkira_service_checkpoint" "test" {
     global_cidr_list_id = alkira_list_global_cidr.checkpoint.id
     segment_id          = alkira_segment.test1.id
 
-    username = "checkpoint_user"
+    username = "checkpoint-user"
     password = "abcd1234"
 
     # domain only required when configuration_mode is AUTOMATED and
@@ -67,7 +67,7 @@ resource "alkira_service_checkpoint" "test2" {
     configuration_mode  = "AUTOMATED"
     global_cidr_list_id = alkira_list_global_cidr.checkpoint.id
     ips                 = ["54.69.129.30"]
-    username            = "checkpoint_user"
+    username            = "checkpoint-user"
     password            = "Alkira2023"
     reachability        = "PUBLIC"
     type                = "SMS"

--- a/alkira/resource_alkira_policy_nat_rule.go
+++ b/alkira/resource_alkira_policy_nat_rule.go
@@ -65,6 +65,13 @@ func resourceAlkiraPolicyNatRule() *schema.Resource {
 				ValidateFunc: validation.StringInSlice(
 					[]string{"DEFAULT", "INTERNET_CONNECTOR"}, false),
 			},
+			"direction": {
+				Description: "The direction of NAT rule. The value could be `INBOUND` or `OUTBOUND`.",
+				Type:        schema.TypeString,
+				Optional:    true,
+				ValidateFunc: validation.StringInSlice(
+					[]string{"INBOUND", "OUTBOUND"}, false),
+			},
 			"match": {
 				Description: "Match condition for the rule.",
 				Type:        schema.TypeSet,
@@ -209,6 +216,23 @@ func resourceAlkiraPolicyNatRule() *schema.Resource {
 							Type:     schema.TypeBool,
 							Optional: true,
 							Default:  false,
+						},
+						"dst_addr_translation_routing_track_prefixes": {
+							Description: "The list of prefixes to track.",
+							Type:        schema.TypeList,
+							Elem:        &schema.Schema{Type: schema.TypeString},
+							Optional:    true,
+						},
+						"dst_addr_translation_routing_track_prefix_list_ids": {
+							Description: "The list of prefix list IDs to track.",
+							Type:        schema.TypeList,
+							Elem:        &schema.Schema{Type: schema.TypeInt},
+							Optional:    true,
+						},
+						"dst_addr_translation_routing_invalidate_prefixes": {
+							Description: "Whether to invalidate the track prefixes.",
+							Type:        schema.TypeBool,
+							Optional:    true,
 						},
 						"egress_type": {
 							Description: "The egress type to use with the " +

--- a/alkira/resource_alkira_policy_nat_rule.go
+++ b/alkira/resource_alkira_policy_nat_rule.go
@@ -172,9 +172,11 @@ func resourceAlkiraPolicyNatRule() *schema.Resource {
 							Optional:    true,
 						},
 						"src_addr_translation_routing_track_invalidate_prefixes": {
-							Description: "Whether to invalidate the track prefixes.",
-							Type:        schema.TypeBool,
-							Optional:    true,
+							Description: "Whether to invalidate the track prefixes. " +
+								"Default value is `false`.",
+							Type:     schema.TypeBool,
+							Optional: true,
+							Default:  false,
 						},
 						"dst_addr_translation_type": {
 							Description: "The translation type are: `STATIC_IP`, " +
@@ -230,9 +232,11 @@ func resourceAlkiraPolicyNatRule() *schema.Resource {
 							Optional:    true,
 						},
 						"dst_addr_translation_routing_invalidate_prefixes": {
-							Description: "Whether to invalidate the track prefixes.",
-							Type:        schema.TypeBool,
-							Optional:    true,
+							Description: "Whether to invalidate the track prefixes. " +
+								"Default value is `false`.",
+							Type:     schema.TypeBool,
+							Optional: true,
+							Default:  false,
 						},
 						"egress_type": {
 							Description: "The egress type to use with the " +

--- a/alkira/resource_alkira_policy_nat_rule_helper.go
+++ b/alkira/resource_alkira_policy_nat_rule_helper.go
@@ -132,6 +132,24 @@ func expandPolicyNatRuleAction(in *schema.Set) *alkira.NatRuleAction {
 			st.RoutingOptions.InvalidateRoutingTrackPrefixes = invalidateRoutingTrackPrefixes
 		}
 
+		if v, ok := actionValue["dst_addr_translation_routing_track_prefixes"].([]interface{}); ok {
+			list := convertTypeListToStringList(v)
+			if len(list) > 0 {
+				dt.RoutingOptions.TrackPrefixes = list
+			}
+		}
+		if v, ok := actionValue["dst_addr_translation_routing_track_prefix_list_ids"].([]interface{}); ok {
+			list := convertTypeListToIntList(v)
+			if len(list) > 0 {
+				dt.RoutingOptions.TrackPrefixListIds = list
+			}
+		}
+		if v, ok := actionValue["dst_addr_translation_routing_invalidate_prefixes"].(bool); ok {
+			invalidateRoutingTrackPrefixes := new(bool)
+			*invalidateRoutingTrackPrefixes = v
+			dt.RoutingOptions.InvalidateRoutingTrackPrefixes = invalidateRoutingTrackPrefixes
+		}
+
 		//
 		// This field has a fixed value based on the translation type.
 		//
@@ -202,6 +220,9 @@ func setNatRuleActionOptions(a alkira.NatRuleAction, d *schema.ResourceData) {
 		"dst_addr_translation_ports":                             a.DestinationAddressTranslation.TranslatedPortList,
 		"dst_addr_translation_list_policy_fqdn_id":               a.DestinationAddressTranslation.TranslatedPolicyFqdnListId,
 		"dst_addr_translation_advertise_to_connector":            a.DestinationAddressTranslation.AdvertiseToConnector,
+		"dst_addr_translation_routing_track_prefixes":            a.DestinationAddressTranslation.RoutingOptions.TrackPrefixes,
+		"dst_addr_translation_routing_track_prefix_list_ids":     a.DestinationAddressTranslation.RoutingOptions.TrackPrefixListIds,
+		"dst_addr_translation_routing_invalidate_prefixes":       a.DestinationAddressTranslation.RoutingOptions.InvalidateRoutingTrackPrefixes,
 		"egress_type": a.Egress.IpType,
 	}
 
@@ -221,6 +242,7 @@ func generatePolicyNatRuleRequest(d *schema.ResourceData, m interface{}) (*alkir
 		Description: d.Get("description").(string),
 		Enabled:     d.Get("enabled").(bool),
 		Category:    d.Get("category").(string),
+		Direction:   d.Get("direction").(string),
 		Match:       *match,
 		Action:      *action,
 	}

--- a/docs/resources/policy_nat_rule.md
+++ b/docs/resources/policy_nat_rule.md
@@ -29,6 +29,7 @@ This resource is usually used along with policy resources:`policy_nat_policy`.
 
 - `category` (String) The category of NAT rule. The value could be `DEFAULT` or `INTERNET_CONNECTOR`. Default value is `DEFAULT`.
 - `description` (String) The description of the policy rule.
+- `direction` (String) The direction of NAT rule. The value could be `INBOUND` or `OUTBOUND`.
 
 ### Read-Only
 
@@ -45,6 +46,9 @@ Optional:
 - `dst_addr_translation_ports` (List of String) The port list to translate the destination prefixes to.
 - `dst_addr_translation_prefix_list_ids` (List of Number) The list of prefix list IDs.
 - `dst_addr_translation_prefixes` (List of String) The list of prefixes.
+- `dst_addr_translation_routing_invalidate_prefixes` (Boolean) Whether to invalidate the track prefixes.
+- `dst_addr_translation_routing_track_prefix_list_ids` (List of Number) The list of prefix list IDs to track.
+- `dst_addr_translation_routing_track_prefixes` (List of String) The list of prefixes to track.
 - `dst_addr_translation_type` (String) The translation type are: `STATIC_IP`, `STATIC_IP_AND_PORT` , `STATIC_PORT` and `NONE`. Default value is `NONE`.
 - `egress_type` (String) The egress type to use with the match. Options are are `ALKIRA_PUBLIC_IP` or `BYOIP`.
 - `src_addr_translation_match_and_invalidate` (Boolean) Whether the translation match and invalidate. Default is `true`.

--- a/docs/resources/policy_nat_rule.md
+++ b/docs/resources/policy_nat_rule.md
@@ -46,7 +46,7 @@ Optional:
 - `dst_addr_translation_ports` (List of String) The port list to translate the destination prefixes to.
 - `dst_addr_translation_prefix_list_ids` (List of Number) The list of prefix list IDs.
 - `dst_addr_translation_prefixes` (List of String) The list of prefixes.
-- `dst_addr_translation_routing_invalidate_prefixes` (Boolean) Whether to invalidate the track prefixes.
+- `dst_addr_translation_routing_invalidate_prefixes` (Boolean) Whether to invalidate the track prefixes. Default value is `false`.
 - `dst_addr_translation_routing_track_prefix_list_ids` (List of Number) The list of prefix list IDs to track.
 - `dst_addr_translation_routing_track_prefixes` (List of String) The list of prefixes to track.
 - `dst_addr_translation_type` (String) The translation type are: `STATIC_IP`, `STATIC_IP_AND_PORT` , `STATIC_PORT` and `NONE`. Default value is `NONE`.
@@ -54,7 +54,7 @@ Optional:
 - `src_addr_translation_match_and_invalidate` (Boolean) Whether the translation match and invalidate. Default is `true`.
 - `src_addr_translation_prefix_list_ids` (List of Number) The list of prefix list IDs.
 - `src_addr_translation_prefixes` (List of String) The list of prefixes.
-- `src_addr_translation_routing_track_invalidate_prefixes` (Boolean) Whether to invalidate the track prefixes.
+- `src_addr_translation_routing_track_invalidate_prefixes` (Boolean) Whether to invalidate the track prefixes. Default value is `false`.
 - `src_addr_translation_routing_track_prefix_list_ids` (List of Number) The list of prefix list IDs.
 - `src_addr_translation_routing_track_prefixes` (List of String) The list of prefixes to track.
 - `src_addr_translation_type` (String) The translation type are: `STATIC_IP`, `DYNAMIC_IP_AND_PORT` and `NONE`. Default value is `NONE`.

--- a/vendor/github.com/alkiranet/alkira-client-go/alkira/policy_nat_rules.go
+++ b/vendor/github.com/alkiranet/alkira-client-go/alkira/policy_nat_rules.go
@@ -15,6 +15,7 @@ type NatPolicyRule struct {
 	Match       NatRuleMatch  `json:"match"`
 	Action      NatRuleAction `json:"action"`
 	Category    string        `json:"category"`
+	Direction   string        `json:"direction"`
 }
 
 type NatRuleMatch struct {
@@ -43,13 +44,14 @@ type NatRuleActionSrcTranslation struct {
 }
 
 type NatRuleActionDstTranslation struct {
-	TranslationType            string   `json:"translationType"`
-	TranslatedPrefixes         []string `json:"translatedPrefixes,omitempty"`
-	TranslatedPrefixListIds    []int    `json:"translatedPrefixListIds,omitempty"`
-	TranslatedPortList         []string `json:"translatedPortList,omitempty"`
-	TranslatedPolicyFqdnListId int      `json:"translatedPolicyFqdnListId,omitempty"`
-	Bidirectional              *bool    `json:"bidirectional,omitempty"`
-	AdvertiseToConnector       *bool    `json:"advertiseToConnector,omitempty"`
+	TranslationType            string                `json:"translationType"`
+	TranslatedPrefixes         []string              `json:"translatedPrefixes,omitempty"`
+	TranslatedPrefixListIds    []int                 `json:"translatedPrefixListIds,omitempty"`
+	TranslatedPortList         []string              `json:"translatedPortList,omitempty"`
+	TranslatedPolicyFqdnListId int                   `json:"translatedPolicyFqdnListId,omitempty"`
+	Bidirectional              *bool                 `json:"bidirectional,omitempty"`
+	AdvertiseToConnector       *bool                 `json:"advertiseToConnector,omitempty"`
+	RoutingOptions             NatRuleRoutingOptions `json:"routingOptions,omitempty"`
 }
 
 type NatRuleRoutingOptions struct {


### PR DESCRIPTION
A new field called direction(INBOUND/OUTBOUND) is added to the NATRule.

The following fields are added to action.destinationNatTranslation,

routingOptions : {

     "trackPrefixes": [],

     "trackPrefixListIds": [],

     "invalidateRoutingTrackPrefixes": null/Boolean

   }