### PR TITLE
AK-65441: fixing array handling logic for segment for RA

### DIFF
--- a/alkira/resource_alkira_connector_remote_access_helper.go
+++ b/alkira/resource_alkira_connector_remote_access_helper.go
@@ -176,7 +176,8 @@ func setAuthorization(d *schema.ResourceData, segmentOptions []alkira.ConnectorR
 	for _, option := range segmentOptions {
 
 		if len(option.UserGroupMappings) != 1 ||
-			len(option.UserGroupMappings[0].CxpToSubnetsMapping) != 1 {
+			len(option.UserGroupMappings[0].CxpToSubnetsMapping) != 1 ||
+			len(option.UserGroupMappings[0].CxpToSubnetsMapping[0].Subnets) == 0 {
 			log.Printf("[ERROR] Invalid SegmentOptions in connector-remote-access")
 			continue
 		}
@@ -187,7 +188,7 @@ func setAuthorization(d *schema.ResourceData, segmentOptions []alkira.ConnectorR
 			"split_tunneling": option.UserGroupMappings[0].SplitTunneling,
 			"prefix_list_id":  option.UserGroupMappings[0].PrefixListId,
 			"billing_tag_id":  option.UserGroupMappings[0].BillingTag,
-			"subnet":          option.UserGroupMappings[0].CxpToSubnetsMapping[0].Subnets,
+			"subnet":          option.UserGroupMappings[0].CxpToSubnetsMapping[0].Subnets[0],
 		}
 
 		authorizations = append(authorizations, auth)


### PR DESCRIPTION
Bug Reproduction (buggy main binary):

Created alkira_connector_remote_access with subnet = "10.0.0.0/24" using main branch binary via dev.tfrc override
TF_LOG=DEBUG terraform plan confirmed the error:
[ERROR] setting state: authorization.0.subnet: '' expected type 'string', got unconvertible type '[]string', value: '[10.0.0.0/24]'
subnet showed as null in state after every Read — perpetual drift on every plan
Fix Applied:

Changed Subnets → Subnets[0] in setAuthorization in resource_alkira_connector_remote_access_helper.go line 190
Fix Verification (fixed binary):

No more [ERROR] in debug logs
subnet = "10.0.0.0/24" correctly populated in state
terraform plan shows no drift on authorization block
Import Test:

terraform state rm alkira_connector_remote_access.test
terraform import alkira_connector_remote_access.test 253
State after import shows subnet = "10.0.0.0/24" populated purely from API with no prior state
Idempotency:

terraform plan after import — authorization block shows "1 unchanged block hidden", confirming subnet is stable with no drift
+# Brownfield Test (existing state with broken binary):
- Ran terraform apply against existing connector (ID 253) using broken binary

Terraform SDK retained prior state value for subnet when d.Set failed
(array -> string type mismatch logged but prior value preserved) - Result: existing users with correct subnet in state will NOT see unexpected
drift when upgrading — bug only fully manifests on fresh creates and imports