### PR TITLE
AK-66002: Add metadata fields for F5 LB service and F5 vServer endpoint.

### DIFF
--- a/alkira/resource_alkira_service_f5_lb.go
+++ b/alkira/resource_alkira_service_f5_lb.go
@@ -252,7 +252,8 @@ func resourceAlkiraF5LoadBalancer() *schema.Resource {
 							Description: "Per-segment metadata populated after provisioning." +
 								"If provisioning occurs out of band (e.g. via the Alkira portal), run " +
 								"`terraform apply -refresh-only` to sync this data into state.",
-							Type:     schema.TypeList,
+							Type:     schema.TypeSet,
+							Set:      f5LBInstanceMetadataHash,
 							Computed: true,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{

--- a/alkira/resource_alkira_service_f5_lb.go
+++ b/alkira/resource_alkira_service_f5_lb.go
@@ -248,6 +248,65 @@ func resourceAlkiraF5LoadBalancer() *schema.Resource {
 								false),
 							Optional: true,
 						},
+						"instance_metadata": {
+							Description: "Per-segment metadata populated after provisioning." +
+								"If provisioning occurs out of band (e.g. via the Alkira portal), run " +
+								"`terraform apply -refresh-only` to sync this data into state.",
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"f5_mgmt_public_ip": {
+										Description: "Management public IP of the instance.",
+										Type:        schema.TypeString,
+										Computed:    true,
+									},
+									"segment_id": {
+										Description: "Segment ID.",
+										Type:        schema.TypeString,
+										Computed:    true,
+									},
+									"route_domain_id": {
+										Description: "Route domain ID.",
+										Type:        schema.TypeInt,
+										Computed:    true,
+									},
+									"routing_type": {
+										Description: "Routing type.",
+										Type:        schema.TypeString,
+										Computed:    true,
+									},
+									"vlans": {
+										Description: "VLANs assigned to the instance for this segment.",
+										Type:        schema.TypeList,
+										Computed:    true,
+										Elem:        &schema.Schema{Type: schema.TypeString},
+									},
+									"tunnels": {
+										Description: "Tunnel configurations for this segment.",
+										Type:        schema.TypeList,
+										Computed:    true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"tunnel_protocol":      {Description: "Tunnel protocol (e.g. IPSEC, GRE).", Type: schema.TypeString, Computed: true},
+												"tunnel_uuid":          {Description: "Unique identifier of the tunnel.", Type: schema.TypeString, Computed: true},
+												"tunnel_id":            {Description: "Service tunnel ID.", Type: schema.TypeString, Computed: true},
+												"customer_tunnel_name": {Description: "Customer-side tunnel name.", Type: schema.TypeString, Computed: true},
+												"cxp_tunnel_name":      {Description: "CXP-side tunnel name.", Type: schema.TypeString, Computed: true},
+												"tunnel_internal_name": {Description: "Internal tunnel name.", Type: schema.TypeString, Computed: true},
+												"infra_node_name":      {Description: "Infrastructure node hosting the tunnel.", Type: schema.TypeString, Computed: true},
+												"customer_outer_ip":    {Description: "Customer-side outer (underlay) IP.", Type: schema.TypeString, Computed: true},
+												"cxp_outer_ip":         {Description: "CXP-side outer (underlay) IP.", Type: schema.TypeString, Computed: true},
+												"cxp_inner_ip":         {Description: "CXP-side inner (overlay) IP.", Type: schema.TypeString, Computed: true},
+												"customer_inner_ip":    {Description: "Customer-side inner (overlay) IP.", Type: schema.TypeString, Computed: true},
+												"lb_type":              {Description: "Load balancer type for this tunnel. Can be `ELB`, `ILB`, or both. If empty, ELB is assumed.", Type: schema.TypeString, Computed: true},
+												"bgp_enabled":          {Description: "True when the segment has BGP advertise options configured.", Type: schema.TypeBool, Computed: true},
+											},
+										},
+									},
+								},
+							},
+						},
 					},
 				},
 			},

--- a/alkira/resource_alkira_service_f5_lb_helper.go
+++ b/alkira/resource_alkira_service_f5_lb_helper.go
@@ -3,12 +3,20 @@ package alkira
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"log"
 	"strings"
 
 	"github.com/alkiranet/alkira-client-go/alkira"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
+
+// f5LBInstanceMetadataHash computes a stable hash for instance_metadata entries
+// keyed on segment_id, which is the unique identifier per entry. This prevents
+// spurious diffs when the API returns segment metadata in a different order.
+var f5LBInstanceMetadataHash = typeSetHash(func(m map[string]interface{}) string {
+	return fmt.Sprintf("%v", m["segment_id"])
+})
 
 // expandF5Instances converts the input data to a slice of F5Instances structs.
 func expandF5Instances(in []interface{}, m interface{}) ([]alkira.F5Instance, error) {

--- a/alkira/resource_alkira_service_f5_lb_helper.go
+++ b/alkira/resource_alkira_service_f5_lb_helper.go
@@ -219,11 +219,52 @@ func setF5Instances(d *schema.ResourceData, ins []alkira.F5Instance) []map[strin
 			"f5_username":                f5Username,
 			"f5_password":                f5Password,
 			"availability_zone":          in.AvailabilityZone,
+			"instance_metadata":          flattenF5LBInstanceMetadata(in.Metadata),
 		}
 
 		instances = append(instances, instance)
 	}
 	return instances
+}
+
+func flattenF5LBInstanceMetadata(m *alkira.F5LBServiceInstanceMetadata) []map[string]interface{} {
+	if m == nil || m.SegmentToMetadata == nil {
+		return nil
+	}
+	var result []map[string]interface{}
+	for segId, seg := range m.SegmentToMetadata {
+		var tunnels []map[string]interface{}
+		for _, t := range seg.Tunnels {
+			bgpEnabled := false
+			if t.BgpEnabled != nil {
+				bgpEnabled = *t.BgpEnabled
+			}
+			tunnels = append(tunnels, map[string]interface{}{
+				"tunnel_protocol":      t.TunnelProtocol,
+				"tunnel_uuid":          t.TunnelUUID,
+				"tunnel_id":            t.TunnelId,
+				"customer_tunnel_name": t.CustomerTunnelName,
+				"cxp_tunnel_name":      t.CxpTunnelName,
+				"tunnel_internal_name": t.TunnelInternalName,
+				"infra_node_name":      t.InfraNodeName,
+				"customer_outer_ip":    t.CustomerOuterIp,
+				"cxp_outer_ip":         t.CxpOuterIp,
+				"cxp_inner_ip":         t.CxpInnerIp,
+				"customer_inner_ip":    t.CustomerInnerIp,
+				"lb_type":              t.LbType,
+				"bgp_enabled":          bgpEnabled,
+			})
+		}
+		result = append(result, map[string]interface{}{
+			"f5_mgmt_public_ip": seg.F5MgmtPublicIp,
+			"segment_id":        segId,
+			"route_domain_id":   int(seg.RouteDomainId),
+			"routing_type":      seg.RoutingType,
+			"vlans":             seg.Vlans,
+			"tunnels":           tunnels,
+		})
+	}
+	return result
 }
 
 // generateRequestF5Lb generates the request payload for creating an F5 Load Balancer service.

--- a/alkira/resource_alkira_service_f5_vserver_endpoint.go
+++ b/alkira/resource_alkira_service_f5_vserver_endpoint.go
@@ -106,6 +106,64 @@ func resourceAlkiraServiceF5vServerEndpoint() *schema.Resource {
 				Optional:    true,
 				Elem:        &schema.Schema{Type: schema.TypeString},
 			},
+			"provision_state": {
+				Description: "The provisioning state of the resource.",
+				Type:        schema.TypeString,
+				Computed:    true,
+			},
+			"instance_metadata": {
+				Description: "Per-instance metadata populated after provisioning." +
+					"ELB instances populate: elastic_ip, secondary_ip, vlan, route_domain_id, ecmp_pool_name. " +
+					"ILB instances populate: virtual_ip, route_domain_id, ecmp_pool_name. " +
+					"If provisioning occurs out of band (e.g. via the Alkira portal), run " +
+					"`terraform apply -refresh-only` to sync this data into state.",
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"instance_id": {
+							Description: "F5 service instance ID.",
+							Type:        schema.TypeString,
+							Computed:    true,
+						},
+						"elastic_ip": {
+							Description: "Elastic IP address assigned to the instance. Populated for ELB type only.",
+							Type:        schema.TypeString,
+							Computed:    true,
+						},
+						"secondary_ip": {
+							Description: "Secondary IP address assigned to the instance. Populated for ELB type only.",
+							Type:        schema.TypeString,
+							Computed:    true,
+						},
+						"virtual_ip": {
+							Description: "Virtual IP address assigned to the instance. Populated for ILB type only.",
+							Type:        schema.TypeString,
+							Computed:    true,
+						},
+						"vlan": {
+							Description: "VLAN assigned to the instance. Populated for ELB type only.",
+							Type:        schema.TypeString,
+							Computed:    true,
+						},
+						"ecmp_pool_name": {
+							Description: "ECMP pool name assigned to the instance.",
+							Type:        schema.TypeString,
+							Computed:    true,
+						},
+						"route_domain_id": {
+							Description: "Route domain ID assigned to the instance.",
+							Type:        schema.TypeInt,
+							Computed:    true,
+						},
+						"segment_id": {
+							Description: "Segment ID associated with the instance.",
+							Type:        schema.TypeInt,
+							Computed:    true,
+						},
+					},
+				},
+			},
 		},
 	}
 }
@@ -198,6 +256,24 @@ func resourceF5vServerEndpointRead(ctx context.Context, d *schema.ResourceData, 
 		return diag.FromErr(err)
 	}
 	d.Set("segment_id", segmentId)
+
+	// Set post-provisioning instance metadata
+	if f5.Metadata != nil && f5.Metadata.InstanceToMetadata != nil {
+		var metadataList []map[string]interface{}
+		for instanceId, m := range f5.Metadata.InstanceToMetadata {
+			metadataList = append(metadataList, map[string]interface{}{
+				"instance_id":     instanceId,
+				"elastic_ip":      m.ElasticIp,
+				"secondary_ip":    m.SecondaryIp,
+				"virtual_ip":      m.VirtualIp,
+				"vlan":            m.Vlan,
+				"ecmp_pool_name":  m.EcmpPoolName,
+				"route_domain_id": int(m.RouteDomainId),
+				"segment_id":      int(m.SegmentId),
+			})
+		}
+		d.Set("instance_metadata", metadataList)
+	}
 
 	// Set provision state
 	if client.Provision && provState != "" {

--- a/alkira/resource_alkira_service_f5_vserver_endpoint.go
+++ b/alkira/resource_alkira_service_f5_vserver_endpoint.go
@@ -10,6 +10,13 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
 
+// f5VServerInstanceMetadataHash computes a stable hash for instance_metadata entries
+// keyed on instance_id, which is the unique identifier per entry. This prevents
+// spurious diffs when the API returns instance metadata in a different order.
+var f5VServerInstanceMetadataHash = typeSetHash(func(m map[string]interface{}) string {
+	return fmt.Sprintf("%v", m["instance_id"])
+})
+
 func resourceAlkiraServiceF5vServerEndpoint() *schema.Resource {
 	return &schema.Resource{
 		Description:   "Resource for managing F5 vServer endpoint. (**BETA**)",
@@ -117,7 +124,8 @@ func resourceAlkiraServiceF5vServerEndpoint() *schema.Resource {
 					"ILB instances populate: virtual_ip, route_domain_id, ecmp_pool_name. " +
 					"If provisioning occurs out of band (e.g. via the Alkira portal), run " +
 					"`terraform apply -refresh-only` to sync this data into state.",
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
+				Set:      f5VServerInstanceMetadataHash,
 				Computed: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{

--- a/docs/resources/service_f5_lb.md
+++ b/docs/resources/service_f5_lb.md
@@ -251,6 +251,40 @@ Optional:
 Read-Only:
 
 - `id` (Number) ID of the F5 load balancer instance.
+- `instance_metadata` (List of Object) Per-segment metadata populated after provisioning.If provisioning occurs out of band (e.g. via the Alkira portal), run `terraform apply -refresh-only` to sync this data into state. (see [below for nested schema](#nestedatt--instance--instance_metadata))
+
+<a id="nestedatt--instance--instance_metadata"></a>
+### Nested Schema for `instance.instance_metadata`
+
+Read-Only:
+
+- `f5_mgmt_public_ip` (String)
+- `route_domain_id` (Number)
+- `routing_type` (String)
+- `segment_id` (String)
+- `tunnels` (List of Object) (see [below for nested schema](#nestedobjatt--instance--instance_metadata--tunnels))
+- `vlans` (List of String)
+
+<a id="nestedobjatt--instance--instance_metadata--tunnels"></a>
+### Nested Schema for `instance.instance_metadata.tunnels`
+
+Read-Only:
+
+- `bgp_enabled` (Boolean)
+- `customer_inner_ip` (String)
+- `customer_outer_ip` (String)
+- `customer_tunnel_name` (String)
+- `cxp_inner_ip` (String)
+- `cxp_outer_ip` (String)
+- `cxp_tunnel_name` (String)
+- `infra_node_name` (String)
+- `lb_type` (String)
+- `tunnel_id` (String)
+- `tunnel_internal_name` (String)
+- `tunnel_protocol` (String)
+- `tunnel_uuid` (String)
+
+
 
 
 <a id="nestedblock--segment_options"></a>

--- a/docs/resources/service_f5_vserver_endpoint.md
+++ b/docs/resources/service_f5_vserver_endpoint.md
@@ -73,6 +73,22 @@ resource "alkira_service_f5_vserver_endpoint" "example-vserver-2" {
 ### Read-Only
 
 - `id` (String) The ID of this resource.
+- `instance_metadata` (List of Object) Per-instance metadata populated after provisioning.ELB instances populate: elastic_ip, secondary_ip, vlan, route_domain_id, ecmp_pool_name. ILB instances populate: virtual_ip, route_domain_id, ecmp_pool_name. If provisioning occurs out of band (e.g. via the Alkira portal), run `terraform apply -refresh-only` to sync this data into state. (see [below for nested schema](#nestedatt--instance_metadata))
+- `provision_state` (String) The provisioning state of the resource.
+
+<a id="nestedatt--instance_metadata"></a>
+### Nested Schema for `instance_metadata`
+
+Read-Only:
+
+- `ecmp_pool_name` (String)
+- `elastic_ip` (String)
+- `instance_id` (String)
+- `route_domain_id` (Number)
+- `secondary_ip` (String)
+- `segment_id` (Number)
+- `virtual_ip` (String)
+- `vlan` (String)
 
 
 

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/alkiranet/terraform-provider-alkira
 go 1.26
 
 require (
-	github.com/alkiranet/alkira-client-go v1.59.1-0.20260317173620-b10dbd782645
+	github.com/alkiranet/alkira-client-go v1.59.1-0.20260324190224-0874697815c2
 	github.com/hashicorp/go-cty v1.5.0
 	github.com/hashicorp/go-retryablehttp v0.7.7
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.37.0

--- a/go.sum
+++ b/go.sum
@@ -5,8 +5,8 @@ github.com/PuerkitoBio/purell v1.1.1/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbt
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
 github.com/agext/levenshtein v1.2.2 h1:0S/Yg6LYmFJ5stwQeRp6EeOcCbj7xiqQSdNelsXvaqE=
 github.com/agext/levenshtein v1.2.2/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
-github.com/alkiranet/alkira-client-go v1.59.1-0.20260317173620-b10dbd782645 h1:JEnkuITr2+ZCQ3Lom+taSlIBBqvIUuy7q1fvvWzDRjg=
-github.com/alkiranet/alkira-client-go v1.59.1-0.20260317173620-b10dbd782645/go.mod h1:ms9LjOc4O1Zrr7/VQOva+xwv3sJuBUqS9JsI+MbE2go=
+github.com/alkiranet/alkira-client-go v1.59.1-0.20260324190224-0874697815c2 h1:YTQhHPqRei+mGloyhbPPSosFN2SkVqTL7eG9k3HE8M4=
+github.com/alkiranet/alkira-client-go v1.59.1-0.20260324190224-0874697815c2/go.mod h1:ms9LjOc4O1Zrr7/VQOva+xwv3sJuBUqS9JsI+MbE2go=
 github.com/apparentlymart/go-textseg/v12 v12.0.0/go.mod h1:S/4uRK2UtaQttw1GenVJEynmyUenKwP++x/+DdGV/Ec=
 github.com/apparentlymart/go-textseg/v15 v15.0.0 h1:uYvfpb3DyLSCGWnctWKGj857c6ew1u1fNQOlOtuGxQY=
 github.com/apparentlymart/go-textseg/v15 v15.0.0/go.mod h1:K8XmNZdhEBkdlyDdvbmmsvpAG721bKi0joRfFdHIWJ4=

--- a/vendor/github.com/alkiranet/alkira-client-go/alkira/service_f5_lb.go
+++ b/vendor/github.com/alkiranet/alkira-client-go/alkira/service_f5_lb.go
@@ -24,15 +24,46 @@ type ServiceF5Lb struct {
 }
 
 type F5Instance struct {
-	Deployment               F5InstanceDeployment `json:"deployment"`
-	Name                     string               `json:"name"`
-	RegistrationCredentialId string               `json:"registrationCredentialId,omitempty"`
-	CredentialId             string               `json:"credentialId"`
-	HostNameFqdn             string               `json:"hostNameFqdn"`
-	LicenseType              string               `json:"licenseType"`
-	Version                  string               `json:"version"`
-	AvailabilityZone         json.Number          `json:"availabilityZone,omitempty"`
-	Id                       int                  `json:"id,omitempty"` // RESPONSE ONLY
+	Deployment               F5InstanceDeployment         `json:"deployment"`
+	Name                     string                       `json:"name"`
+	RegistrationCredentialId string                       `json:"registrationCredentialId,omitempty"`
+	CredentialId             string                       `json:"credentialId"`
+	HostNameFqdn             string                       `json:"hostNameFqdn"`
+	LicenseType              string                       `json:"licenseType"`
+	Version                  string                       `json:"version"`
+	AvailabilityZone         json.Number                  `json:"availabilityZone,omitempty"`
+	Id                       int                          `json:"id,omitempty"`       // RESPONSE ONLY
+	Metadata                 *F5LBServiceInstanceMetadata `json:"metadata,omitempty"` // RESPONSE ONLY
+}
+
+type F5LBServiceInstanceMetadata struct {
+	F5MgmtPublicIp    string                                        `json:"f5MgmtPublicIp,omitempty"`
+	SegmentToMetadata map[string]F5LBServiceInstanceSegmentMetadata `json:"segmentToMetadata,omitempty"`
+}
+
+type F5LBServiceInstanceSegmentMetadata struct {
+	SegmentId      int64                       `json:"segmentId,omitempty"`
+	RouteDomainId  int64                       `json:"routeDomainId,omitempty"`
+	RoutingType    string                      `json:"routingType,omitempty"`
+	F5MgmtPublicIp string                      `json:"f5MgmtPublicIp,omitempty"`
+	Vlans          []string                    `json:"vlans,omitempty"`
+	Tunnels        []F5LBServiceInstanceTunnel `json:"tunnels,omitempty"`
+}
+
+type F5LBServiceInstanceTunnel struct {
+	TunnelProtocol     string `json:"tunnelProtocol,omitempty"`
+	TunnelUUID         string `json:"tunnelUUID,omitempty"`
+	TunnelId           string `json:"tunnelId,omitempty"`
+	CustomerTunnelName string `json:"customerTunnelName,omitempty"`
+	CxpTunnelName      string `json:"cxpTunnelName,omitempty"`
+	TunnelInternalName string `json:"tunnelInternalName,omitempty"`
+	InfraNodeName      string `json:"infraNodeName,omitempty"`
+	CustomerOuterIp    string `json:"customerOuterIp,omitempty"`
+	CxpOuterIp         string `json:"cxpOuterIp,omitempty"`
+	CxpInnerIp         string `json:"cxpInnerIp,omitempty"`
+	CustomerInnerIp    string `json:"customerInnerIp,omitempty"`
+	LbType             string `json:"lbType,omitempty"`
+	BgpEnabled         *bool  `json:"bgpEnabled,omitempty"`
 }
 
 type F5SegmentOption map[string]F5SegmentSubOption

--- a/vendor/github.com/alkiranet/alkira-client-go/alkira/service_f5_vserver_endpoint.go
+++ b/vendor/github.com/alkiranet/alkira-client-go/alkira/service_f5_vserver_endpoint.go
@@ -17,11 +17,26 @@ type F5vServerEndpoint struct {
 	F5ServiceInstanceIds []int                          `json:"f5ServiceInstanceIds,omitempty"`
 	PortRanges           []string                       `json:"portRanges,omitempty"`
 	DestinationEndpoints *F5VServerDestinationEndpoints `json:"destinationEndpoints,omitempty"`
+	Metadata             *F5VServerEndpointMetadata     `json:"metadata,omitempty"` // RESPONSE ONLY
 }
 
 type F5VServerDestinationEndpoints struct {
 	PortRanges  []string `json:"portRanges"`
 	IpAddresses []string `json:"ipAddresses"`
+}
+
+type F5VServerEndpointInstanceMetadata struct {
+	ElasticIp     string `json:"elasticIp,omitempty"`
+	SecondaryIp   string `json:"secondaryIp,omitempty"`
+	RouteDomainId int64  `json:"routeDomainId,omitempty"`
+	SegmentId     int64  `json:"segmentId,omitempty"`
+	Vlan          string `json:"vlan,omitempty"`
+	EcmpPoolName  string `json:"ecmpPoolName,omitempty"`
+	VirtualIp     string `json:"virtualIp,omitempty"`
+}
+
+type F5VServerEndpointMetadata struct {
+	InstanceToMetadata map[string]F5VServerEndpointInstanceMetadata `json:"instanceToMetadata,omitempty"`
 }
 
 func NewF5vServerEndpoint(ac *AlkiraClient) *AlkiraAPI[F5vServerEndpoint] {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,7 +1,7 @@
 # github.com/agext/levenshtein v1.2.2
 ## explicit
 github.com/agext/levenshtein
-# github.com/alkiranet/alkira-client-go v1.59.1-0.20260317173620-b10dbd782645
+# github.com/alkiranet/alkira-client-go v1.59.1-0.20260324190224-0874697815c2
 ## explicit; go 1.26
 github.com/alkiranet/alkira-client-go/alkira
 # github.com/apparentlymart/go-textseg/v15 v15.0.0


### PR DESCRIPTION
## Summary
- Added `instance_metadata` computed fields to `alkira_service_f5_lb` and `alkira_service_f5_vserver_endpoint` resources
- `instance_metadata` is implemented as a `TypeSet` (keyed on `segment_id` for F5 LB, `instance_id` for vServer) to prevent spurious diffs when the API returns entries in a different order
- Updated vendor with latest `alkira-client-go` changes from main
- Regenerated documentation

## Test plan

| TC | Description | Result |
|---|---|---|
| TC-01 | `instance_metadata` is empty when `provision = false` | PASS |
| TC-02 | `instance_metadata` populated after ACTIVE provisioning (single instance, single segment) | PASS |
| TC-03 | No spurious diff on re-read (ordering stability via TypeSet hash) | PASS |
| TC-04 | Two metadata entries produced for a single instance with two segments (requires `2LARGE`) | PASS |
| TC-05 | vServer ELB metadata: `elastic_ip`, `secondary_ip`, `vlan` populated; `virtual_ip` empty | PASS |
| TC-06 | vServer ILB metadata: `virtual_ip` populated; ELB fields empty | PASS |
| TC-07 | vServer with 2 referenced instances produces 2 metadata entries with distinct `elastic_ip` | PASS |
| TC-08 | `terraform import` correctly captures `instance_metadata` into state | PASS |
| TC-09 | `terraform apply -refresh-only` syncs metadata regardless of `provision` setting | PASS |

🤖 Generated with [Claude Code](https://claude.com/claude-code)