### PR TITLE
AK-65446: Fix pan_credential_name not populated in Read

### DIFF
--- a/alkira/resource_alkira_service_pan.go
+++ b/alkira/resource_alkira_service_pan.go
@@ -535,6 +535,16 @@ func resourceServicePanRead(ctx context.Context, d *schema.ResourceData, m inter
 	d.Set("pan_registration_credential_id", pan.RegistrationCredentialId)
 	d.Set("pan_master_key_credential_id", pan.MasterKeyCredentialId)
 
+	// Set PAN credential name (computed field)
+	// API returns credential name via GetCredentialById()
+	if pan.CredentialId != "" {
+		if cred, err := client.GetCredentialById(pan.CredentialId); err == nil {
+			d.Set("pan_credential_name", cred.Name)
+		} else {
+			log.Printf("[WARNING] Failed to get PAN credential name: %v", err)
+		}
+	}
+
 	if pan.PanoramaDeviceGroup != nil {
 		d.Set("panorama_device_group", pan.PanoramaDeviceGroup)
 	}


### PR DESCRIPTION
## Summary

- Populate `pan_credential_name` computed field during Read via `GetCredentialById()`
- Gracefully handle credential lookup failures with a warning log

## Problem

The `pan_credential_name` field is defined as `Computed` but was never set in the Read function. After `terraform refresh` or `terraform apply`, the field becomes empty. Subsequent updates then fail with:

```
pan_credential_name is empty when updating PAN credential
```

## Solution

In `resourceServicePanRead()`, fetch the credential name using `client.GetCredentialById()` when `CredentialId` is present. If the lookup fails (e.g. credential deleted out-of-band), log a warning instead of failing the Read.

## Changes

- `alkira/resource_alkira_service_pan.go` — Add credential name lookup in Read function

## Testing Performed

### Phase 1: Greenfield CRUD

- Create — `pan_credential_name` populated with random suffix
- Refresh + Plan — Name persists, **"No changes"**
- **KEY TEST:** Update description — Only `description` in diff, no "empty credential name" error, same resource ID
- Idempotency — **"No changes"**
- Destroy — Clean destroy, empty state

### Phase 2: Import + Generate Config

- Generate config — `pan_credential_name` populated from API during import Read
- Apply import — Succeeded, credential name set correctly
- **KEY TEST:** Plan after import — **"No changes"**
- Destroy — Clean destroy

### Code Quality

- `make lint` — 0 issues
- `go build` — clean
- Unit tests — All pass