### PR TITLE
AK-59647 : make registration_pin_expiry optional for PAN service

### DIFF
--- a/alkira/resource_alkira_service_pan.go
+++ b/alkira/resource_alkira_service_pan.go
@@ -325,7 +325,7 @@ func resourceAlkiraServicePan() *schema.Resource {
 				Description: "PAN Registration PIN Expiry. The date " +
 					"should be in format of `YYYY-MM-DD`, e.g. `2000-01-01`.",
 				Type:     schema.TypeString,
-				Required: true,
+				Optional: true,
 			},
 			"name": {
 				Description: "Name of the PAN service.",

--- a/docs/index.md
+++ b/docs/index.md
@@ -94,4 +94,5 @@ may take a much longer time to apply when provisioning is enabled.
 - `password` (String) Your Tenant Password. If this is not provided then `api_key` must have a value.
 - `provision` (Boolean) With provision or not.
 - `username` (String) Your username. If this is not provided then `api_key` must have a value.
+- `validation` (Boolean) Asynchronous validations.
 

--- a/docs/resources/connector_azure_expressroute.md
+++ b/docs/resources/connector_azure_expressroute.md
@@ -310,6 +310,7 @@ Segment options define routing parameters for each network segment, including:
 ### Read-Only
 
 - `id` (String) The ID of this resource.
+- `implicit_group_id` (Number) The implicit group ID associated with the connector.
 - `provision_state` (String) The provision state of the connector.
 
 <a id="nestedblock--instances"></a>
@@ -331,7 +332,7 @@ Optional:
 
 Read-Only:
 
-- `id` (Number) The ID of this resource.
+- `id` (Number)
 
 <a id="nestedblock--instances--ipsec_customer_gateway"></a>
 ### Nested Schema for `instances.ipsec_customer_gateway`

--- a/docs/resources/connector_juniper_sdwan.md
+++ b/docs/resources/connector_juniper_sdwan.md
@@ -91,8 +91,6 @@ Optional:
 
 Import is supported using the following syntax:
 
-The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
-
 ```shell
 terraform import alkira_connector_juniper_sdwan.example CONNECTOR_ID
 ```

--- a/docs/resources/service_pan.md
+++ b/docs/resources/service_pan.md
@@ -95,7 +95,6 @@ resource "alkira_service_pan" "test1" {
 - `name` (String) Name of the PAN service.
 - `pan_password` (String) PAN Panorama password.
 - `pan_username` (String) PAN Panorama username. For AWS, username should be `admin`. For AZURE, it should be `akadmin`.
-- `registration_pin_expiry` (String) PAN Registration PIN Expiry. The date should be in format of `YYYY-MM-DD`, e.g. `2000-01-01`.
 - `registration_pin_id` (String) PAN Registration PIN ID.
 - `registration_pin_value` (String) PAN Registration PIN Value.
 - `segment_ids` (Set of Number) IDs of segments associated with the service.
@@ -119,6 +118,7 @@ resource "alkira_service_pan" "test1" {
 - `panorama_enabled` (Boolean) Enable Panorama or not. Default value is `false`.
 - `panorama_ip_addresses` (List of String) Panorama IP addresses.
 - `panorama_template` (String) Panorama Template.
+- `registration_pin_expiry` (String) PAN Registration PIN Expiry. The date should be in format of `YYYY-MM-DD`, e.g. `2000-01-01`.
 - `segment_options` (Block Set) The segment options as used by your PAN firewall. (see [below for nested schema](#nestedblock--segment_options))
 - `tunnel_protocol` (String) Tunnel Protocol, default to `IPSEC`, could be either `IPSEC` or `GRE`.
 - `type` (String) The type of the PAN firewall. Either 'VM-300', 'VM-500' or 'VM-700'

--- a/examples/resources/alkira_connector_juniper_sdwan/resource.tf
+++ b/examples/resources/alkira_connector_juniper_sdwan/resource.tf
@@ -2,7 +2,7 @@ resource "alkira_connector_juniper_sdwan" "juniper" {
   name    = "test"
   cxp     = "US-EAST"
   size    = "SMALL"
-  version = "6.3.4"
+  juniper_ssr_version = "6.3.4"
   group   = alkira_group.test.name
   availability_zone = 0
 


### PR DESCRIPTION
- Change registration_pin_expiry from required to optional in schema and helper
- Update documentation to reflect the optional nature
- Update Azure ExpressRoute connector docs with implicit_group_id
- Clean up Juniper SDWAN connector import docs
- Update example to use juniper_ssr_version
- Fix docs