### PR TITLE
AK-59340 - expose `implicit_group_id` for Azure express route

### DIFF
--- a/alkira/resource_alkira_connector_azure_expressroute.go
+++ b/alkira/resource_alkira_connector_azure_expressroute.go
@@ -80,6 +80,11 @@ func resourceAlkiraConnectorAzureExpressRoute() *schema.Resource {
 				Type:        schema.TypeString,
 				Optional:    true,
 			},
+			"implicit_group_id": {
+				Description: "The implicit group ID associated with the connector.",
+				Type:        schema.TypeInt,
+				Computed:    true,
+			},
 			"provision_state": {
 				Description: "The provision state of the connector.",
 				Type:        schema.TypeString,
@@ -340,6 +345,7 @@ func resourceConnectorAzureExpressRouteRead(ctx context.Context, d *schema.Resou
 	d.Set("billing_tag_ids", connector.BillingTags)
 	d.Set("cxp", connector.Cxp)
 	d.Set("group", connector.Group)
+	d.Set("implicit_group_id", connector.ImplicitGroupId)
 	d.Set("enabled", connector.Enabled)
 	d.Set("name", connector.Name)
 	d.Set("description", connector.Description)


### PR DESCRIPTION
Adds a computed field for the implicit group ID associated with the connector.

Refs: AK-59340