### PR TITLE
AK-65424: Fix typo in VMware SD-WAN connector Read function

### DIFF
--- a/alkira/resource_alkira_connector_vmware_sdwan.go
+++ b/alkira/resource_alkira_connector_vmware_sdwan.go
@@ -271,11 +271,11 @@ func resourceConnectorVmwareSdwanRead(ctx context.Context, d *schema.ResourceDat
 
 	for _, m := range connector.VmWareSdWanVRFMappings {
 		mapping := map[string]interface{}{
-			"advertise_on_prem_routes":   m.AdvertiseOnPremRoutes,
-			"advertise_default_route":    !m.DisableInternetExit,
-			"gateway_bgp_asn":            m.GatewayBgpAsn,
-			"segment_id":                 m.SegmentId,
-			"vmware_sdwang_segment_name": m.VmWareSdWanSegmentName,
+			"advertise_on_prem_routes":  m.AdvertiseOnPremRoutes,
+			"advertise_default_route":   !m.DisableInternetExit,
+			"gateway_bgp_asn":           m.GatewayBgpAsn,
+			"segment_id":                m.SegmentId,
+			"vmware_sdwan_segment_name": m.VmWareSdWanSegmentName,
 		}
 		mappings = append(mappings, mapping)
 	}


### PR DESCRIPTION
## Summary

- Fix typo `vmware_sdwang_segment_name` → `vmware_sdwan_segment_name` in the VMware SD-WAN connector Read function

## Problem

The Read function in `alkira_connector_vmware_sdwan` used `vmware_sdwang_segment_name` (extra "g") as the map key when flattening API responses into Terraform state. Since this key doesn't match the schema field `vmware_sdwan_segment_name`, the value was silently dropped, causing:

1. `vmware_sdwan_segment_name` always empty in state after refresh
2. Perpetual drift on every `terraform plan`
3. Broken import — generated config had empty segment name

## Solution

Fix the map key in `resourceConnectorVmwareSdwanRead` to use the correct field name `vmware_sdwan_segment_name`.

## Changes

- `alkira/resource_alkira_connector_vmware_sdwan.go` — Fix typo in Read function target_segment mapping (line 278)

## Testing Performed

### Phase 1: Greenfield CRUD

- Create — Resource created, `vmware_sdwan_segment_name` correctly populated in state
- **KEY TEST:** Refresh + Plan — **"No changes"** (no drift on `vmware_sdwan_segment_name`)
- Update (description only) — Only description in diff, segment name preserved
- Idempotency — "No changes"
- Destroy — Clean deletion

### Phase 2: Import + Generate Config

- Generate config from existing resource — `vmware_sdwan_segment_name` populated correctly in generated config
- **KEY TEST:** Import + fill credentials — No spurious diff on `vmware_sdwan_segment_name`

### Mutation Tests

- Matching value → "No changes"
- Different value → Diff correctly detected
- Unrelated field update → Only that field in diff, segment name preserved
- API payload verification — `vmWareSdWanSegmentName` present in both REQ and RSP

### Code Quality

- `go build` — clean