### PR TITLE
AK-65436: Set global_tenant_id in Read function for Versa SD-WAN connector

### DIFF
--- a/alkira/resource_alkira_connector_versa_sdwan.go
+++ b/alkira/resource_alkira_connector_versa_sdwan.go
@@ -283,6 +283,7 @@ func resourceConnectorVersaSdwanRead(ctx context.Context, d *schema.ResourceData
 	d.Set("size", connector.Size)
 	d.Set("tunnel_protocol", connector.TunnelProtocol)
 	d.Set("description", connector.Description)
+	d.Set("global_tenant_id", connector.GlobalTenantId)
 
 	// Set Instances
 	setVersaSdwanInstance(d, connector)


### PR DESCRIPTION
## Summary

- Fix `global_tenant_id` field not being set in Read function for `alkira_connector_versa_sdwan`
- Eliminates perpetual state drift on `terraform plan` after resource creation
- Enables proper tracking of non-default tenant IDs

## Problem

The `global_tenant_id` field was defined in schema with `Default: 1` and sent correctly to the API during Create/Update, but was never set in the Read function from the API response. This caused:

- Perpetual state drift on every `terraform plan`
- Terraform unable to track the actual API value
- Existing connectors with non-default tenant IDs showing spurious changes

## Solution

Added a single line in `resourceConnectorVersaSdwanRead()` to set the field from the API response:

```go
d.Set("global_tenant_id", connector.GlobalTenantId)
```

## Changes

- `alkira/resource_alkira_connector_versa_sdwan.go` — Added `d.Set("global_tenant_id", connector.GlobalTenantId)` in Read function (line 286)

## Testing Performed

### Phase 1: Greenfield CRUD with Default global_tenant_id
- Created connector with default `global_tenant_id` (not specified in config)
- Verified state shows `global_tenant_id = 1`
- Verified `terraform refresh` → no changes
- Verified `terraform plan` → "No changes"

### Phase 2: Greenfield CRUD with Non-Default global_tenant_id
- Created connector with `global_tenant_id = 2`
- Verified state shows `global_tenant_id = 2`
- Verified `terraform refresh` → no changes
- Verified `terraform plan` → "No changes"
- Updated: changed `name` field only
- Verified plan shows only name change, `global_tenant_id` unchanged
- Verified update request includes `globalTenantId:2` (all fields sent correctly)
- Verified after update: `terraform plan` → "No changes"

### Debug Logs Verified
- Create Request includes `globalTenantId` with correct value
- API Response returns `globalTenantId`
- Read (Get) Response returns `globalTenantId`
- Update Request includes all fields including `globalTenantId`

### Code Quality
- `make lint` — 0 issues
- `go build` — clean

All test resources cleaned up, no orphaned resources in tenant.