### PR TITLE
[CLONE-63][AK-66045] forces exportAllSubnets=false when vpc_subnet entries are …

### DIFF
--- a/alkira/resource_alkira_connector_gcp_vpc_helper.go
+++ b/alkira/resource_alkira_connector_gcp_vpc_helper.go
@@ -45,6 +45,12 @@ func expandGcpRouting(in []interface{}, subnets *schema.Set) (*alkira.ConnectorG
 
 	exportOptions.Prefixes = prefixes
 
+	// Subnet entries and exportAllSubnets are mutually exclusive.
+	// If specific subnets are provided, exportAllSubnets must be false.
+	if len(prefixes) > 0 {
+		exportOptions.ExportAllSubnets = false
+	}
+
 	gcp := &alkira.ConnectorGcpVpcRouting{
 		ExportOptions: exportOptions,
 		ImportOptions: importOptions,
@@ -157,7 +163,7 @@ func generateConnectorGcpVpcRequest(d *schema.ResourceData, m interface{}) (*alk
 		gcpRoutingRaw := rawConfig.GetAttr("gcp_routing")
 		if !gcpRoutingRaw.IsNull() && gcpRoutingRaw.IsKnown() && gcpRoutingRaw.LengthInt() > 0 {
 			exportAll := gcpRoutingRaw.Index(cty.NumberIntVal(0)).GetAttr("export_all_subnets")
-			if exportAll.IsNull() {
+			if exportAll.IsNull() && len(gcpRouting.ExportOptions.Prefixes) == 0 {
 				gcpRouting.ExportOptions.ExportAllSubnets = true
 			}
 		}

--- a/alkira/resource_alkira_connector_gcp_vpc_helper_test.go
+++ b/alkira/resource_alkira_connector_gcp_vpc_helper_test.go
@@ -569,12 +569,14 @@ func TestExpandGcpRouting(t *testing.T) {
 			},
 		},
 		{
-			name: "default route mode with subnets but export_all_subnets defaults to true",
+			// vpc_subnet present but export_all_subnets not set.
+			// Provider must send exportAllSubnets=false; the API rejects true+userInputPrefixes together.
+			name: "vpc_subnet present without explicit export_all_subnets — must force false",
 			gcpRouting: []interface{}{
 				map[string]interface{}{
 					"custom_prefix":   "ADVERTISE_DEFAULT_ROUTE",
 					"prefix_list_ids": schema.NewSet(schema.HashInt, []interface{}{}),
-					// export_all_subnets not specified, defaults to true
+					// export_all_subnets omitted — Go zero-value is false, but default was hardcoded true
 				},
 			},
 			subnets: schema.NewSet(
@@ -592,13 +594,89 @@ func TestExpandGcpRouting(t *testing.T) {
 			expectError: false,
 			expected: &alkira.ConnectorGcpVpcRouting{
 				ExportOptions: alkira.ConnectorGcpVpcExportOptions{
-					ExportAllSubnets: true, // defaults to true
+					ExportAllSubnets: false, // subnets present → must be false
 					Prefixes: []alkira.UserInputPrefixes{
 						{
 							FqId:  "projects/test/regions/us-central1/subnetworks/subnet-1",
 							Value: "10.0.1.0/24",
 							Type:  "SUBNET",
 						},
+					},
+				},
+				ImportOptions: alkira.ConnectorGcpVpcImportOptions{
+					RouteImportMode: "ADVERTISE_DEFAULT_ROUTE",
+					PrefixListIds:   nil,
+				},
+			},
+		},
+		{
+			// no gcp_routing block at all, but vpc_subnet present.
+			// exportAllSubnets must be false when subnets are provided.
+			name: "no gcp_routing block with vpc_subnet present — must force false",
+			gcpRouting: nil,
+			subnets: schema.NewSet(
+				func(i interface{}) int {
+					m := i.(map[string]interface{})
+					return schema.HashString(m["id"].(string))
+				},
+				[]interface{}{
+					map[string]interface{}{
+						"id":   "projects/test/regions/us-central1/subnetworks/subnet-1",
+						"cidr": "10.0.1.0/24",
+					},
+				},
+			),
+			expectError: false,
+			expected: &alkira.ConnectorGcpVpcRouting{
+				ExportOptions: alkira.ConnectorGcpVpcExportOptions{
+					ExportAllSubnets: false,
+					Prefixes: []alkira.UserInputPrefixes{
+						{
+							FqId:  "projects/test/regions/us-central1/subnetworks/subnet-1",
+							Value: "10.0.1.0/24",
+							Type:  "SUBNET",
+						},
+					},
+				},
+				ImportOptions: alkira.ConnectorGcpVpcImportOptions{
+					RouteImportMode: "ADVERTISE_DEFAULT_ROUTE",
+					PrefixListIds:   nil,
+				},
+			},
+		},
+		{
+			// multiple subnets, no explicit export_all_subnets.
+			// All three connectors (-31, -32, -33) used multiple subnets.
+			name: "multiple vpc_subnets without explicit export_all_subnets — must force false",
+			gcpRouting: []interface{}{
+				map[string]interface{}{
+					"custom_prefix":   "ADVERTISE_DEFAULT_ROUTE",
+					"prefix_list_ids": schema.NewSet(schema.HashInt, []interface{}{}),
+				},
+			},
+			subnets: schema.NewSet(
+				func(i interface{}) int {
+					m := i.(map[string]interface{})
+					return schema.HashString(m["id"].(string))
+				},
+				[]interface{}{
+					map[string]interface{}{
+						"id":   "projects/test/regions/us-central1/subnetworks/subnet-1",
+						"cidr": "10.22.1.0/24",
+					},
+					map[string]interface{}{
+						"id":   "projects/test/regions/us-east1/subnetworks/subnet-2",
+						"cidr": "10.22.2.0/24",
+					},
+				},
+			),
+			expectError: false,
+			expected: &alkira.ConnectorGcpVpcRouting{
+				ExportOptions: alkira.ConnectorGcpVpcExportOptions{
+					ExportAllSubnets: false,
+					Prefixes: []alkira.UserInputPrefixes{
+						{FqId: "projects/test/regions/us-central1/subnetworks/subnet-1", Value: "10.22.1.0/24", Type: "SUBNET"},
+						{FqId: "projects/test/regions/us-east1/subnetworks/subnet-2", Value: "10.22.2.0/24", Type: "SUBNET"},
 					},
 				},
 				ImportOptions: alkira.ConnectorGcpVpcImportOptions{
@@ -667,7 +745,7 @@ func TestExpandGcpRouting(t *testing.T) {
 				// Use order-insensitive comparison for TypeSet-based fields
 				assert.ElementsMatch(t, tt.expected.ImportOptions.PrefixListIds, result.ImportOptions.PrefixListIds)
 				assert.Equal(t, tt.expected.ExportOptions.ExportAllSubnets, result.ExportOptions.ExportAllSubnets)
-				assert.Equal(t, tt.expected.ExportOptions.Prefixes, result.ExportOptions.Prefixes)
+				assert.ElementsMatch(t, tt.expected.ExportOptions.Prefixes, result.ExportOptions.Prefixes)
 			}
 		})
 	}


### PR DESCRIPTION
…… (#575)

* [AK-66045] forces exportAllSubnets=false when vpc_subnet entries are present to prevent API 400 conflict

[AK-66045]: https://alkiranet.atlassian.net/browse/AK-66045?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ