### PR TITLE
AK-65442: Remove networkEntitySubType from network_entity_scale_options

### DIFF
--- a/alkira/resource_alkira_network_entity_scale_options.go
+++ b/alkira/resource_alkira_network_entity_scale_options.go
@@ -208,7 +208,6 @@ func resourceNetworkEntityScaleOptionsRead(ctx context.Context, d *schema.Resour
 	d.Set("entity_id", strconv.Itoa(networkEntityScaleOptions.EntityId))
 	d.Set("entity_type", networkEntityScaleOptions.EntityType)
 	d.Set("network_entity_id", networkEntityScaleOptions.NetworkEntityId)
-	d.Set("network_entity_sub_type", networkEntityScaleOptions.NetworkEntitySubType)
 	d.Set("network_entity_type", networkEntityScaleOptions.NetworkEntityType)
 	d.Set("doc_state", networkEntityScaleOptions.DocState)
 	d.Set("last_config_updated_at", networkEntityScaleOptions.LastConfigUpdatedAt)

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/alkiranet/terraform-provider-alkira
 go 1.26
 
 require (
-	github.com/alkiranet/alkira-client-go v1.59.1-0.20260310051734-d6fba43c6ebf
+	github.com/alkiranet/alkira-client-go v1.59.1-0.20260317173620-b10dbd782645
 	github.com/hashicorp/go-cty v1.5.0
 	github.com/hashicorp/go-retryablehttp v0.7.7
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.37.0

--- a/go.sum
+++ b/go.sum
@@ -5,8 +5,8 @@ github.com/PuerkitoBio/purell v1.1.1/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbt
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
 github.com/agext/levenshtein v1.2.2 h1:0S/Yg6LYmFJ5stwQeRp6EeOcCbj7xiqQSdNelsXvaqE=
 github.com/agext/levenshtein v1.2.2/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
-github.com/alkiranet/alkira-client-go v1.59.1-0.20260310051734-d6fba43c6ebf h1:ec3I0vG3Ry5Yte6rtIPW3JWe+ieJzbkRlz0SGOSlCLI=
-github.com/alkiranet/alkira-client-go v1.59.1-0.20260310051734-d6fba43c6ebf/go.mod h1:ms9LjOc4O1Zrr7/VQOva+xwv3sJuBUqS9JsI+MbE2go=
+github.com/alkiranet/alkira-client-go v1.59.1-0.20260317173620-b10dbd782645 h1:JEnkuITr2+ZCQ3Lom+taSlIBBqvIUuy7q1fvvWzDRjg=
+github.com/alkiranet/alkira-client-go v1.59.1-0.20260317173620-b10dbd782645/go.mod h1:ms9LjOc4O1Zrr7/VQOva+xwv3sJuBUqS9JsI+MbE2go=
 github.com/apparentlymart/go-textseg/v12 v12.0.0/go.mod h1:S/4uRK2UtaQttw1GenVJEynmyUenKwP++x/+DdGV/Ec=
 github.com/apparentlymart/go-textseg/v15 v15.0.0 h1:uYvfpb3DyLSCGWnctWKGj857c6ew1u1fNQOlOtuGxQY=
 github.com/apparentlymart/go-textseg/v15 v15.0.0/go.mod h1:K8XmNZdhEBkdlyDdvbmmsvpAG721bKi0joRfFdHIWJ4=

--- a/vendor/github.com/alkiranet/alkira-client-go/alkira/network_entity_scale_options.go
+++ b/vendor/github.com/alkiranet/alkira-client-go/alkira/network_entity_scale_options.go
@@ -22,18 +22,17 @@ type SegmentScaleOptions struct {
 }
 
 type NetworkEntityScaleOptions struct {
-	Description          string                `json:"description"`
-	DocState             string                `json:"docState,omitempty"`
-	EntityId             int                   `json:"entityId"`
-	EntityType           string                `json:"entityType"`
-	Id                   json.Number           `json:"id,omitempty"`                  // response only
-	LastConfigUpdatedAt  int                   `json:"lastConfigUpdatedAt,omitempty"` // response only
-	Name                 string                `json:"name"`
-	NetworkEntityId      string                `json:"networkEntityId"`
-	NetworkEntitySubType string                `json:"networkEntitySubType"`
-	NetworkEntityType    string                `json:"networkEntityType"`
-	SegmentScaleOptions  []SegmentScaleOptions `json:"segmentScaleOptions"`
-	State                string                `json:"state,omitempty"` // response only
+	Description         string                `json:"description"`
+	DocState            string                `json:"docState,omitempty"`
+	EntityId            int                   `json:"entityId"`
+	EntityType          string                `json:"entityType"`
+	Id                  json.Number           `json:"id,omitempty"`                  // response only
+	LastConfigUpdatedAt int                   `json:"lastConfigUpdatedAt,omitempty"` // response only
+	Name                string                `json:"name"`
+	NetworkEntityId     string                `json:"networkEntityId"`
+	NetworkEntityType   string                `json:"networkEntityType"`
+	SegmentScaleOptions []SegmentScaleOptions `json:"segmentScaleOptions"`
+	State               string                `json:"state,omitempty"` // response only
 }
 
 // NewNetworkEntityScaleOptions new network entity scale options

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,7 +1,7 @@
 # github.com/agext/levenshtein v1.2.2
 ## explicit
 github.com/agext/levenshtein
-# github.com/alkiranet/alkira-client-go v1.59.1-0.20260310051734-d6fba43c6ebf
+# github.com/alkiranet/alkira-client-go v1.59.1-0.20260317173620-b10dbd782645
 ## explicit; go 1.26
 github.com/alkiranet/alkira-client-go/alkira
 # github.com/apparentlymart/go-textseg/v15 v15.0.0


### PR DESCRIPTION
## Summary

- Remove `networkEntitySubType` field from `NetworkEntityScaleOptions` client struct
- Remove corresponding state setter from provider Read function
- Update `alkira-client-go` dependency

## Problem

The `network_entity_sub_type` field was being set in the Read function but the backend API does not include `networkEntitySubType` in its response. This caused a schema/state mismatch where the provider attempted to read a field that was never returned.

## Solution

Remove the field from both the `alkira-client-go` struct and the provider Read function to align with the actual API behavior.

## Changes

- `vendor/github.com/alkiranet/alkira-client-go/alkira/network_entity_scale_options.go` — Remove `NetworkEntitySubType` from struct
- `alkira/resource_alkira_network_entity_scale_options.go` — Remove `d.Set("network_entity_sub_type", ...)` from Read
- `go.mod`, `go.sum`, `vendor/modules.txt` — Update `alkira-client-go` dependency

## Testing Performed

### API Payload Verification

- Confirmed backend model does not include `networkEntitySubType`
- Verified all remaining fields align between provider and backend
- Confirmed `segmentScaleOptions` nested structure matches backend expectations

### Greenfield CRUD

- Create with additional tunnels per node — Resource created successfully
- Read/Refresh — Plan shows "No changes"
- Update description — Only changed field in diff, same resource ID
- Delete — Destroy succeeds, state empty

### Import + Generate Config

- Generate config populates all required fields correctly
- **KEY TEST:** No `network_entity_sub_type` in generated config, confirming field is not in API response
- Post-import plan shows "No changes"

### Code Quality

- `go build` — clean
- `make lint` — 0 issues