### PR TITLE
AK-65430: Implement Read function and WriteOnly fields for alkira_credential_ssh_key_pair

### DIFF
--- a/alkira/resource_alkira_credential_ssh_key_pair.go
+++ b/alkira/resource_alkira_credential_ssh_key_pair.go
@@ -3,9 +3,12 @@ package alkira
 import (
 	"context"
 	"fmt"
+	"os"
+	"strings"
 
 	"github.com/alkiranet/alkira-client-go/alkira"
 
+	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -31,9 +34,7 @@ func resourceAlkiraCredentialSshKeyPair() *schema.Resource {
 				Description: "Public key.",
 				Type:        schema.TypeString,
 				Optional:    true,
-				DefaultFunc: schema.EnvDefaultFunc(
-					"AK_SSH_PUBLIC_KEY",
-					nil),
+				WriteOnly:   true,
 			},
 		},
 	}
@@ -42,8 +43,13 @@ func resourceAlkiraCredentialSshKeyPair() *schema.Resource {
 func resourceCredentialSshKeyPairCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*alkira.AlkiraClient)
 
+	publicKey, err := getSshKeyPairCredentialValue(d, "public_key", "AK_SSH_PUBLIC_KEY")
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
 	c := alkira.CredentialKeyPair{
-		PublicKey: d.Get("public_key").(string),
+		PublicKey: publicKey,
 		Type:      "IMPORTED",
 	}
 
@@ -58,18 +64,40 @@ func resourceCredentialSshKeyPairCreate(ctx context.Context, d *schema.ResourceD
 }
 
 func resourceCredentialSshKeyPairRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*alkira.AlkiraClient)
+
+	credential, err := client.GetCredentialById(d.Id())
+	if err != nil {
+		if strings.Contains(err.Error(), "not found") {
+			d.SetId("")
+			return nil
+		}
+		return diag.FromErr(err)
+	}
+
+	d.Set("name", credential.Name)
+
+	// Note: public_key is NOT returned by the API for security reasons.
+	// The getSshKeyPairCredentialValue helper reads from config or AK_SSH_PUBLIC_KEY env var.
+	// Private keys are never returned by the API.
+
 	return nil
 }
 
 func resourceCredentialSshKeyPairUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*alkira.AlkiraClient)
 
+	publicKey, err := getSshKeyPairCredentialValue(d, "public_key", "AK_SSH_PUBLIC_KEY")
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
 	c := alkira.CredentialKeyPair{
-		PublicKey: d.Get("public_key").(string),
+		PublicKey: publicKey,
 		Type:      "IMPORTED",
 	}
 
-	err := client.UpdateCredential(d.Id(), d.Get("name").(string), alkira.CredentialTypeKeyPair, c, 0)
+	err = client.UpdateCredential(d.Id(), d.Get("name").(string), alkira.CredentialTypeKeyPair, c, 0)
 
 	if err != nil {
 		return diag.FromErr(err)
@@ -95,4 +123,28 @@ func resourceCredentialSshKeyPairDelete(ctx context.Context, d *schema.ResourceD
 
 	d.SetId("")
 	return nil
+}
+
+// getSshKeyPairCredentialValue gets a value from config or environment variable.
+// For WriteOnly fields, reads from raw config since values are not stored in state.
+func getSshKeyPairCredentialValue(d *schema.ResourceData, field string, envVar string) (string, error) {
+	// First try raw config (for WriteOnly fields)
+	attrPath := cty.Path{cty.GetAttrStep{Name: field}}
+	val, diags := d.GetRawConfigAt(attrPath)
+
+	if !diags.HasError() && !val.IsNull() && val.IsKnown() && val.Type() == cty.String {
+		strVal := val.AsString()
+		if strVal != "" {
+			return strVal, nil
+		}
+	}
+
+	// Fall back to environment variable
+	envValue := os.Getenv(envVar)
+	if envValue != "" {
+		return envValue, nil
+	}
+
+	// Return empty string if not set (field is Optional)
+	return "", nil
 }


### PR DESCRIPTION
## Summary

- Implement Read function for `alkira_credential_ssh_key_pair` to enable proper import, refresh, and drift detection
- Add `WriteOnly` attribute to `public_key` field to prevent storing credentials in Terraform state and fix broken import workflow
- Add environment variable support for `public_key` via `AK_SSH_PUBLIC_KEY`

## Problem

1. **Read function was empty** — returned `nil`, causing broken import, no refresh, no drift detection
2. **Spurious diffs on import** — importing a credential and adding `public_key` to config triggered unnecessary update operations (backend rejects SSH key pair updates)
3. **`DefaultFunc` incompatible with `WriteOnly`** — required refactoring env var handling

## Solution

### Read Function

- Uses `client.GetCredentialById()` to populate `name` from API
- Handles not-found by clearing resource ID (deleted-out-of-band detection)
- `public_key` is NOT returned by API — maintained via user config and WriteOnly semantics

### WriteOnly Field

- `public_key` marked `WriteOnly: true`
- Value sent to API on Create/Update but never stored in state
- After import, generated config shows `public_key = null`
- User fills in credential value — plan shows "No changes" (no spurious update)

### Environment Variable Support

- Replaced `DefaultFunc` (incompatible with WriteOnly) with `getSshKeyPairCredentialValue()` helper
- Reads from raw config via `GetRawConfigAt()`, falls back to env var `AK_SSH_PUBLIC_KEY`
- Returns empty string if not set (field is Optional)

## Changes

- `alkira/resource_alkira_credential_ssh_key_pair.go` — Read function, WriteOnly schema, credential value helper

## Testing Performed

### Phase 1: Greenfield CRUD (Fixed Build)

- Create: WriteOnly field shows as `(write-only attribute)` in state, `null` in raw JSON
- Read/Refresh: Plan shows "No changes" after refresh
- Update: Only changed field (name) in diff; API rejects update (expected — SSH key pair updates not supported)
- Idempotency: Subsequent plan shows "No changes"
- Delete: Destroy succeeds, state empty

### Phase 2: Import + Generate Config

- Generated config has `public_key = null`, `name` populated
- Import apply succeeds
- **KEY TEST:** Filling in `public_key` after import produces "No changes" — no spurious update

### Phase 3: Environment Variable Fallback

- Create with env var only (no inline credential): succeeds
- Empty value handling: API accepts empty public_key (field is Optional)

### Code Quality

- `make lint` — 0 issues
- `go build` — clean