### PR TITLE
AK-65582: Fix TypeList spurious updates for Bluecat service and Policy Prefix List

### DIFF
--- a/alkira/helper.go
+++ b/alkira/helper.go
@@ -274,7 +274,7 @@ func toInt(v interface{}) int {
 	return 0
 }
 
-// serviceInstanceHash returns a schema.SchemaSetFunc that computes a hash
+// typeSetHash returns a schema.SchemaSetFunc that computes a hash
 // for TypeSet elements using a key extractor function. The key extractor
 // builds a string from the element's fields, which is then hashed to
 // produce the set key. This allows elements to be matched by content
@@ -290,7 +290,7 @@ func toInt(v interface{}) int {
 //
 // For single-field blocks: return just that field (e.g., m["hostname"])
 // For multi-field blocks: combine all fields with fmt.Sprintf
-func serviceInstanceHash(keyExtractor func(map[string]interface{}) string) schema.SchemaSetFunc {
+func typeSetHash(keyExtractor func(map[string]interface{}) string) schema.SchemaSetFunc {
 	return func(v interface{}) int {
 		var buf bytes.Buffer
 		m := v.(map[string]interface{})

--- a/alkira/helper.go
+++ b/alkira/helper.go
@@ -1,9 +1,11 @@
 package alkira
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"log"
 	"math/rand"
 	"strconv"
@@ -270,4 +272,29 @@ func toInt(v interface{}) int {
 		}
 	}
 	return 0
+}
+
+// serviceInstanceHash returns a schema.SchemaSetFunc that computes a hash
+// for TypeSet elements using a key extractor function. The key extractor
+// builds a string from the element's fields, which is then hashed to
+// produce the set key. This allows elements to be matched by content
+// rather than position, preventing spurious updates when elements are
+// added, removed, or reordered.
+//
+// IMPORTANT: TypeSet compares elements solely by hash. The key extractor
+// MUST include ALL fields of the block. If any field is omitted, changes
+// to that field will be invisible to Terraform — plan will show
+// "No changes" even when the value has changed. The corresponding Read
+// helper that populates the set from API data must also always set every
+// field (including empty/zero values) so that hashes match the config.
+//
+// For single-field blocks: return just that field (e.g., m["hostname"])
+// For multi-field blocks: combine all fields with fmt.Sprintf
+func serviceInstanceHash(keyExtractor func(map[string]interface{}) string) schema.SchemaSetFunc {
+	return func(v interface{}) int {
+		var buf bytes.Buffer
+		m := v.(map[string]interface{})
+		fmt.Fprintf(&buf, "%s-", keyExtractor(m))
+		return schema.HashString(buf.String())
+	}
 }

--- a/alkira/resource_alkira_policy_prefix_list.go
+++ b/alkira/resource_alkira_policy_prefix_list.go
@@ -19,7 +19,7 @@ import (
 // The corresponding Read helper (setPrefix) must also always populate
 // every field — including empty strings — so the hash computed from
 // API data matches the hash computed from the user's config.
-var prefixHash = serviceInstanceHash(func(m map[string]interface{}) string {
+var prefixHash = typeSetHash(func(m map[string]interface{}) string {
 	cidr := ""
 	if v, ok := m["cidr"].(string); ok {
 		cidr = v
@@ -41,7 +41,7 @@ var prefixHash = serviceInstanceHash(func(m map[string]interface{}) string {
 //
 // The corresponding Read helper (setPrefixRanges) must also always
 // populate every field so the hash from API data matches the config hash.
-var prefixRangeHash = serviceInstanceHash(func(m map[string]interface{}) string {
+var prefixRangeHash = typeSetHash(func(m map[string]interface{}) string {
 	prefix := ""
 	if v, ok := m["prefix"].(string); ok {
 		prefix = v

--- a/alkira/resource_alkira_policy_prefix_list.go
+++ b/alkira/resource_alkira_policy_prefix_list.go
@@ -1,7 +1,6 @@
 package alkira
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 
@@ -9,6 +8,52 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
+
+// prefixHash computes a hash for a "prefix" block in a policy prefix list.
+//
+// IMPORTANT: Every field in the block MUST be included in the hash.
+// TypeSet compares elements solely by their hash value. If a field is
+// omitted from the hash, changes to that field will be invisible to
+// Terraform (plan will show "No changes" even when the value differs).
+//
+// The corresponding Read helper (setPrefix) must also always populate
+// every field — including empty strings — so the hash computed from
+// API data matches the hash computed from the user's config.
+var prefixHash = serviceInstanceHash(func(m map[string]interface{}) string {
+	cidr := ""
+	if v, ok := m["cidr"].(string); ok {
+		cidr = v
+	}
+	desc := ""
+	if v, ok := m["description"].(string); ok {
+		desc = v
+	}
+	return fmt.Sprintf("%s-%s", cidr, desc)
+})
+
+// prefixRangeHash computes a hash for a "prefix_range" block in a policy
+// prefix list.
+//
+// IMPORTANT: Every field in the block MUST be included in the hash.
+// TypeSet compares elements solely by their hash value. If a field is
+// omitted (e.g. le, ge, or description), changes to that field will be
+// invisible to Terraform and plan will silently show "No changes".
+//
+// The corresponding Read helper (setPrefixRanges) must also always
+// populate every field so the hash from API data matches the config hash.
+var prefixRangeHash = serviceInstanceHash(func(m map[string]interface{}) string {
+	prefix := ""
+	if v, ok := m["prefix"].(string); ok {
+		prefix = v
+	}
+	desc := ""
+	if v, ok := m["description"].(string); ok {
+		desc = v
+	}
+	le := toInt(m["le"])
+	ge := toInt(m["ge"])
+	return fmt.Sprintf("%s-%d-%d-%s", prefix, le, ge, desc)
+})
 
 func resourceAlkiraPolicyPrefixList() *schema.Resource {
 	return &schema.Resource{
@@ -301,26 +346,4 @@ func resourcePolicyPrefixListDelete(ctx context.Context, d *schema.ResourceData,
 	}
 
 	return nil
-}
-
-// prefixHash computes a hash for a prefix block based on its cidr field.
-// This allows Terraform to identify prefixes by their CIDR value rather than
-// their position in the list, preventing unwanted reordering when prefixes
-// are deleted from the middle of the list.
-func prefixHash(v interface{}) int {
-	var buf bytes.Buffer
-	m := v.(map[string]interface{})
-	fmt.Fprintf(&buf, "%s-", m["cidr"])
-	return schema.HashString(buf.String())
-}
-
-// prefixRangeHash computes a hash for a prefix_range block based on its
-// prefix, le, and ge fields. This allows Terraform to identify prefix ranges
-// by their content rather than their position in the list, preventing unwanted
-// reordering when ranges are deleted from the middle of the list.
-func prefixRangeHash(v interface{}) int {
-	var buf bytes.Buffer
-	m := v.(map[string]interface{})
-	fmt.Fprintf(&buf, "%s-%d-%d-", m["prefix"], toInt(m["le"]), toInt(m["ge"]))
-	return schema.HashString(buf.String())
 }

--- a/alkira/resource_alkira_policy_prefix_list_helper.go
+++ b/alkira/resource_alkira_policy_prefix_list_helper.go
@@ -14,12 +14,10 @@ func setPrefixRanges(d *schema.ResourceData, r []alkira.PolicyPrefixListRange) {
 
 	for _, rng := range r {
 		prefixRange := map[string]interface{}{
-			"prefix": rng.Prefix,
-			"le":     rng.Le,
-			"ge":     rng.Ge,
-		}
-		if rng.Description != "" {
-			prefixRange["description"] = rng.Description
+			"prefix":      rng.Prefix,
+			"le":          rng.Le,
+			"ge":          rng.Ge,
+			"description": rng.Description,
 		}
 		set.Add(prefixRange)
 	}
@@ -104,11 +102,13 @@ func setPrefix(d *schema.ResourceData, prefixes []string, details map[string]*al
 	set := schema.NewSet(prefixHash, nil)
 
 	for _, p := range prefixes {
-		prefixEntry := map[string]interface{}{
-			"cidr": p,
+		desc := ""
+		if details[p] != nil {
+			desc = details[p].Description
 		}
-		if details[p] != nil && details[p].Description != "" {
-			prefixEntry["description"] = details[p].Description
+		prefixEntry := map[string]interface{}{
+			"cidr":        p,
+			"description": desc,
 		}
 		set.Add(prefixEntry)
 	}

--- a/alkira/resource_alkira_service_bluecat.go
+++ b/alkira/resource_alkira_service_bluecat.go
@@ -27,7 +27,7 @@ func resourceAlkiraBluecat() *schema.Resource {
 				d.SetNew("provision_state", "SUCCESS")
 			}
 
-			return validateBluecatInstanceHostnames(d.Get("instance").([]interface{}))
+			return validateBluecatInstanceHostnames(d.Get("instance").(*schema.Set).List())
 		},
 		Importer: &schema.ResourceImporter{
 			StateContext: importWithReadValidation(resourceBluecatRead),
@@ -116,7 +116,8 @@ func resourceAlkiraBluecat() *schema.Resource {
 				Computed:    true,
 			},
 			"instance": {
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
+				Set:      bluecatInstanceHash,
 				Required: true,
 				Description: "The properties pertaining to each individual " +
 					"instance of the Bluecat service.",
@@ -444,8 +445,8 @@ func generateBluecatRequest(d *schema.ResourceData, m interface{}) (*alkira.Serv
 	// id lookup. This prevents positional list shifts from sending wrong ids to the API.
 	oldInstanceListRaw, newInstanceListRaw := d.GetChange("instance")
 	instances, err := expandBluecatInstances(
-		newInstanceListRaw.([]interface{}),
-		oldInstanceListRaw.([]interface{}),
+		newInstanceListRaw.(*schema.Set).List(),
+		oldInstanceListRaw.(*schema.Set).List(),
 		m,
 	)
 	if err != nil {

--- a/alkira/resource_alkira_service_bluecat_helper.go
+++ b/alkira/resource_alkira_service_bluecat_helper.go
@@ -8,6 +8,28 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
+// bluecatInstanceHash computes a unique hash for Bluecat service instances
+// based on hostname + type, which are the immutable identity fields.
+//
+// Rationale for hash composition:
+// - hostname: Unique identifier, validated for uniqueness in CustomizeDiff
+// - type: Immutable after provisioning (BDDS or EDGE)
+//
+// Excluded from hash (updatable fields):
+// - model: Can be changed (e.g., cBDDS50 -> cBDDS100)
+// - version: Can be changed (e.g., 9.4.0 -> 10.0.0)
+// - name: Computed field set to hostname
+// - id: Computed field from API
+//
+// Changes to model/version will show as updates (not replacements) because
+// the hash stays the same. The expandBluecatInstances function does
+// hostname-based ID lookup to ensure the correct instance ID is used.
+var bluecatInstanceHash = serviceInstanceHash(func(m map[string]interface{}) string {
+	hostname := getHostnameFromInstance(m)
+	instanceType, _ := m["type"].(string)
+	return fmt.Sprintf("%s-%s", hostname, instanceType)
+})
+
 func expandBluecatInstances(in []interface{}, oldInstances []interface{}, m interface{}) ([]alkira.BluecatInstance, error) {
 	if in == nil || len(in) == 0 {
 		return nil, fmt.Errorf("[ERROR]: Bluecat instances cannot be nil or empty")
@@ -227,7 +249,7 @@ func deflateBluecatInstances(c []alkira.BluecatInstance, d *schema.ResourceData)
 
 	// Read existing instances from state to preserve sensitive fields
 	// not returned by the API.
-	oldInstances := d.Get("instance").([]interface{})
+	oldInstances := d.Get("instance").(*schema.Set).List()
 
 	for _, v := range c {
 		j := map[string]interface{}{

--- a/alkira/resource_alkira_service_bluecat_helper.go
+++ b/alkira/resource_alkira_service_bluecat_helper.go
@@ -24,7 +24,7 @@ import (
 // Changes to model/version will show as updates (not replacements) because
 // the hash stays the same. The expandBluecatInstances function does
 // hostname-based ID lookup to ensure the correct instance ID is used.
-var bluecatInstanceHash = serviceInstanceHash(func(m map[string]interface{}) string {
+var bluecatInstanceHash = typeSetHash(func(m map[string]interface{}) string {
 	hostname := getHostnameFromInstance(m)
 	instanceType, _ := m["type"].(string)
 	return fmt.Sprintf("%s-%s", hostname, instanceType)

--- a/alkira/resource_alkira_service_bluecat_test.go
+++ b/alkira/resource_alkira_service_bluecat_test.go
@@ -242,8 +242,24 @@ func TestAlkiraServiceBluecat_buildServiceBluecatRequestWithInstances(t *testing
 	require.Equal(t, expectedCxp, request.Cxp)
 	require.Len(t, request.Instances, 2)
 
+	// Verify instances (find by type since TypeSet doesn't preserve order)
+	var bddsInstances []alkira.BluecatInstance
+	var edgeInstances []alkira.BluecatInstance
+	for i := range request.Instances {
+		switch request.Instances[i].Type {
+		case "BDDS":
+			bddsInstances = append(bddsInstances, request.Instances[i])
+		case "EDGE":
+			edgeInstances = append(edgeInstances, request.Instances[i])
+		}
+	}
+
+	// Assert instance counts
+	require.Len(t, bddsInstances, 1, "Should have exactly 1 BDDS instance")
+	require.Len(t, edgeInstances, 1, "Should have exactly 1 EDGE instance")
+
 	// Verify BDDS instance
-	bddsInstance := request.Instances[0]
+	bddsInstance := bddsInstances[0]
 	require.Equal(t, "bdds-primary", bddsInstance.Name)
 	require.Equal(t, "BDDS", bddsInstance.Type)
 	require.NotNil(t, bddsInstance.BddsOptions)
@@ -252,7 +268,7 @@ func TestAlkiraServiceBluecat_buildServiceBluecatRequestWithInstances(t *testing
 	require.Equal(t, "9.4.0", bddsInstance.BddsOptions.Version)
 
 	// Verify Edge instance
-	edgeInstance := request.Instances[1]
+	edgeInstance := edgeInstances[0]
 	require.Equal(t, "edge-primary", edgeInstance.Name)
 	require.Equal(t, "EDGE", edgeInstance.Type)
 	require.NotNil(t, edgeInstance.EdgeOptions)
@@ -294,7 +310,7 @@ func TestAlkiraServiceBluecat_resourceSchema(t *testing.T) {
 	}
 
 	if instanceSchema, exists := resource.Schema["instance"]; exists {
-		assert.Equal(t, schema.TypeList, instanceSchema.Type, "Instance should be list type")
+		assert.Equal(t, schema.TypeSet, instanceSchema.Type, "Instance should be set type")
 		assert.True(t, instanceSchema.Required, "Instance should be required")
 	}
 
@@ -615,7 +631,8 @@ func buildServiceBluecatRequest(d *schema.ResourceData) *alkira.ServiceBluecat {
 
 	// Handle instances configuration
 	if instancesRaw := d.Get("instance"); instancesRaw != nil {
-		if instancesList, ok := instancesRaw.([]interface{}); ok {
+		if instancesSet, ok := instancesRaw.(*schema.Set); ok {
+			instancesList := instancesSet.List()
 			instances := make([]alkira.BluecatInstance, len(instancesList))
 			for i, instanceRaw := range instancesList {
 				if instanceMap, ok := instanceRaw.(map[string]interface{}); ok {
@@ -711,4 +728,206 @@ func getStringSliceFromMapBluecat(m map[string]interface{}, key string) []string
 		}
 	}
 	return []string{}
+}
+
+func TestBluecatInstanceHash_Stability(t *testing.T) {
+	// Same hostname should produce same hash regardless of computed fields
+	hostname := "bdds-primary.example.com"
+
+	instance1 := map[string]interface{}{
+		"name": "bdds-primary",
+		"type": "BDDS",
+		"id":   123,
+		"bdds_options": []interface{}{
+			map[string]interface{}{
+				"hostname":              hostname,
+				"model":                 "cBDDS50",
+				"version":               "9.4.0",
+				"license_credential_id": "cred-123",
+			},
+		},
+	}
+
+	instance2 := map[string]interface{}{
+		"name": "different-name",
+		"type": "BDDS",
+		"id":   456, // Different computed id
+		"bdds_options": []interface{}{
+			map[string]interface{}{
+				"hostname":              hostname, // Same hostname
+				"model":                 "cBDDS50",
+				"version":               "9.4.0",
+				"license_credential_id": "different-cred",
+			},
+		},
+	}
+
+	hash1 := bluecatInstanceHash(instance1)
+	hash2 := bluecatInstanceHash(instance2)
+
+	assert.Equal(t, hash1, hash2, "Hash should be stable for same hostname regardless of other fields")
+}
+
+func TestBluecatInstanceHash_Uniqueness(t *testing.T) {
+	// Different hostnames should produce different hashes
+	bddsInstance := map[string]interface{}{
+		"name": "bdds-primary",
+		"type": "BDDS",
+		"bdds_options": []interface{}{
+			map[string]interface{}{
+				"hostname": "bdds.example.com",
+				"model":    "cBDDS50",
+				"version":  "9.4.0",
+			},
+		},
+	}
+
+	edgeInstance := map[string]interface{}{
+		"name": "edge-primary",
+		"type": "EDGE",
+		"edge_options": []interface{}{
+			map[string]interface{}{
+				"hostname": "edge.example.com",
+				"version":  "4.2.0",
+			},
+		},
+	}
+
+	hash1 := bluecatInstanceHash(bddsInstance)
+	hash2 := bluecatInstanceHash(edgeInstance)
+
+	assert.NotEqual(t, hash1, hash2, "Hash should be unique for different hostnames")
+}
+
+func TestBluecatInstanceHash_ModelVersionChangeDoesNotChangeHash(t *testing.T) {
+	// KEY TEST: Changing model or version should NOT change hash
+	// This ensures such changes are treated as updates, not replacements
+	hostname := "bdds-primary.example.com"
+
+	instance1 := map[string]interface{}{
+		"name": "bdds-primary",
+		"type": "BDDS",
+		"bdds_options": []interface{}{
+			map[string]interface{}{
+				"hostname": hostname,
+				"model":    "cBDDS50",
+				"version":  "9.4.0",
+			},
+		},
+	}
+
+	instance2 := map[string]interface{}{
+		"name": "bdds-primary",
+		"type": "BDDS",
+		"bdds_options": []interface{}{
+			map[string]interface{}{
+				"hostname": hostname,
+				"model":    "cBDDS100", // CHANGED
+				"version":  "10.0.0",   // CHANGED
+			},
+		},
+	}
+
+	hash1 := bluecatInstanceHash(instance1)
+	hash2 := bluecatInstanceHash(instance2)
+
+	assert.Equal(t, hash1, hash2, "Hash should be stable for same hostname+type even when model/version changes")
+}
+
+func TestBluecatInstanceHash_TypeChangeChangesHash(t *testing.T) {
+	// Changing type SHOULD change hash because type is immutable
+	// This ensures type changes show as replacements (which is correct since type cannot be updated)
+	hostname := "same-hostname.example.com"
+
+	bddsInstance := map[string]interface{}{
+		"name": "instance1",
+		"type": "BDDS",
+		"bdds_options": []interface{}{
+			map[string]interface{}{
+				"hostname": hostname,
+				"model":    "cBDDS50",
+				"version":  "9.4.0",
+			},
+		},
+	}
+
+	edgeInstance := map[string]interface{}{
+		"name": "instance2",
+		"type": "EDGE", // Different type
+		"edge_options": []interface{}{
+			map[string]interface{}{
+				"hostname": hostname, // Same hostname
+				"version":  "4.2.0",
+			},
+		},
+	}
+
+	hash1 := bluecatInstanceHash(bddsInstance)
+	hash2 := bluecatInstanceHash(edgeInstance)
+
+	assert.NotEqual(t, hash1, hash2, "Hash should be different for same hostname with different types")
+}
+
+func TestBluecatInstanceHash_EmptyOptions(t *testing.T) {
+	// Empty bdds_options or edge_options should not panic and return empty hash
+	instance1 := map[string]interface{}{
+		"name":         "test",
+		"type":         "BDDS",
+		"bdds_options": []interface{}{},
+	}
+
+	hash1 := bluecatInstanceHash(instance1)
+	assert.NotZero(t, hash1, "Empty options should return a hash (empty string hashes to non-zero)")
+
+	instance2 := map[string]interface{}{
+		"name": "test",
+		"type": "BDDS", // Same type as instance1
+		// No bdds_options or edge_options at all
+	}
+
+	hash2 := bluecatInstanceHash(instance2)
+	assert.Equal(t, hash1, hash2, "Missing options and empty options should produce same hash (empty hostname)")
+}
+
+func TestBluecatInstanceHash_NilOptions(t *testing.T) {
+	// nil bdds_options or edge_options should not panic
+	instance := map[string]interface{}{
+		"name":         "test",
+		"type":         "BDDS",
+		"bdds_options": nil,
+	}
+
+	// Should not panic
+	hash1 := bluecatInstanceHash(instance)
+	assert.NotZero(t, hash1, "nil options should return a hash")
+}
+
+func TestBluecatInstanceHash_EmptyHostname(t *testing.T) {
+	// Empty hostname should return hash of empty string with type
+	instance1 := map[string]interface{}{
+		"name": "test",
+		"type": "BDDS",
+		"bdds_options": []interface{}{
+			map[string]interface{}{
+				"hostname": "", // Empty hostname
+				"model":    "cBDDS50",
+				"version":  "9.4.0",
+			},
+		},
+	}
+
+	instance2 := map[string]interface{}{
+		"name": "test",
+		"type": "BDDS", // Same type as instance1
+		"bdds_options": []interface{}{
+			map[string]interface{}{
+				"hostname": "", // Empty hostname
+			},
+		},
+	}
+
+	hash1 := bluecatInstanceHash(instance1)
+	hash2 := bluecatInstanceHash(instance2)
+
+	assert.Equal(t, hash1, hash2, "Empty hostnames with same type should produce same hash")
 }

--- a/docs/resources/service_bluecat.md
+++ b/docs/resources/service_bluecat.md
@@ -313,7 +313,7 @@ resource "alkira_service_bluecat" "production" {
 
 - `cxp` (String) The CXP where the service should be provisioned.
 - `global_cidr_list_id` (Number) The ID of the global cidr list to be associated with the Bluecat service.
-- `instance` (Block List, Min: 1) The properties pertaining to each individual instance of the Bluecat service. (see [below for nested schema](#nestedblock--instance))
+- `instance` (Block Set, Min: 1) The properties pertaining to each individual instance of the Bluecat service. (see [below for nested schema](#nestedblock--instance))
 - `name` (String) Name of the Bluecat service.
 - `segment_ids` (Set of String) IDs of segments associated with the service.
 - `service_group_name` (String) The name of the service group to be associated with the service. A service group represents the service in traffic policies, route policies and when configuring segment resource shares.


### PR DESCRIPTION
## Summary

- Convert Bluecat service `instance` from TypeList to TypeSet with hostname+type-based hash
- Convert Policy Prefix List `prefix` and `prefix_range` from TypeList to TypeSet with CIDR-based hash
- Add generic `serviceInstanceHash` helper for reusability across multiple services

## Problem

TypeList matches elements by position, causing spurious updates when instances are removed from the middle of a list. 

**Example from real user case:**
- Initial config: `[bdds1, edge1]`
- Updated config: `[bdds1, bdds2, edge1]`
- **Current behavior:** Terraform treats this as an update of `edge1 -> bdds2` and addition of `edge1`
- **Expected behavior:** Only addition of `bdds2`

Similarly, removing `bdds2` from `[bdds1, bdds2, edge1, edge2]` results in `[bdds1, edge1]`, but:
- **Current behavior:** Update of `bdds2 -> edge1` instead of just removing `bdds2` and `edge2`

## Solution

TypeSet matches elements by hash key, using instance identity fields:
- **Bluecat service:** Hash on `hostname + type` (both immutable after provisioning)
- **Policy Prefix List:** Hash on `cidr` for prefixes, `prefix-le-ge` tuple for prefix_ranges

This ensures removing an instance only affects that specific instance, not others that happen to be at a different position.

**Hash composition rationale (Bluecat):**
- `hostname`: Unique identifier, validated for uniqueness in CustomizeDiff
- `type`: Immutable after provisioning (BDDS or EDGE) - per API documentation
- Excluded from hash: `model`, `version` (upgradable fields that should trigger updates, not replacements)

## Changes

- `alkira/helper.go` — Add `serviceInstanceHash()` generic helper
- `alkira/resource_alkira_service_bluecat.go` — Change `instance` from TypeList to TypeSet
- `alkira/resource_alkira_service_bluecat_helper.go` — Update expand/flatten for TypeSet access, hash uses hostname+type
- `alkira/resource_alkira_policy_prefix_list.go` — Change `prefix` and `prefix_range` to TypeSet
- `alkira/resource_alkira_policy_prefix_list_helper.go` — Refactor to use generic hash function

## Testing Performed

### Bluecat Service (Live Testing)

**Test environment:** `test/bluecat-typeset-live-test/`

1. **Create initial service** — 3 instances (bdds-b, bdds-d, bdds-a)
2. **Refresh + Plan** — "No changes"
3. **KEY TEST: Remove middle instance (bdds-d)** — Only bdds-d removed, bdds-b/bdds-a unaffected
4. **Add instance back (bdds-c)** — Only bdds-c created
5. **Reorder instances** — "No changes" (TypeSet ignores order)
6. **Stability verification** — All subsequent plans show "No changes"
7. **Destroy** — All resources cleaned up successfully

### Hash Function Tests (Unit Tests)

- `TestBluecatInstanceHash_Stability` — Same hostname+type produces same hash
- `TestBluecatInstanceHash_Uniqueness` — Different hostnames produce different hashes
- `TestBluecatInstanceHash_ModelVersionChangeDoesNotChangeHash` — Model/version changes don't change hash (allows updates)
- `TestBluecatInstanceHash_TypeChangeChangesHash` — Different types produce different hashes (type is immutable)
- `TestBluecatInstanceHash_EmptyOptions` — Empty options handled gracefully
- `TestBluecatInstanceHash_NilOptions` — Nil options handled gracefully
- `TestBluecatInstanceHash_EmptyHostname` — Empty hostname produces consistent hash

### Policy Prefix List (Live Testing)

**Test environment:** `test/policy-prefix-list-typeset-live-test/`

#### Phase 1: `prefix` Block (Simple CIDR)
- Create with 3 prefixes
- **KEY TEST:** Remove middle prefix (10.2.0.0/24) — Only that prefix deleted, others unchanged
- Add new prefix — No spurious updates
- Reorder prefixes — Plan shows "No changes" (TypeSet ignores order)

#### Phase 2: `prefix_range` Block (Complex with le/ge)
- Create with 3 prefix ranges
- **KEY TEST:** Remove middle range (192.168.0.0/16) — Only that range deleted, le/ge preserved for others
- Update le/ge values — Only modified range changes

#### Phase 3-4: Mixed and Import
- Mixed `prefix` and `prefix_range` blocks
- Import + generate config works correctly

### Code Quality

- `make lint` — 0 issues
- `go build` — clean
- Unit tests — All pass (hash stability, uniqueness, expand/flatten)