### PR TITLE
AK-59844 - make bgpAuthKeyAlkira optional in ipsec connectors

### DIFF
--- a/vendor/github.com/alkiranet/alkira-client-go/alkira/connector_ipsec.go
+++ b/vendor/github.com/alkiranet/alkira-client-go/alkira/connector_ipsec.go
@@ -63,7 +63,7 @@ type ConnectorIPSecStaticRouting struct {
 
 type ConnectorIPSecDynamicRouting struct {
 	Availability     string `json:"availability,omitempty"`
-	BgpAuthKeyAlkira string `json:"bgpAuthKeyAlkira"`
+	BgpAuthKeyAlkira string `json:"bgpAuthKeyAlkira,omitempty"`
 	CustomerGwAsn    string `json:"customerGwAsn"`
 }
 

--- a/vendor/github.com/alkiranet/alkira-client-go/alkira/connector_ipsec_adv.go
+++ b/vendor/github.com/alkiranet/alkira-client-go/alkira/connector_ipsec_adv.go
@@ -74,7 +74,7 @@ type ConnectorAdvIPSecStaticRouting struct {
 
 type ConnectorAdvIPSecDynamicRouting struct {
 	Availability     string `json:"availability,omitempty"`
-	BgpAuthKeyAlkira string `json:"bgpAuthKeyAlkira"`
+	BgpAuthKeyAlkira string `json:"bgpAuthKeyAlkira,omitempty"`
 	CustomerGwAsn    string `json:"customerGwAsn"`
 }
 


### PR DESCRIPTION
This change modifies the `BgpAuthKeyAlkira` field in both `ConnectorIPSecDynamicRouting` and `ConnectorAdvIPSecDynamicRouting` structs to be optional by adding the `omitempty` tag. This ensures that the field is not included in JSON marshaling when empty, which aligns with API expectations and prevents potential validation issues.