### PR TITLE
AK-65440: Fix missing destination endpoints in F5 vServer Read function

### DIFF
--- a/alkira/resource_alkira_service_f5_vserver_endpoint.go
+++ b/alkira/resource_alkira_service_f5_vserver_endpoint.go
@@ -182,6 +182,16 @@ func resourceF5vServerEndpointRead(ctx context.Context, d *schema.ResourceData, 
 	d.Set("f5_service_id", f5.F5ServiceId)
 	d.Set("f5_service_instance_ids", f5.F5ServiceInstanceIds)
 
+	// Set destination endpoint fields if present
+	if f5.DestinationEndpoints != nil {
+		if f5.DestinationEndpoints.PortRanges != nil {
+			d.Set("destination_endpoint_port_ranges", f5.DestinationEndpoints.PortRanges)
+		}
+		if f5.DestinationEndpoints.IpAddresses != nil {
+			d.Set("destination_endpoint_ip_addresses", f5.DestinationEndpoints.IpAddresses)
+		}
+	}
+
 	segmentId, err := getSegmentIdByName(f5.Segment, m)
 
 	if err != nil {

--- a/alkira/resource_alkira_service_f5_vserver_endpoint_test.go
+++ b/alkira/resource_alkira_service_f5_vserver_endpoint_test.go
@@ -37,6 +37,25 @@ func TestAlkiraServiceF5vServerEndpoint_basicFunctionality(t *testing.T) {
 	assert.Equal(t, []string{"80", "443"}, serviceF5vServerEndpoint.PortRanges)
 }
 
+func TestAlkiraServiceF5vServerEndpoint_destinationEndpoints(t *testing.T) {
+	// Test with destination endpoints
+	endpointWithDest := &alkira.F5vServerEndpoint{
+		Id:   json.Number("123"),
+		Name: "test-endpoint",
+		DestinationEndpoints: &alkira.F5VServerDestinationEndpoints{
+			PortRanges:  []string{"8080", "9090-9100"},
+			IpAddresses: []string{"10.0.0.1", "10.0.0.2"},
+		},
+	}
+
+	// Verify all fields are set correctly
+	assert.Equal(t, json.Number("123"), endpointWithDest.Id)
+	assert.Equal(t, "test-endpoint", endpointWithDest.Name)
+	assert.NotNil(t, endpointWithDest.DestinationEndpoints)
+	assert.Equal(t, []string{"8080", "9090-9100"}, endpointWithDest.DestinationEndpoints.PortRanges)
+	assert.Equal(t, []string{"10.0.0.1", "10.0.0.2"}, endpointWithDest.DestinationEndpoints.IpAddresses)
+}
+
 func TestAlkiraServiceF5vServerEndpoint_nameValidation(t *testing.T) {
 	tests := GetCommonNameValidationTestCases()
 


### PR DESCRIPTION
## Summary

- Fix missing `destination_endpoint_port_ranges` and `destination_endpoint_ip_addresses` fields in F5 vServer endpoint Read function
- Add code to set destination endpoint fields from API response when present
- Add unit test for destination endpoints structure

## Problem

The Read function for `alkira_service_f5_vserver_endpoint` was missing code to set `destination_endpoint_port_ranges` and `destination_endpoint_ip_addresses` from the API response. This caused:

1. **Spurious diffs on every plan/apply** — These fields would show as null in state after refresh, triggering unnecessary updates
2. **Import didn't populate fields correctly** — Imported resources would have null destination endpoint values
3. **Drift detection broken** — Changes to these fields in the API wouldn't be detected

## Solution

The fix adds code in `resourceF5vServerEndpointRead()` to set the two missing fields from the nested `f5.DestinationEndpoints` structure when present:

```go
// Set destination endpoint fields if present
if f5.DestinationEndpoints != nil {
    if f5.DestinationEndpoints.PortRanges != nil {
        d.Set("destination_endpoint_port_ranges", f5.DestinationEndpoints.PortRanges)
    }
    if f5.DestinationEndpoints.IpAddresses != nil {
        d.Set("destination_endpoint_ip_addresses", f5.DestinationEndpoints.IpAddresses)
    }
}
```

The implementation:
- Performs outer nil-check on `DestinationEndpoints` before accessing nested fields
- Performs individual nil-checks on each nested field before setting
- Uses correct schema field names matching the flat schema structure
- Follows the same pattern as other field sets in the Read function

## Changes

- `alkira/resource_alkira_service_f5_vserver_endpoint.go` — Add destination endpoint field setting in Read function
- `alkira/resource_alkira_service_f5_vserver_endpoint_test.go` — Add unit test for destination endpoints structure

## Testing Performed

### Phase 1: Greenfield CRUD (Completed & Verified)

**Test environment:** `test/AK-65440-f5-vserver-destination-endpoints/`

- **Create:** F5 LB Service + F5 vServer Endpoint created successfully
- **Read/Refresh:** `terraform refresh` completed successfully
- **KEY TEST:** `terraform plan` shows **"No changes"** after refresh — Confirms fix prevents spurious diffs
- **Destroy:** All resources destroyed successfully

### Phase 2: Import Workflow (Completed & Verified)

- **Import:** Existing resource imported successfully using `terraform import`
- **Generated Config:** `terraform plan -generate-config-out=generated.tf` produces correct config with destination endpoint fields populated
- **Post-Import Plan:** `terraform plan` shows **"No changes"** — Import correctly populates all fields

### Phase 3: Brownfield Upgrade Path (Completed & Verified)

- **Create with Registry:** Resource created with published provider version (without fix)
- **Switch to Fixed Build:** Upgraded to new provider build with fix
- **Upgrade Plan:** `terraform plan` shows **"No changes"** — Seamless upgrade, no spurious diffs
- **Refresh After Upgrade:** `terraform refresh` correctly populates destination endpoint fields from API
- **Post-Upgrade Plan:** Shows **"No changes"** — State transition is stable

### Phase 4: ELB Type Without Destination Endpoints (Completed & Verified)

- ELB type endpoints don't have `destinationEndpoints` in API response
- Fix correctly handles null case — no errors or spurious diffs when these fields are absent
- **Create:** ELB endpoint created successfully
- **Refresh:** Plan shows "No changes" (null destination endpoints don't cause drift)

### Unit Tests (Completed & Verified)

- `TestAlkiraServiceF5vServerEndpoint_destinationEndpoints` — Verifies API structure and field access

### Code Quality (All Passing)

- `make lint` — 0 issues
- `go build` — Clean build
- Unit tests — All pass