### PR TITLE
AK-65435: setting missing fields for OCI connector.

### DIFF
--- a/alkira/resource_alkira_connector_oci_vcn.go
+++ b/alkira/resource_alkira_connector_oci_vcn.go
@@ -274,6 +274,9 @@ func resourceConnectorOciVcnRead(ctx context.Context, d *schema.ResourceData, m 
 		return diag.FromErr(fmt.Errorf("failed to find segment"))
 	}
 
+	// Set vcn_cidr, vcn_subnet, vcn_route_table
+	setConnectorOciVcnRouting(d, connector.VcnRouting)
+
 	// Set provision state
 	if client.Provision && provState != "" {
 		d.Set("provision_state", provState)

--- a/alkira/resource_alkira_connector_oci_vcn_helper.go
+++ b/alkira/resource_alkira_connector_oci_vcn_helper.go
@@ -1,12 +1,109 @@
 package alkira
 
 import (
+	"encoding/json"
 	"fmt"
 	"log"
 
 	"github.com/alkiranet/alkira-client-go/alkira"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
+
+// setConnectorOciVcnRouting sets vcn_cidr, vcn_subnet, and vcn_route_table in state
+// by unmarshaling the VcnRouting interface{} returned from the API into typed structs.
+func setConnectorOciVcnRouting(d *schema.ResourceData, vcnRouting interface{}) {
+	if vcnRouting == nil {
+		return
+	}
+
+	routingJSON, err := json.Marshal(vcnRouting)
+	if err != nil {
+		log.Printf("[ERROR] Failed to marshal VcnRouting: %v", err)
+		return
+	}
+
+	var routing alkira.ConnectorOciVcnRouting
+	if err := json.Unmarshal(routingJSON, &routing); err != nil {
+		log.Printf("[ERROR] Failed to unmarshal VcnRouting: %v", err)
+		return
+	}
+
+	setOciVcnExportPrefixes(routing.Export, d)
+	setOciVcnImportRouteTables(routing.Import, d)
+}
+
+// setOciVcnExportPrefixes sets vcn_cidr or vcn_subnet from export options.
+func setOciVcnExportPrefixes(exportOptions interface{}, d *schema.ResourceData) {
+	if exportOptions == nil {
+		return
+	}
+
+	exportJSON, err := json.Marshal(exportOptions)
+	if err != nil {
+		log.Printf("[ERROR] Failed to marshal ExportOptions: %v", err)
+		return
+	}
+
+	var export alkira.ConnectorOciVcnExportOptions
+	if err := json.Unmarshal(exportJSON, &export); err != nil {
+		log.Printf("[ERROR] Failed to unmarshal ExportOptions: %v", err)
+		return
+	}
+
+	var cidrList []string
+	var subnetList []map[string]interface{}
+
+	for _, prefix := range export.Prefixes {
+		switch prefix.Type {
+		case "CIDR":
+			cidrList = append(cidrList, prefix.Value)
+		case "SUBNET":
+			subnetList = append(subnetList, map[string]interface{}{
+				"id":   prefix.Id,
+				"cidr": prefix.Value,
+			})
+		}
+	}
+
+	if len(cidrList) > 0 {
+		d.Set("vcn_cidr", cidrList)
+	}
+	if len(subnetList) > 0 {
+		d.Set("vcn_subnet", subnetList)
+	}
+}
+
+// setOciVcnImportRouteTables sets vcn_route_table from import options.
+func setOciVcnImportRouteTables(importOptions interface{}, d *schema.ResourceData) {
+	if importOptions == nil {
+		return
+	}
+
+	importJSON, err := json.Marshal(importOptions)
+	if err != nil {
+		log.Printf("[ERROR] Failed to marshal ImportOptions: %v", err)
+		return
+	}
+
+	var importOpts alkira.ConnectorOciVcnImportOptions
+	if err := json.Unmarshal(importJSON, &importOpts); err != nil {
+		log.Printf("[ERROR] Failed to unmarshal ImportOptions: %v", err)
+		return
+	}
+
+	var tables []map[string]interface{}
+	for _, rt := range importOpts.RouteTables {
+		tables = append(tables, map[string]interface{}{
+			"id":              rt.Id,
+			"options":         rt.Mode,
+			"prefix_list_ids": rt.PrefixListIds,
+		})
+	}
+
+	if len(tables) > 0 {
+		d.Set("vcn_route_table", tables)
+	}
+}
 
 // expandConnectorOciVcnRouteTables expand OCI-VCN route tables
 func expandConnectorOciVcnRouteTables(in *schema.Set) []alkira.ConnectorOciVcnRouteTables {

--- a/alkira/resource_alkira_connector_oci_vcn_helper_test.go
+++ b/alkira/resource_alkira_connector_oci_vcn_helper_test.go
@@ -1,0 +1,208 @@
+package alkira
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/stretchr/testify/assert"
+)
+
+func ociVcnTestSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"vcn_cidr": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"vcn_subnet": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id":   {Type: schema.TypeString, Optional: true},
+						"cidr": {Type: schema.TypeString, Optional: true},
+					},
+				},
+			},
+			"vcn_route_table": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {Type: schema.TypeString, Optional: true},
+						"prefix_list_ids": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem:     &schema.Schema{Type: schema.TypeInt},
+						},
+						"options": {
+							Type:     schema.TypeString,
+							Optional: true,
+							ValidateFunc: validation.StringInSlice([]string{
+								"ADVERTISE_DEFAULT_ROUTE",
+								"OVERRIDE_DEFAULT_ROUTE",
+								"ADVERTISE_CUSTOM_PREFIX",
+							}, false),
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func TestSetConnectorOciVcnRouting_Nil(t *testing.T) {
+	d := ociVcnTestSchema().TestResourceData()
+	setConnectorOciVcnRouting(d, nil)
+
+	assert.Empty(t, d.Get("vcn_cidr"))
+	assert.Equal(t, 0, d.Get("vcn_subnet").(*schema.Set).Len())
+	assert.Equal(t, 0, d.Get("vcn_route_table").(*schema.Set).Len())
+}
+
+func TestSetConnectorOciVcnRouting_InvalidType(t *testing.T) {
+	d := ociVcnTestSchema().TestResourceData()
+	// Pass a non-map type — should log error and return without panic
+	setConnectorOciVcnRouting(d, "not-a-map")
+
+	assert.Empty(t, d.Get("vcn_cidr"))
+}
+
+func TestSetConnectorOciVcnRouting_EmptyRouting(t *testing.T) {
+	d := ociVcnTestSchema().TestResourceData()
+
+	vcnRouting := map[string]interface{}{
+		"exportToCXPOptions": map[string]interface{}{
+			"userInputPrefixes": []interface{}{},
+			"routeExportMode":   "USER_INPUT_PREFIXES",
+		},
+		"importFromCXPOptions": map[string]interface{}{
+			"routeTables": []interface{}{},
+		},
+	}
+
+	setConnectorOciVcnRouting(d, vcnRouting)
+
+	assert.Empty(t, d.Get("vcn_cidr"))
+	assert.Equal(t, 0, d.Get("vcn_subnet").(*schema.Set).Len())
+	assert.Equal(t, 0, d.Get("vcn_route_table").(*schema.Set).Len())
+}
+
+func TestSetConnectorOciVcnRouting_WithCidr(t *testing.T) {
+	d := ociVcnTestSchema().TestResourceData()
+
+	vcnRouting := map[string]interface{}{
+		"exportToCXPOptions": map[string]interface{}{
+			"userInputPrefixes": []interface{}{
+				map[string]interface{}{"type": "CIDR", "value": "10.0.0.0/16"},
+				map[string]interface{}{"type": "CIDR", "value": "192.168.0.0/24"},
+			},
+			"routeExportMode": "USER_INPUT_PREFIXES",
+		},
+		"importFromCXPOptions": map[string]interface{}{
+			"routeTables": []interface{}{},
+		},
+	}
+
+	setConnectorOciVcnRouting(d, vcnRouting)
+
+	cidr := d.Get("vcn_cidr").([]interface{})
+	assert.Len(t, cidr, 2)
+	assert.Contains(t, cidr, "10.0.0.0/16")
+	assert.Contains(t, cidr, "192.168.0.0/24")
+	assert.Equal(t, 0, d.Get("vcn_subnet").(*schema.Set).Len())
+}
+
+func TestSetConnectorOciVcnRouting_WithSubnets(t *testing.T) {
+	d := ociVcnTestSchema().TestResourceData()
+
+	vcnRouting := map[string]interface{}{
+		"exportToCXPOptions": map[string]interface{}{
+			"userInputPrefixes": []interface{}{
+				map[string]interface{}{
+					"id":    "ocid1.subnet.oc1..aaa",
+					"type":  "SUBNET",
+					"value": "172.16.0.0/29",
+				},
+			},
+			"routeExportMode": "USER_INPUT_PREFIXES",
+		},
+		"importFromCXPOptions": map[string]interface{}{
+			"routeTables": []interface{}{},
+		},
+	}
+
+	setConnectorOciVcnRouting(d, vcnRouting)
+
+	assert.Empty(t, d.Get("vcn_cidr"))
+	subnets := d.Get("vcn_subnet").(*schema.Set).List()
+	assert.Len(t, subnets, 1)
+	subnet := subnets[0].(map[string]interface{})
+	assert.Equal(t, "ocid1.subnet.oc1..aaa", subnet["id"])
+	assert.Equal(t, "172.16.0.0/29", subnet["cidr"])
+}
+
+func TestSetConnectorOciVcnRouting_WithRouteTables(t *testing.T) {
+	d := ociVcnTestSchema().TestResourceData()
+
+	vcnRouting := map[string]interface{}{
+		"exportToCXPOptions": map[string]interface{}{
+			"userInputPrefixes": []interface{}{},
+			"routeExportMode":   "USER_INPUT_PREFIXES",
+		},
+		"importFromCXPOptions": map[string]interface{}{
+			"routeTables": []interface{}{
+				map[string]interface{}{
+					"id":              "ocid1.routetable.oc1..aaa",
+					"routeImportMode": "ADVERTISE_CUSTOM_PREFIX",
+					"prefixListIds":   []interface{}{float64(1), float64(2)},
+				},
+			},
+		},
+	}
+
+	setConnectorOciVcnRouting(d, vcnRouting)
+
+	tables := d.Get("vcn_route_table").(*schema.Set).List()
+	assert.Len(t, tables, 1)
+	table := tables[0].(map[string]interface{})
+	assert.Equal(t, "ocid1.routetable.oc1..aaa", table["id"])
+	assert.Equal(t, "ADVERTISE_CUSTOM_PREFIX", table["options"])
+	assert.ElementsMatch(t, []int{1, 2}, table["prefix_list_ids"])
+}
+
+func TestSetConnectorOciVcnRouting_CidrAndRouteTables(t *testing.T) {
+	d := ociVcnTestSchema().TestResourceData()
+
+	vcnRouting := map[string]interface{}{
+		"exportToCXPOptions": map[string]interface{}{
+			"userInputPrefixes": []interface{}{
+				map[string]interface{}{"type": "CIDR", "value": "10.0.0.0/16"},
+			},
+			"routeExportMode": "USER_INPUT_PREFIXES",
+		},
+		"importFromCXPOptions": map[string]interface{}{
+			"routeTables": []interface{}{
+				map[string]interface{}{
+					"id":              "ocid1.routetable.oc1..bbb",
+					"routeImportMode": "ADVERTISE_DEFAULT_ROUTE",
+					"prefixListIds":   []interface{}{},
+				},
+			},
+		},
+	}
+
+	setConnectorOciVcnRouting(d, vcnRouting)
+
+	cidr := d.Get("vcn_cidr").([]interface{})
+	assert.Len(t, cidr, 1)
+	assert.Equal(t, "10.0.0.0/16", cidr[0])
+
+	tables := d.Get("vcn_route_table").(*schema.Set).List()
+	assert.Len(t, tables, 1)
+	table := tables[0].(map[string]interface{})
+	assert.Equal(t, "ocid1.routetable.oc1..bbb", table["id"])
+	assert.Equal(t, "ADVERTISE_DEFAULT_ROUTE", table["options"])
+}


### PR DESCRIPTION
Bug Reproduction (broken main binary):

Imported existing OCI VCN connector (ID 6494) using broken binary
Confirmed vcn_cidr, vcn_subnet, vcn_route_table all missing from state after import
Fix Applied:

Added setConnectorOciVcnRouting helper in resource_alkira_connector_oci_vcn_helper.go that parses connector.VcnRouting interface{} and sets vcn_cidr, vcn_subnet,
and vcn_route_table
Called setConnectorOciVcnRouting in resourceConnectorOciVcnRead
Fix Verification (fixed binary):

Removed state, reimported connector 6494 with fixed binary
terraform plan after import shows no changes — idempotency confirmed