### PR TITLE
AK-66442: Bump alkira-client-go to v1.59.1-0.20260310051734-d6fba43c6ebf

### DIFF
--- a/alkira/resource_alkira_network_entity_scale_options.go
+++ b/alkira/resource_alkira_network_entity_scale_options.go
@@ -141,7 +141,7 @@ func convertEntityIdToInt(entityId string) int {
 
 func resourceNetworkEntityScaleOptionsCreate(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
 	client := m.(*alkira.AlkiraClient)
-	api := alkira.NewControllerScaleOptions(client)
+	api := alkira.NewNetworkEntityScaleOptions(client)
 
 	request, err := generateNetworkEntityScaleOptionsRequest(d)
 	if err != nil {
@@ -192,7 +192,7 @@ func resourceNetworkEntityScaleOptionsCreate(ctx context.Context, d *schema.Reso
 
 func resourceNetworkEntityScaleOptionsRead(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
 	client := m.(*alkira.AlkiraClient)
-	api := alkira.NewControllerScaleOptions(client)
+	api := alkira.NewNetworkEntityScaleOptions(client)
 
 	networkEntityScaleOptions, provState, err := api.GetById(d.Id())
 	if err != nil {
@@ -245,7 +245,7 @@ func resourceNetworkEntityScaleOptionsRead(ctx context.Context, d *schema.Resour
 
 func resourceNetworkEntityScaleOptionsUpdate(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
 	client := m.(*alkira.AlkiraClient)
-	api := alkira.NewControllerScaleOptions(client)
+	api := alkira.NewNetworkEntityScaleOptions(client)
 
 	request, err := generateNetworkEntityScaleOptionsRequest(d)
 	if err != nil {
@@ -294,7 +294,7 @@ func resourceNetworkEntityScaleOptionsUpdate(ctx context.Context, d *schema.Reso
 
 func resourceNetworkEntityScaleOptionsDelete(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
 	client := m.(*alkira.AlkiraClient)
-	api := alkira.NewControllerScaleOptions(client)
+	api := alkira.NewNetworkEntityScaleOptions(client)
 
 	provState, err, valErr, provErr := api.Delete(d.Id())
 	if err != nil {
@@ -329,7 +329,7 @@ func resourceNetworkEntityScaleOptionsDelete(ctx context.Context, d *schema.Reso
 	return nil
 }
 
-func generateNetworkEntityScaleOptionsRequest(d *schema.ResourceData) (*alkira.ControllerScaleOptions, error) {
+func generateNetworkEntityScaleOptionsRequest(d *schema.ResourceData) (*alkira.NetworkEntityScaleOptions, error) {
 	var segmentScaleOptions []alkira.SegmentScaleOptions
 	if v, ok := d.Get("segment_scale_options").([]any); ok {
 		for _, item := range v {
@@ -358,7 +358,7 @@ func generateNetworkEntityScaleOptionsRequest(d *schema.ResourceData) (*alkira.C
 		}
 	}
 
-	networkEntityScaleOptions := &alkira.ControllerScaleOptions{
+	networkEntityScaleOptions := &alkira.NetworkEntityScaleOptions{
 		Name:                d.Get("name").(string),
 		Description:         d.Get("description").(string),
 		EntityId:            convertEntityIdToInt(d.Get("entity_id").(string)),

--- a/go.mod
+++ b/go.mod
@@ -1,11 +1,10 @@
 module github.com/alkiranet/terraform-provider-alkira
 
-go 1.23.0
-
-toolchain go1.23.8
+go 1.26
 
 require (
-	github.com/alkiranet/alkira-client-go v1.55.2
+	github.com/alkiranet/alkira-client-go v1.59.1-0.20260310051734-d6fba43c6ebf
+	github.com/hashicorp/go-cty v1.5.0
 	github.com/hashicorp/go-retryablehttp v0.7.7
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.37.0
 	github.com/stretchr/testify v1.8.4
@@ -21,7 +20,6 @@ require (
 	github.com/google/go-cmp v0.7.0 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
-	github.com/hashicorp/go-cty v1.5.0 // indirect
 	github.com/hashicorp/go-hclog v1.6.3 // indirect
 	github.com/hashicorp/go-plugin v1.6.3 // indirect
 	github.com/hashicorp/go-uuid v1.0.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -5,8 +5,8 @@ github.com/PuerkitoBio/purell v1.1.1/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbt
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
 github.com/agext/levenshtein v1.2.2 h1:0S/Yg6LYmFJ5stwQeRp6EeOcCbj7xiqQSdNelsXvaqE=
 github.com/agext/levenshtein v1.2.2/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
-github.com/alkiranet/alkira-client-go v1.55.2 h1:hFcLVpi9f5LdUd/cT5LdqgcJ29Pi9DSu1QG4P0S59jo=
-github.com/alkiranet/alkira-client-go v1.55.2/go.mod h1:FAMWv4QxxAw3UKbaA+/iai0YFU/ozmyQVNcByg6MmCs=
+github.com/alkiranet/alkira-client-go v1.59.1-0.20260310051734-d6fba43c6ebf h1:ec3I0vG3Ry5Yte6rtIPW3JWe+ieJzbkRlz0SGOSlCLI=
+github.com/alkiranet/alkira-client-go v1.59.1-0.20260310051734-d6fba43c6ebf/go.mod h1:ms9LjOc4O1Zrr7/VQOva+xwv3sJuBUqS9JsI+MbE2go=
 github.com/apparentlymart/go-textseg/v12 v12.0.0/go.mod h1:S/4uRK2UtaQttw1GenVJEynmyUenKwP++x/+DdGV/Ec=
 github.com/apparentlymart/go-textseg/v15 v15.0.0 h1:uYvfpb3DyLSCGWnctWKGj857c6ew1u1fNQOlOtuGxQY=
 github.com/apparentlymart/go-textseg/v15 v15.0.0/go.mod h1:K8XmNZdhEBkdlyDdvbmmsvpAG721bKi0joRfFdHIWJ4=

--- a/vendor/github.com/alkiranet/alkira-client-go/alkira/api.go
+++ b/vendor/github.com/alkiranet/alkira-client-go/alkira/api.go
@@ -21,7 +21,7 @@ func (a *AlkiraAPI[T]) Create(resource *T) (*T, string, error, error, error) {
 	body, err := json.Marshal(resource)
 
 	if err != nil {
-		return nil, "", fmt.Errorf("api-create: failed to marshal: %v", err), nil, nil
+		return nil, "", fmt.Errorf("api-create: failed to marshal: %w", err), nil, nil
 	}
 
 	data, state, err, errVal, errProv := a.Client.create(a.Uri, body, a.Provision)
@@ -31,10 +31,10 @@ func (a *AlkiraAPI[T]) Create(resource *T) (*T, string, error, error, error) {
 	}
 
 	var result T
-	err = json.Unmarshal([]byte(data), &result)
+	err = json.Unmarshal(data, &result)
 
 	if err != nil {
-		return nil, state, fmt.Errorf("api-create: failed to unmarshal: %v", err), errVal, errProv
+		return nil, state, fmt.Errorf("api-create: failed to unmarshal: %w", err), errVal, errProv
 	}
 
 	return &result, state, nil, errVal, errProv
@@ -60,7 +60,7 @@ func (a *AlkiraAPI[T]) Update(id string, resource *T) (string, error, error, err
 	body, err := json.Marshal(resource)
 
 	if err != nil {
-		return "", fmt.Errorf("api-update: failed to marshal: %v", err), nil, nil
+		return "", fmt.Errorf("api-update: failed to marshal: %w", err), nil, nil
 	}
 
 	state, err, errVal, errProv := a.Client.update(uri, body, a.Provision)
@@ -86,10 +86,10 @@ func (a *AlkiraAPI[T]) GetById(id string) (*T, string, error) {
 	}
 
 	var result T
-	err = json.Unmarshal([]byte(data), &result)
+	err = json.Unmarshal(data, &result)
 
 	if err != nil {
-		return nil, provState, fmt.Errorf("api-get-all: failed to unmarshal: %v", err)
+		return nil, provState, fmt.Errorf("api-get-all: failed to unmarshal: %w", err)
 	}
 
 	return &result, provState, nil
@@ -112,10 +112,10 @@ func (a *AlkiraAPI[T]) GetByName(name string) (*T, string, error) {
 	}
 
 	var result []T
-	err = json.Unmarshal([]byte(data), &result)
+	err = json.Unmarshal(data, &result)
 
 	if err != nil {
-		return nil, state, fmt.Errorf("api-get-by-name: failed to unmarshal: %v", err)
+		return nil, state, fmt.Errorf("api-get-by-name: failed to unmarshal: %w", err)
 	}
 
 	if len(result) != 1 {

--- a/vendor/github.com/alkiranet/alkira-client-go/alkira/client.go
+++ b/vendor/github.com/alkiranet/alkira-client-go/alkira/client.go
@@ -30,22 +30,22 @@ const defaultProvTimeout time.Duration = 240 * time.Minute
 const defaultValTimeout time.Duration = 10 * time.Minute
 
 // Default Retry
-const defaultRetryInterval time.Duration = 5 * time.Second
+// const defaultRetryInterval time.Duration = 5 * time.Second
 const defaultRetryTimeout time.Duration = 10 * time.Second
 
 type AlkiraClient struct {
-	Client                *retryablehttp.Client
-	URI                   string
-	Username              string
-	Password              string
-	Secret                string
-	Authorization         string
-	Provision             bool
-	Validate              bool
-	TenantNetworkId       string
-	SerializationEnabled  bool
-	serializationTimeout  time.Duration
-	apiMutex              sync.Mutex
+	Client               *retryablehttp.Client
+	URI                  string
+	Username             string
+	Password             string
+	Secret               string
+	Authorization        string
+	Provision            bool
+	Validate             bool
+	TenantNetworkId      string
+	SerializationEnabled bool
+	serializationTimeout time.Duration
+	apiMutex             sync.Mutex
 }
 
 type Session struct {
@@ -104,7 +104,7 @@ func NewAlkiraClientWithAuthHeader(url string, username string, password string,
 	}
 
 	// Generate Authorization header string
-	auth := ""
+	var auth string
 
 	if len(secret) > 0 {
 		authStr := secret
@@ -163,15 +163,15 @@ func NewAlkiraClientWithAuthHeader(url string, username string, password string,
 	tenantNetworkResponse, err := retryClient.Do(tenantNetworkRequest)
 
 	if err != nil {
-		return nil, fmt.Errorf("failed to make tenant network request, %v", err)
+		return nil, fmt.Errorf("failed to make tenant network request, %w", err)
 	}
 
-	defer tenantNetworkResponse.Body.Close()
+	defer func() { _ = tenantNetworkResponse.Body.Close() }()
 
 	data, err := io.ReadAll(tenantNetworkResponse.Body)
 	if err != nil {
 		logf("ERROR", "NewAlkiraClientWithAuthHeader: failed to read tenant network response body: %v", err)
-		return nil, fmt.Errorf("NewAlkiraClientWithAuthHeader: failed to read tenant network response body: %v", err)
+		return nil, fmt.Errorf("NewAlkiraClientWithAuthHeader: failed to read tenant network response body: %w", err)
 	}
 	logf("TRACE", "Tenant Network Summary: %s\n", string(data))
 
@@ -179,9 +179,13 @@ func NewAlkiraClientWithAuthHeader(url string, username string, password string,
 		return nil, fmt.Errorf("failed to get tenant network (%d)", tenantNetworkResponse.StatusCode)
 	}
 
-	json.Unmarshal([]byte(data), &result)
+	err = json.Unmarshal(data, &result)
+	if err != nil {
+		logf("ERROR", "NewAlkiraClientWithAuthHeader: failed to unmarshal tenant network data: %v", err)
+		return nil, fmt.Errorf("NewAlkiraClientWithAuthHeader: failed to unmarshal tenant network data: %w", err)
+	}
 
-	tenantNetworkId := 0
+	var tenantNetworkId int
 
 	if len(result) > 0 {
 		tenantNetworkId = result[0].Id
@@ -242,6 +246,9 @@ func NewAlkiraClientInternal(url string, username string, password string, secre
 		"password": password,
 		"secret":   secret,
 	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal login request: %w", err)
+	}
 
 	// Create retry-able HTTP client
 	tr := &http.Transport{
@@ -262,7 +269,7 @@ func NewAlkiraClientInternal(url string, username string, password string, secre
 				}
 			}
 		} else {
-			return time.Duration(defaultRetryTimeout)
+			return defaultRetryTimeout
 		}
 		return retryablehttp.LinearJitterBackoff(min, max, attemptNum, resp)
 	}
@@ -291,22 +298,22 @@ func NewAlkiraClientInternal(url string, username string, password string, secre
 	request, requestErr := retryablehttp.NewRequest("POST", loginUrl, bytes.NewBuffer(loginRequestBody))
 
 	if requestErr != nil {
-		return nil, fmt.Errorf("failed to create login request, %v", requestErr)
+		return nil, fmt.Errorf("failed to create login request, %w", requestErr)
 	}
 
 	request.Header.Set("Content-Type", "application/json")
 	response, err := retryClient.Do(request)
 
 	if err != nil {
-		return nil, fmt.Errorf("failed to make login request, %v", err)
+		return nil, fmt.Errorf("failed to make login request, %w", err)
 	}
 
-	defer response.Body.Close()
+	defer func() { _ = response.Body.Close() }()
 
 	userAuthData, err := io.ReadAll(response.Body)
 	if err != nil {
 		logf("ERROR", "NewAlkiraClientInternal: failed to read user auth response body: %v", err)
-		return nil, fmt.Errorf("NewAlkiraClientInternal: failed to read user auth response body: %v", err)
+		return nil, fmt.Errorf("NewAlkiraClientInternal: failed to read user auth response body: %w", err)
 	}
 
 	if response.StatusCode != 200 {
@@ -321,15 +328,15 @@ func NewAlkiraClientInternal(url string, username string, password string, secre
 	sessionResponse, err := retryClient.Do(sessionRequest)
 
 	if err != nil {
-		return nil, fmt.Errorf("failed to make session request, %v", err)
+		return nil, fmt.Errorf("failed to make session request, %w", err)
 	}
 
-	defer sessionResponse.Body.Close()
+	defer func() { _ = sessionResponse.Body.Close() }()
 
 	sessionData, err := io.ReadAll(sessionResponse.Body)
 	if err != nil {
 		logf("ERROR", "NewAlkiraClientInternal: failed to read session response body: %v", err)
-		return nil, fmt.Errorf("NewAlkiraClientInternal: failed to read session response body: %v", err)
+		return nil, fmt.Errorf("NewAlkiraClientInternal: failed to read session response body: %w", err)
 	}
 	logf("TRACE", "session data: %s\n", string(sessionData))
 
@@ -346,15 +353,15 @@ func NewAlkiraClientInternal(url string, username string, password string, secre
 	tenantNetworkResponse, err := retryClient.Do(tenantNetworkRequest)
 
 	if err != nil {
-		return nil, fmt.Errorf("failed to make tenant network request, %v", err)
+		return nil, fmt.Errorf("failed to make tenant network request, %w", err)
 	}
 
-	defer tenantNetworkResponse.Body.Close()
+	defer func() { _ = tenantNetworkResponse.Body.Close() }()
 
 	data, err := io.ReadAll(tenantNetworkResponse.Body)
 	if err != nil {
 		logf("ERROR", "NewAlkiraClientInternal: failed to read tenant network response body: %v", err)
-		return nil, fmt.Errorf("NewAlkiraClientInternal: failed to read tenant network response body: %v", err)
+		return nil, fmt.Errorf("NewAlkiraClientInternal: failed to read tenant network response body: %w", err)
 	}
 	logf("TRACE", "Tenant Network Summary: %s\n", string(data))
 
@@ -362,13 +369,13 @@ func NewAlkiraClientInternal(url string, username string, password string, secre
 		return nil, fmt.Errorf("failed to get tenant network (%d)", tenantNetworkResponse.StatusCode)
 	}
 
-	err = json.Unmarshal([]byte(data), &result)
+	err = json.Unmarshal(data, &result)
 	if err != nil {
 		logf("ERROR", "NewAlkiraClientInternal: failed to unmarshal tenant network data: %v", err)
-		return nil, fmt.Errorf("NewAlkiraClientInternal: failed to unmarshal tenant network data: %v", err)
+		return nil, fmt.Errorf("NewAlkiraClientInternal: failed to unmarshal tenant network data: %w", err)
 	}
 
-	tenantNetworkId := 0
+	var tenantNetworkId int
 
 	if len(result) > 0 {
 		tenantNetworkId = result[0].Id
@@ -409,16 +416,16 @@ func (ac *AlkiraClient) get(uri string) ([]byte, string, error) {
 	response, err := ac.Client.Do(request)
 
 	if err != nil {
-		return nil, "", fmt.Errorf("client-get(%s) failed to send request, %v", requestId, err)
+		return nil, "", fmt.Errorf("client-get(%s) failed to send request, %w", requestId, err)
 	}
 
-	defer response.Body.Close()
+	defer func() { _ = response.Body.Close() }()
 	logf("DEBUG", "client-get(%s): received response with status: %d", requestId, response.StatusCode)
 	logf("DEBUG", "client-get(%s): response headers: %v", requestId, response.Header)
 	data, err := io.ReadAll(response.Body)
 	if err != nil {
 		logf("ERROR", "client-get(%s): failed to read response body: %v", requestId, err)
-		return nil, "", fmt.Errorf("client-get(%s) failed to read response body: %v", requestId, err)
+		return nil, "", fmt.Errorf("client-get(%s) failed to read response body: %w", requestId, err)
 	}
 	logf("DEBUG", "client-get(%s) %d RSP: %s", requestId, response.StatusCode, string(data))
 	logf("DEBUG", "client-get(%s): response body length: %d", requestId, len(data))
@@ -449,16 +456,16 @@ func (ac *AlkiraClient) getByName(uri string) ([]byte, string, error) {
 	response, err := ac.Client.Do(request)
 
 	if err != nil {
-		return nil, "", fmt.Errorf("client-get(%s): failed to send request, %v", requestId, err)
+		return nil, "", fmt.Errorf("client-get(%s): failed to send request, %w", requestId, err)
 	}
 
-	defer response.Body.Close()
+	defer func() { _ = response.Body.Close() }()
 	logf("DEBUG", "client-get(%s): received response with status: %d", requestId, response.StatusCode)
 	logf("DEBUG", "client-get(%s): response headers: %v", requestId, response.Header)
 	data, err := io.ReadAll(response.Body)
 	if err != nil {
 		logf("ERROR", "client-get(%s): failed to read response body: %v", requestId, err)
-		return nil, "", fmt.Errorf("client-get(%s): failed to read response body: %v", requestId, err)
+		return nil, "", fmt.Errorf("client-get(%s): failed to read response body: %w", requestId, err)
 	}
 	logf("DEBUG", "client-get(%s) %d RSP: %s", requestId, response.StatusCode, string(data))
 	logf("DEBUG", "client-get(%s): response body length: %d", requestId, len(data))
@@ -488,11 +495,19 @@ func (ac *AlkiraClient) executeWithMutex(fn func() error) error {
 
 	// Channel to signal mutex acquisition
 	mutexAcquired := make(chan struct{})
+	// Channel to signal that a timeout occurred before the mutex was acquired
+	timedOut := make(chan struct{})
 
 	// Try to acquire the mutex in a goroutine
 	go func() {
 		ac.apiMutex.Lock()
-		close(mutexAcquired)
+		select {
+		case <-timedOut:
+			// Timeout already fired — release the mutex immediately so it isn't leaked
+			ac.apiMutex.Unlock()
+		default:
+			close(mutexAcquired)
+		}
 	}()
 
 	// Wait for either mutex acquisition or timeout
@@ -503,12 +518,13 @@ func (ac *AlkiraClient) executeWithMutex(fn func() error) error {
 		logf("DEBUG", "API mutex acquired, executing request")
 		return fn()
 	case <-time.After(ac.serializationTimeout):
-		// Timeout occurred
+		// Timeout occurred — signal the goroutine to release the mutex if it acquires it late
+		close(timedOut)
 		return fmt.Errorf("failed to acquire API mutex within timeout (%v)", ac.serializationTimeout)
 	}
 }
 
- // formatProvisionError formats the provision error message with detailed information if available
+// formatProvisionError formats the provision error message with detailed information if available
 func formatProvisionError(operation string, requestId string, provisionRequestId string, request *TenantNetworkProvisionRequest) error {
 	errMsg := fmt.Sprintf("client-%s(%s): provision request %s failed", operation, requestId, provisionRequestId)
 	if request.ErrorDetails != nil && request.ErrorDetails.Message != "" && request.ErrorDetails.Metadata != nil {
@@ -529,23 +545,23 @@ func (ac *AlkiraClient) create(uri string, body []byte, provision bool) ([]byte,
 	// to provision.
 	//
 	parsedURL, urlErr := url.Parse(uri)
-    if urlErr != nil {
-        return nil, "", fmt.Errorf("client-create: failed to parse URI: %w", urlErr), nil, nil
-    }
+	if urlErr != nil {
+		return nil, "", fmt.Errorf("client-create: failed to parse URI: %w", urlErr), nil, nil
+	}
 
-    query := parsedURL.Query()
+	query := parsedURL.Query()
 
-    if ac.Provision && provision {
-        logf("DEBUG", "client-create: enable provision")
-       	query.Set("provision", "true")
-    }
-    if ac.Validate {
-       	logf("DEBUG", "client-create: enable async validation")
-       	query.Set("async", "true")
-    }
+	if ac.Provision && provision {
+		logf("DEBUG", "client-create: enable provision")
+		query.Set("provision", "true")
+	}
+	if ac.Validate {
+		logf("DEBUG", "client-create: enable async validation")
+		query.Set("async", "true")
+	}
 
-    parsedURL.RawQuery = query.Encode()
-    uri = parsedURL.String()
+	parsedURL.RawQuery = query.Encode()
+	uri = parsedURL.String()
 
 	requestId := "client-" + uuid.New().String()
 	request, _ := retryablehttp.NewRequest("POST", uri, bytes.NewBuffer(body))
@@ -558,32 +574,35 @@ func (ac *AlkiraClient) create(uri string, body []byte, provision bool) ([]byte,
 	var response *http.Response
 	var err error
 	mutexErr := ac.executeWithMutex(func() error {
-		response, err = ac.Client.Do(request)
+		response, err = ac.Client.Do(request) //nolint:bodyclose // Body is closed after mutex release
 		return err
 	})
 
+	// Ensure response body is closed on all paths after we use it
+	if response != nil && response.Body != nil {
+		defer func() { _ = response.Body.Close() }()
+	}
+
 	if mutexErr != nil {
-		return nil, "", fmt.Errorf("client-create(%s): %v", requestId, mutexErr), nil, nil
+		return nil, "", fmt.Errorf("client-create(%s): %w", requestId, mutexErr), nil, nil
 	}
 
 	if err != nil {
-		return nil, "", fmt.Errorf("client-create(%s): failed to send request, %v", requestId, err), nil, nil
+		return nil, "", fmt.Errorf("client-create(%s): failed to send request, %w", requestId, err), nil, nil
 	}
-
-	defer response.Body.Close()
 	logf("DEBUG", "client-create(%s): received response with status: %d", requestId, response.StatusCode)
 	logf("DEBUG", "client-create(%s): response headers: %v", requestId, response.Header)
 	data, err := io.ReadAll(response.Body)
 	if err != nil {
 		logf("ERROR", "client-create(%s): failed to read response body: %v", requestId, err)
-		return nil, "", fmt.Errorf("client-create(%s): failed to read response body: %v", requestId, err), nil, nil
+		return nil, "", fmt.Errorf("client-create(%s): failed to read response body: %w", requestId, err), nil, nil
 	}
 
 	logf("DEBUG", "client-create(%s) %d RSP: %s", requestId, response.StatusCode, string(data))
 	logf("DEBUG", "client-create(%s): response body length: %d", requestId, len(data))
 
 	if response.StatusCode != 201 && response.StatusCode != 200 && response.StatusCode != 202 {
-		return nil, "", fmt.Errorf("client-create(%s): %d %s.", requestId, response.StatusCode, string(data)), nil, nil
+		return nil, "", fmt.Errorf("client-create(%s): %d %s", requestId, response.StatusCode, string(data)), nil, nil
 	}
 
 	// Handle validation if enabled and response is 202
@@ -601,7 +620,7 @@ func (ac *AlkiraClient) create(uri string, body []byte, provision bool) ([]byte,
 	// If provision is enabled, wait for provision to finish and
 	// return the provision state
 	//
-	if ac.Provision == true && provision == true {
+	if ac.Provision && provision {
 		provisionRequestId := response.Header.Get("x-provision-request-id")
 
 		if provisionRequestId == "" {
@@ -615,9 +634,10 @@ func (ac *AlkiraClient) create(uri string, body []byte, provision bool) ([]byte,
 				return false, err
 			}
 
-			if request.State == "SUCCESS" {
+			switch request.State {
+			case "SUCCESS":
 				return true, nil
-			} else if request.State == "FAILED" || request.State == "PARTIAL_SUCCESS" {
+			case "FAILED", "PARTIAL_SUCCESS":
 				return false, formatProvisionError("create", requestId, provisionRequestId, request)
 			}
 
@@ -626,7 +646,7 @@ func (ac *AlkiraClient) create(uri string, body []byte, provision bool) ([]byte,
 		})
 
 		if err != nil {
-			if err == wait.ErrWaitTimeout {
+			if errors.Is(err, wait.ErrWaitTimeout) {
 				return data, "FAILED", nil, nil, fmt.Errorf("client-create(%s): provision request %s timed out", requestId, provisionRequestId)
 			}
 
@@ -649,23 +669,23 @@ func (ac *AlkiraClient) delete(uri string, provision bool) (string, error, error
 	// to provision.
 	//
 	parsedURL, urlErr := url.Parse(uri)
-    if urlErr != nil {
-        return "", fmt.Errorf("client-delete: failed to parse URI: %w", urlErr), nil, nil
-    }
+	if urlErr != nil {
+		return "", fmt.Errorf("client-delete: failed to parse URI: %w", urlErr), nil, nil
+	}
 
-    query := parsedURL.Query()
+	query := parsedURL.Query()
 
-    if ac.Provision && provision {
-        logf("DEBUG", "client-delete: enable provision")
-       	query.Set("provision", "true")
-    }
-    if ac.Validate {
-       	logf("DEBUG", "client-delete: enable async validation")
-       	query.Set("async", "true")
-    }
+	if ac.Provision && provision {
+		logf("DEBUG", "client-delete: enable provision")
+		query.Set("provision", "true")
+	}
+	if ac.Validate {
+		logf("DEBUG", "client-delete: enable async validation")
+		query.Set("async", "true")
+	}
 
-    parsedURL.RawQuery = query.Encode()
-    uri = parsedURL.String()
+	parsedURL.RawQuery = query.Encode()
+	uri = parsedURL.String()
 
 	requestId := "client-" + uuid.New().String()
 	request, _ := retryablehttp.NewRequest("DELETE", uri, nil)
@@ -678,25 +698,28 @@ func (ac *AlkiraClient) delete(uri string, provision bool) (string, error, error
 	var response *http.Response
 	var err error
 	mutexErr := ac.executeWithMutex(func() error {
-		response, err = ac.Client.Do(request)
+		response, err = ac.Client.Do(request) //nolint:bodyclose // Body is closed after mutex release
 		return err
 	})
 
+	// Ensure response body is closed on all paths after we use it
+	if response != nil && response.Body != nil {
+		defer func() { _ = response.Body.Close() }()
+	}
+
 	if mutexErr != nil {
-		return "", fmt.Errorf("client-delete(%s): %v", requestId, mutexErr), nil, nil
+		return "", fmt.Errorf("client-delete(%s): %w", requestId, mutexErr), nil, nil
 	}
 
 	if err != nil {
-		return "", fmt.Errorf("client-delete(%s): failed to send request, %v", requestId, err), nil, nil
+		return "", fmt.Errorf("client-delete(%s): failed to send request, %w", requestId, err), nil, nil
 	}
-
-	defer response.Body.Close()
 	logf("DEBUG", "client-delete(%s): received response with status: %d", requestId, response.StatusCode)
 	logf("DEBUG", "client-delete(%s): response headers: %v", requestId, response.Header)
 	data, err := io.ReadAll(response.Body)
 	if err != nil {
 		logf("ERROR", "client-delete(%s): failed to read response body: %v", requestId, err)
-		return "", fmt.Errorf("client-delete(%s): failed to read response body: %v", requestId, err), nil, nil
+		return "", fmt.Errorf("client-delete(%s): failed to read response body: %w", requestId, err), nil, nil
 	}
 
 	logf("DEBUG", "client-delete(%s): %d RSP: %s\n", requestId, response.StatusCode, string(data))
@@ -724,7 +747,7 @@ func (ac *AlkiraClient) delete(uri string, provision bool) (string, error, error
 
 	// If provision is enabled, wait for provision to finish and
 	// return the proper provision state
-	if ac.Provision == true && provision == true {
+	if ac.Provision && provision {
 		provisionRequestId := response.Header.Get("x-provision-request-id")
 
 		if provisionRequestId == "" {
@@ -738,9 +761,10 @@ func (ac *AlkiraClient) delete(uri string, provision bool) (string, error, error
 				return false, err
 			}
 
-			if request.State == "SUCCESS" {
+			switch request.State {
+			case "SUCCESS":
 				return true, nil
-			} else if request.State == "FAILED" {
+			case "FAILED":
 				return false, formatProvisionError("delete", requestId, provisionRequestId, request)
 			}
 
@@ -749,7 +773,7 @@ func (ac *AlkiraClient) delete(uri string, provision bool) (string, error, error
 		})
 
 		if err != nil {
-			if err == wait.ErrWaitTimeout {
+			if errors.Is(err, wait.ErrWaitTimeout) {
 				return "FAILED", nil, nil, fmt.Errorf("client-delete(%s): provision request %s timed out", requestId, provisionRequestId)
 			}
 
@@ -772,23 +796,23 @@ func (ac *AlkiraClient) update(uri string, body []byte, provision bool) (string,
 	// to provision.
 	//
 	parsedURL, urlErr := url.Parse(uri)
-    if urlErr != nil {
-        return "", fmt.Errorf("client-update: failed to parse URI: %w", urlErr), nil, nil
-    }
+	if urlErr != nil {
+		return "", urlErr, nil, nil
+	}
 
-    query := parsedURL.Query()
+	query := parsedURL.Query()
 
-    if ac.Provision && provision {
-        logf("DEBUG", "client-update: enable provision")
-       	query.Set("provision", "true")
-    }
-    if ac.Validate {
-       	logf("DEBUG", "client-update: enable async validation")
-       	query.Set("async", "true")
-    }
+	if ac.Provision && provision {
+		logf("DEBUG", "client-update: enable provision")
+		query.Set("provision", "true")
+	}
+	if ac.Validate {
+		logf("DEBUG", "client-update: enable async validation")
+		query.Set("async", "true")
+	}
 
-    parsedURL.RawQuery = query.Encode()
-    uri = parsedURL.String()
+	parsedURL.RawQuery = query.Encode()
+	uri = parsedURL.String()
 
 	requestId := "client-" + uuid.New().String()
 	request, _ := retryablehttp.NewRequest("PUT", uri, bytes.NewBuffer(body))
@@ -801,25 +825,28 @@ func (ac *AlkiraClient) update(uri string, body []byte, provision bool) (string,
 	var response *http.Response
 	var err error
 	mutexErr := ac.executeWithMutex(func() error {
-		response, err = ac.Client.Do(request)
+		response, err = ac.Client.Do(request) //nolint:bodyclose // Body is closed after mutex release
 		return err
 	})
 
+	// Ensure response body is closed on all paths after we use it
+	if response != nil && response.Body != nil {
+		defer func() { _ = response.Body.Close() }()
+	}
+
 	if mutexErr != nil {
-		return "", fmt.Errorf("client-update(%s): %v", requestId, mutexErr), nil, nil
+		return "", fmt.Errorf("client-update(%s): %w", requestId, mutexErr), nil, nil
 	}
 
 	if err != nil {
-		return "", fmt.Errorf("client-update(%s): failed to send request, %v", requestId, err), nil, nil
+		return "", fmt.Errorf("client-update(%s): failed to send request, %w", requestId, err), nil, nil
 	}
-
-	defer response.Body.Close()
 	logf("DEBUG", "client-update(%s): received response with status: %d", requestId, response.StatusCode)
 	logf("DEBUG", "client-update(%s): response headers: %v", requestId, response.Header)
 	data, err := io.ReadAll(response.Body)
 	if err != nil {
 		logf("ERROR", "client-update(%s): failed to read response body: %v", requestId, err)
-		return "", fmt.Errorf("client-update(%s): failed to read response body: %v", requestId, err), nil, nil
+		return "", fmt.Errorf("client-update(%s): failed to read response body: %w", requestId, err), nil, nil
 	}
 
 	logf("DEBUG", "client-update(%s): %d RSP: %s\n", requestId, response.StatusCode, string(data))
@@ -843,7 +870,7 @@ func (ac *AlkiraClient) update(uri string, body []byte, provision bool) (string,
 	//
 	// If provision is enabled, wait for provision to finish and return the proper state
 	//
-	if ac.Provision == true && provision == true {
+	if ac.Provision && provision {
 		provisionRequestId := response.Header.Get("x-provision-request-id")
 
 		if provisionRequestId == "" {
@@ -857,9 +884,10 @@ func (ac *AlkiraClient) update(uri string, body []byte, provision bool) (string,
 				return false, err
 			}
 
-			if request.State == "SUCCESS" {
+			switch request.State {
+			case "SUCCESS":
 				return true, nil
-			} else if request.State == "FAILED" {
+			case "FAILED":
 				return false, formatProvisionError("update", requestId, provisionRequestId, request)
 			}
 
@@ -868,7 +896,7 @@ func (ac *AlkiraClient) update(uri string, body []byte, provision bool) (string,
 		})
 
 		if err != nil {
-			if err == wait.ErrWaitTimeout {
+			if errors.Is(err, wait.ErrWaitTimeout) {
 				return "FAILED", nil, nil, fmt.Errorf("client-update(%s): provision request %s timed out", requestId, provisionRequestId)
 			}
 

--- a/vendor/github.com/alkiranet/alkira-client-go/alkira/connector_aruba_edge.go
+++ b/vendor/github.com/alkiranet/alkira-client-go/alkira/connector_aruba_edge.go
@@ -21,6 +21,7 @@ type ConnectorArubaEdge struct {
 	TunnelProtocol       string                 `json:"tunnelProtocol"`
 	Version              string                 `json:"version"`
 	Enabled              bool                   `json:"enabled"`
+	ScaleGroupId         string                 `json:"scaleGroupId,omitempty"`
 	Description          string                 `json:"description,omitempty"`
 }
 
@@ -47,7 +48,7 @@ type ArubaEdgeInstanceConfig struct {
 	//json structure.
 }
 
-// NewConnectorArubaEdge initalize a new connector
+// NewConnectorArubaEdge initialize a new connector
 func NewConnectorArubaEdge(ac *AlkiraClient) *AlkiraAPI[ConnectorArubaEdge] {
 	uri := fmt.Sprintf("%s/tenantnetworks/%s/aruba-edge-connectors", ac.URI, ac.TenantNetworkId)
 	api := &AlkiraAPI[ConnectorArubaEdge]{ac, uri, true}

--- a/vendor/github.com/alkiranet/alkira-client-go/alkira/connector_azure_vnet.go
+++ b/vendor/github.com/alkiranet/alkira-client-go/alkira/connector_azure_vnet.go
@@ -94,7 +94,7 @@ type ConnectorAzureVnet struct {
 	Description                       string                `json:"description,omitempty"`
 }
 
-// NewConnectorAzureVnet initalize a new connector
+// NewConnectorAzureVnet initialize a new connector
 func NewConnectorAzureVnet(ac *AlkiraClient) *AlkiraAPI[ConnectorAzureVnet] {
 	uri := fmt.Sprintf("%s/tenantnetworks/%s/azurevnetconnectors", ac.URI, ac.TenantNetworkId)
 	api := &AlkiraAPI[ConnectorAzureVnet]{ac, uri, true}

--- a/vendor/github.com/alkiranet/alkira-client-go/alkira/connector_azure_vnet_third_party.go
+++ b/vendor/github.com/alkiranet/alkira-client-go/alkira/connector_azure_vnet_third_party.go
@@ -1,0 +1,28 @@
+package alkira
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+type AzureVnetThirdPartyConnector struct {
+	Name                                     string      `json:"name"`
+	Description                              string      `json:"description,omitempty"`
+	CXP                                      string      `json:"cxp"`
+	Enabled                                  bool        `json:"enabled"`
+	Group                                    string      `json:"group,omitempty"`
+	Segments                                 []string    `json:"segments"`
+	Size                                     string      `json:"size"`
+	AzureVnetThirdPartyConnectorAttachmentId int         `json:"azureVnetThirdPartyConnectorAttachmentId"`
+	BillingTags                              []int       `json:"billingTags,omitempty"`
+	StaticRoutes                             []int       `json:"staticRoutes,omitempty"`
+	Id                                       json.Number `json:"id,omitempty"`                  // response only
+	ImplicitGroupId                          int         `json:"implicitGroupId,omitempty"`     // response only
+	CxpPeeringGatewayId                      int         `json:"cxpPeeringGatewayId,omitempty"` // response only
+}
+
+func NewAzureVnetThirdPartyConnector(ac *AlkiraClient) *AlkiraAPI[AzureVnetThirdPartyConnector] {
+	uri := fmt.Sprintf("%s/tenantnetworks/%s/azure-vnet-third-party-connectors", ac.URI, ac.TenantNetworkId)
+	api := &AlkiraAPI[AzureVnetThirdPartyConnector]{ac, uri, true}
+	return api
+}

--- a/vendor/github.com/alkiranet/alkira-client-go/alkira/connector_gcp_vpc.go
+++ b/vendor/github.com/alkiranet/alkira-client-go/alkira/connector_gcp_vpc.go
@@ -15,8 +15,8 @@ type UserInputPrefixes struct {
 }
 
 type ConnectorGcpVpcExportOptions struct {
-	ExportAllSubnets bool                `json:"exportAllSubnets,omitempty"`
-	Prefixes         []UserInputPrefixes `json:"userInputPrefixes,omitempty"`
+	ExportAllSubnets bool                `json:"exportAllSubnets"`
+	Prefixes         []UserInputPrefixes `json:"userInputPrefixes"`
 }
 
 type ConnectorGcpVpcImportOptions struct {

--- a/vendor/github.com/alkiranet/alkira-client-go/alkira/connector_juniper_sdwan.go
+++ b/vendor/github.com/alkiranet/alkira-client-go/alkira/connector_juniper_sdwan.go
@@ -1,4 +1,5 @@
 // Copyright (C) 2023-2025 Alkira Inc. All Rights Reserved.
+
 package alkira
 
 import (

--- a/vendor/github.com/alkiranet/alkira-client-go/alkira/credentials.go
+++ b/vendor/github.com/alkiranet/alkira-client-go/alkira/credentials.go
@@ -325,23 +325,28 @@ func (ac *AlkiraClient) GetCredentials() (string, error) {
 
 // GetCredentialById get one credential by its Id
 func (ac *AlkiraClient) GetCredentialById(id string) (CredentialResponseDetail, error) {
-	uri := fmt.Sprintf("%s/api/credentials/%s", ac.URI, id)
-
 	var credential CredentialResponseDetail
 
-	data, _, err := ac.get(uri)
-
+	// Get all credentials and filter by ID
+	// Note:  API endpoint /api/credentials/{id} is not valid.
+	credentialsJSON, err := ac.GetCredentials()
 	if err != nil {
-		return credential, err
+		return credential, fmt.Errorf("GetCredentialById: failed to get credentials: %w", err)
 	}
 
-	err = json.Unmarshal(data, &credential)
-
-	if err != nil {
-		return credential, fmt.Errorf("GetCredentialById: failed to unmarshal: %w", err)
+	var credentials []CredentialResponseDetail
+	if err := json.Unmarshal([]byte(credentialsJSON), &credentials); err != nil {
+		return credential, fmt.Errorf("GetCredentialById: failed to unmarshal credentials: %w", err)
 	}
 
-	return credential, nil
+	// Find the credential matching the ID
+	for i := range credentials {
+		if credentials[i].Id == id {
+			return credentials[i], nil
+		}
+	}
+
+	return credential, fmt.Errorf("GetCredentialById: credential with id %s not found", id)
 }
 
 // GetCredentialByName get the credential by its name

--- a/vendor/github.com/alkiranet/alkira-client-go/alkira/monitoring_alerts.go
+++ b/vendor/github.com/alkiranet/alkira-client-go/alkira/monitoring_alerts.go
@@ -15,7 +15,7 @@ func (ac *AlkiraClient) GetAlerts(queryStatus string, queryType string, queryPri
 	uri, err := url.Parse(baseUri)
 
 	if err != nil {
-		return "", fmt.Errorf("GetAlerts: failed to parse URI: %v", err)
+		return "", fmt.Errorf("GetAlerts: failed to parse URI: %w", err)
 	}
 
 	// Process optional query parameters

--- a/vendor/github.com/alkiranet/alkira-client-go/alkira/monitoring_auditlogs.go
+++ b/vendor/github.com/alkiranet/alkira-client-go/alkira/monitoring_auditlogs.go
@@ -41,7 +41,7 @@ func (ac *AlkiraClient) GetAuditLogs(queryStatus string, queryType string) (stri
 	uri, err := url.Parse(baseUri)
 
 	if err != nil {
-		return "", fmt.Errorf("GetAuditLogs: failed to parse URI: %v", err)
+		return "", fmt.Errorf("GetAuditLogs: failed to parse URI: %w", err)
 	}
 
 	// Process optional query parameters

--- a/vendor/github.com/alkiranet/alkira-client-go/alkira/monitoring_health.go
+++ b/vendor/github.com/alkiranet/alkira-client-go/alkira/monitoring_health.go
@@ -18,7 +18,7 @@ func (ac *AlkiraClient) GetHealthAll() (string, error) {
 func (ac *AlkiraClient) GetHealthOfConnector(connectorId string) (string, error) {
 
 	if connectorId == "" {
-		return "", fmt.Errorf("Invalid connector ID %s.", connectorId)
+		return "", fmt.Errorf("invalid connector ID %s", connectorId)
 	}
 
 	uri := fmt.Sprintf("%s/tenantnetworks/%s/health/connector/%s", ac.URI, ac.TenantNetworkId, connectorId)
@@ -32,7 +32,7 @@ func (ac *AlkiraClient) GetHealthOfConnector(connectorId string) (string, error)
 func (ac *AlkiraClient) GetHealthOfConnectorInstance(connectorId string, instanceId string) (string, error) {
 
 	if connectorId == "" || instanceId == "" {
-		return "", fmt.Errorf("Invalid connector ID %s or instance ID %s.", connectorId, instanceId)
+		return "", fmt.Errorf("invalid connector ID %s or instance ID %s", connectorId, instanceId)
 	}
 
 	uri := fmt.Sprintf("%s/tenantnetworks/%s/health/connector/%s/instance/%s", ac.URI, ac.TenantNetworkId, connectorId, instanceId)
@@ -45,7 +45,7 @@ func (ac *AlkiraClient) GetHealthOfConnectorInstance(connectorId string, instanc
 func (ac *AlkiraClient) GetHealthOfService(serviceId string) (string, error) {
 
 	if serviceId == "" {
-		return "", fmt.Errorf("Invalid service ID %s.", serviceId)
+		return "", fmt.Errorf("invalid service ID %s", serviceId)
 	}
 
 	uri := fmt.Sprintf("%s/tenantnetworks/%s/health/service/%s", ac.URI, ac.TenantNetworkId, serviceId)
@@ -59,7 +59,7 @@ func (ac *AlkiraClient) GetHealthOfService(serviceId string) (string, error) {
 func (ac *AlkiraClient) GetHealthOfServiceInstance(serviceId string, instanceId string) (string, error) {
 
 	if serviceId == "" || instanceId == "" {
-		return "", fmt.Errorf("Invalid service ID %s or instance ID %s.", serviceId, instanceId)
+		return "", fmt.Errorf("invalid service ID %s or instance ID %s", serviceId, instanceId)
 	}
 
 	uri := fmt.Sprintf("%s/tenantnetworks/%s/health/service/%s/instance/%s", ac.URI, ac.TenantNetworkId, serviceId, instanceId)

--- a/vendor/github.com/alkiranet/alkira-client-go/alkira/monitoring_jobs.go
+++ b/vendor/github.com/alkiranet/alkira-client-go/alkira/monitoring_jobs.go
@@ -15,7 +15,7 @@ func (ac *AlkiraClient) GetJobs(queryStatus string, queryType string) (string, e
 	uri, err := url.Parse(baseUri)
 
 	if err != nil {
-		return "", fmt.Errorf("GetJobs: failed to parse URI: %v", err)
+		return "", fmt.Errorf("GetJobs: failed to parse URI: %w", err)
 	}
 
 	// Process optional query parameters

--- a/vendor/github.com/alkiranet/alkira-client-go/alkira/network_entity_scale_options.go
+++ b/vendor/github.com/alkiranet/alkira-client-go/alkira/network_entity_scale_options.go
@@ -21,7 +21,7 @@ type SegmentScaleOptions struct {
 	AdditionalTunnelOptionsPerNode []AdditionalTunnelOptionsPerNode `json:"additionalTunnelOptionsPerNode"`
 }
 
-type ControllerScaleOptions struct {
+type NetworkEntityScaleOptions struct {
 	Description          string                `json:"description"`
 	DocState             string                `json:"docState,omitempty"`
 	EntityId             int                   `json:"entityId"`
@@ -36,9 +36,9 @@ type ControllerScaleOptions struct {
 	State                string                `json:"state,omitempty"` // response only
 }
 
-// NewControllerScaleOptions new controller scale options
-func NewControllerScaleOptions(ac *AlkiraClient) *AlkiraAPI[ControllerScaleOptions] {
+// NewNetworkEntityScaleOptions new network entity scale options
+func NewNetworkEntityScaleOptions(ac *AlkiraClient) *AlkiraAPI[NetworkEntityScaleOptions] {
 	uri := fmt.Sprintf("%s/tenantnetworks/%s/network-entity-scale-options", ac.URI, ac.TenantNetworkId)
-	api := &AlkiraAPI[ControllerScaleOptions]{ac, uri, true}
+	api := &AlkiraAPI[NetworkEntityScaleOptions]{ac, uri, true}
 	return api
 }

--- a/vendor/github.com/alkiranet/alkira-client-go/alkira/peering_gateway_azure_vnet_third_party_connector_attachment.go
+++ b/vendor/github.com/alkiranet/alkira-client-go/alkira/peering_gateway_azure_vnet_third_party_connector_attachment.go
@@ -1,0 +1,22 @@
+package alkira
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+type AzureVnetThirdPartyConnectorAttachment struct {
+	Name                string      `json:"name"`
+	Description         string      `json:"description,omitempty"`
+	CxpPeeringGatewayId int         `json:"cxpPeeringGatewayId"`
+	VnetId              string      `json:"vnetId"`
+	Id                  json.Number `json:"id,omitempty"`           // response only
+	InternalName        string      `json:"internalName,omitempty"` // response only
+	State               string      `json:"state,omitempty"`        // response only
+}
+
+func NewAzureVnetThirdPartyConnectorAttachment(ac *AlkiraClient) *AlkiraAPI[AzureVnetThirdPartyConnectorAttachment] {
+	uri := fmt.Sprintf("%s/tenantnetworks/%s/azure-vnet-third-party-connector-attachments", ac.URI, ac.TenantNetworkId)
+	api := &AlkiraAPI[AzureVnetThirdPartyConnectorAttachment]{ac, uri, false}
+	return api
+}

--- a/vendor/github.com/alkiranet/alkira-client-go/alkira/peering_gateway_cxp.go
+++ b/vendor/github.com/alkiranet/alkira-client-go/alkira/peering_gateway_cxp.go
@@ -7,15 +7,25 @@ import (
 	"fmt"
 )
 
+type PeeringGatewayCxpMetadata struct {
+	IlbIpAddress   string `json:"ilbIpAddress,omitempty"`
+	GuestEmail     string `json:"guestEmail,omitempty"`
+	VnetResourceId string `json:"vnetResourceId,omitempty"`
+	VnetName       string `json:"vnetName,omitempty"`
+	SubscriptionId string `json:"subscriptionId,omitempty"`
+	ResourceGroup  string `json:"resourceGroup,omitempty"`
+}
+
 type PeeringGatewayCxp struct {
-	Name          string      `json:"name"`
-	Description   string      `json:"description,omitempty"`
-	Cxp           string      `json:"cxp"`
-	CloudProvider string      `json:"cloudProvider"`
-	CloudRegion   string      `json:"cloudRegion"`
-	Segment       string      `json:"segment"`
-	Id            json.Number `json:"id,omitempty"`    // response only
-	State         string      `json:"state,omitempty"` // response only
+	Name          string                     `json:"name"`
+	Description   string                     `json:"description,omitempty"`
+	Cxp           string                     `json:"cxp"`
+	CloudProvider string                     `json:"cloudProvider"`
+	CloudRegion   string                     `json:"cloudRegion"`
+	Segment       string                     `json:"segment"`
+	Id            json.Number                `json:"id,omitempty"`       // response only
+	State         string                     `json:"state,omitempty"`    // response only
+	Metadata      *PeeringGatewayCxpMetadata `json:"metadata,omitempty"` // response only, available when state is ACTIVE
 }
 
 func NewPeeringGatewayCxp(ac *AlkiraClient) *AlkiraAPI[PeeringGatewayCxp] {

--- a/vendor/github.com/alkiranet/alkira-client-go/alkira/routes.go
+++ b/vendor/github.com/alkiranet/alkira-client-go/alkira/routes.go
@@ -31,6 +31,7 @@ type RouteQueryParams struct {
 	RouteRecvType        string `json:"routeRecvType,omitempty"`        // route receive type filter
 	Prefix               string `json:"prefix,omitempty"`               // prefix filter
 	LPMPrefix            string `json:"lpmPrefix,omitempty"`            // LPM prefix filter
+	MatchOriginalPrefix  bool   `json:"matchOriginalPrefix,omitempty"`  // match original prefix filter
 }
 
 // Route count query parameters
@@ -52,6 +53,8 @@ type RouteCountQueryParams struct {
 	Prefix               string `json:"prefix,omitempty"`               // prefix filter
 	LPMPrefix            string `json:"lpmPrefix,omitempty"`            // LPM prefix filter
 	PrefixType           string `json:"prefixType,omitempty"`           // prefix type filter
+	RouteType            string `json:"routeType,omitempty"`            // route type filter
+	MatchOriginalPrefix  bool   `json:"matchOriginalPrefix,omitempty"`  // match original prefix filter
 }
 
 // Route UI connector represents a connector in a route
@@ -183,6 +186,9 @@ func (ac *AlkiraClient) GetRoutes(params RouteQueryParams) (*RoutesUIResponse, e
 	if params.LPMPrefix != "" {
 		queryParams.Set("lpmPrefix", params.LPMPrefix)
 	}
+	if params.MatchOriginalPrefix {
+		queryParams.Set("matchOriginalPrefix", "true")
+	}
 
 	// Append query parameters to URI if any
 	if len(queryParams) > 0 {
@@ -192,14 +198,14 @@ func (ac *AlkiraClient) GetRoutes(params RouteQueryParams) (*RoutesUIResponse, e
 	// Make the request
 	data, _, err := ac.get(uri)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get routes: %v", err)
+		return nil, fmt.Errorf("failed to get routes: %w", err)
 	}
 
 	// Parse response
 	var routes RoutesUIResponse
-	err = json.Unmarshal([]byte(data), &routes)
+	err = json.Unmarshal(data, &routes)
 	if err != nil {
-		return nil, fmt.Errorf("failed to unmarshal routes response: %v", err)
+		return nil, fmt.Errorf("failed to unmarshal routes response: %w", err)
 	}
 
 	return &routes, nil
@@ -265,6 +271,12 @@ func (ac *AlkiraClient) GetRouteCount(params RouteCountQueryParams) (*RouteCount
 	if params.PrefixType != "" {
 		queryParams.Set("prefixType", params.PrefixType)
 	}
+	if params.RouteType != "" {
+		queryParams.Set("routeType", params.RouteType)
+	}
+	if params.MatchOriginalPrefix {
+		queryParams.Set("matchOriginalPrefix", "true")
+	}
 
 	// Append query parameters to URI if any
 	if len(queryParams) > 0 {
@@ -274,14 +286,14 @@ func (ac *AlkiraClient) GetRouteCount(params RouteCountQueryParams) (*RouteCount
 	// Make the request
 	data, _, err := ac.get(uri)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get route count: %v", err)
+		return nil, fmt.Errorf("failed to get route count: %w", err)
 	}
 
 	// Parse response
 	var routeCount RouteCountUIResult
-	err = json.Unmarshal([]byte(data), &routeCount)
+	err = json.Unmarshal(data, &routeCount)
 	if err != nil {
-		return nil, fmt.Errorf("failed to unmarshal route count response: %v", err)
+		return nil, fmt.Errorf("failed to unmarshal route count response: %w", err)
 	}
 
 	return &routeCount, nil

--- a/vendor/github.com/alkiranet/alkira-client-go/alkira/service_bluecat.go
+++ b/vendor/github.com/alkiranet/alkira-client-go/alkira/service_bluecat.go
@@ -36,7 +36,7 @@ type BluecatInstance struct {
 	EdgeOptions      *EdgeOptions `json:"edgeOptions,omitempty"`
 	Id               int          `json:"id,omitempty"`
 	InternalName     string       `json:"internalName,omitempty"`
-	Name             string       `json:"name"`
+	Name             string       `json:"name,omitempty"`
 	Type             string       `json:"type"`                       // BDDS or EDGE
 	CxpBgpIp         string       `json:"cxpBgpIp,omitempty"`         // RESPONSE ONLY
 	CxpBgpAsn        string       `json:"cxpBgpAsn,omitempty"`        // RESPONSE ONLY

--- a/vendor/github.com/alkiranet/alkira-client-go/alkira/tenant_networks.go
+++ b/vendor/github.com/alkiranet/alkira-client-go/alkira/tenant_networks.go
@@ -62,10 +62,10 @@ func (ac *AlkiraClient) GetTenantNetworkId() (string, error) {
 	}
 
 	var result []TenantNetworkId
-	err = json.Unmarshal([]byte(data), &result)
+	err = json.Unmarshal(data, &result)
 
 	if err != nil {
-		return "", fmt.Errorf("GetTenantNetworkId: failed to unmarshal: %v", err)
+		return "", fmt.Errorf("GetTenantNetworkId: failed to unmarshal: %w", err)
 	}
 
 	return strconv.Itoa(result[0].Id), nil
@@ -82,10 +82,10 @@ func (ac *AlkiraClient) GetTenantNetworkState() (string, error) {
 	}
 
 	var result TenantNetworkState
-	err = json.Unmarshal([]byte(data), &result)
+	err = json.Unmarshal(data, &result)
 
 	if err != nil {
-		return "", fmt.Errorf("GetTenantNetworkState: failed to unmarshal: %v", err)
+		return "", fmt.Errorf("GetTenantNetworkState: failed to unmarshal: %w", err)
 	}
 
 	return result.State, nil
@@ -102,10 +102,10 @@ func (ac *AlkiraClient) GetTenantNetworkConnectorState(id string) (string, error
 	}
 
 	var result TenantNetworkConnectorState
-	err = json.Unmarshal([]byte(data), &result)
+	err = json.Unmarshal(data, &result)
 
 	if err != nil {
-		return "", fmt.Errorf("GetTenantNetworkConnectorState: failed to unmarshal: %v", err)
+		return "", fmt.Errorf("GetTenantNetworkConnectorState: failed to unmarshal: %w", err)
 	}
 
 	return result.State, nil
@@ -122,10 +122,10 @@ func (ac *AlkiraClient) GetTenantNetworkServiceState(id string) (string, error) 
 	}
 
 	var result TenantNetworkServiceState
-	err = json.Unmarshal([]byte(data), &result)
+	err = json.Unmarshal(data, &result)
 
 	if err != nil {
-		return "", fmt.Errorf("GetTenantNetworkConnectorState: failed to unmarshal: %v", err)
+		return "", fmt.Errorf("GetTenantNetworkConnectorState: failed to unmarshal: %w", err)
 	}
 
 	return result.State, nil
@@ -142,10 +142,10 @@ func (ac *AlkiraClient) GetTenantNetworkProvisionRequest(id string) (*TenantNetw
 	}
 
 	var result TenantNetworkProvisionRequest
-	err = json.Unmarshal([]byte(data), &result)
+	err = json.Unmarshal(data, &result)
 
 	if err != nil {
-		return nil, fmt.Errorf("GetTenantNetworkProvisionRequest: failed to unmarshal: %v", err)
+		return nil, fmt.Errorf("GetTenantNetworkProvisionRequest: failed to unmarshal: %w", err)
 	}
 
 	return &result, nil
@@ -162,10 +162,10 @@ func (ac *AlkiraClient) ProvisionTenantNetwork() (string, error) {
 	}
 
 	var result TenantNetworkState
-	err = json.Unmarshal([]byte(data), &result)
+	err = json.Unmarshal(data, &result)
 
 	if err != nil {
-		return "", fmt.Errorf("ProvisionTenantNetwork: failed to unmarshal: %v", err)
+		return "", fmt.Errorf("ProvisionTenantNetwork: failed to unmarshal: %w", err)
 	}
 
 	return result.State, nil

--- a/vendor/github.com/alkiranet/alkira-client-go/alkira/validation.go
+++ b/vendor/github.com/alkiranet/alkira-client-go/alkira/validation.go
@@ -4,6 +4,7 @@ package alkira
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"time"
@@ -42,13 +43,13 @@ func (ac *AlkiraClient) GetValidationState(id string) (*ValidationState, error) 
 	logf("DEBUG", "GetValidationState: raw response data as bytes: %v", data)
 
 	var result ValidationState
-	err = json.Unmarshal([]byte(data), &result)
+	err = json.Unmarshal(data, &result)
 	if err != nil {
 		// Log additional debugging information
 		logf("ERROR", "GetValidationState: JSON unmarshal failed with data length: %d", len(data))
 		logf("ERROR", "GetValidationState: JSON unmarshal failed with data as string: %s", string(data))
 		logf("ERROR", "GetValidationState: JSON unmarshal error: %v", err)
-		return nil, fmt.Errorf("GetValidationState: failed to unmarshal: %v", err)
+		return nil, fmt.Errorf("GetValidationState: failed to unmarshal: %w", err)
 	}
 
 	logf("DEBUG", "GetValidationState: successfully unmarshaled validation state: %+v", result)
@@ -99,7 +100,7 @@ func (ac *AlkiraClient) handleValidation(response *http.Response) error {
 		})
 
 		if err != nil {
-			if err == wait.ErrWaitTimeout {
+			if errors.Is(err, wait.ErrWaitTimeout) {
 				logf("ERROR", "handleValidation: validation %s timed out", validationStateID)
 				return fmt.Errorf("validation %s timed out", validationStateID)
 			}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,8 +1,8 @@
 # github.com/agext/levenshtein v1.2.2
 ## explicit
 github.com/agext/levenshtein
-# github.com/alkiranet/alkira-client-go v1.55.2
-## explicit; go 1.20
+# github.com/alkiranet/alkira-client-go v1.59.1-0.20260310051734-d6fba43c6ebf
+## explicit; go 1.26
 github.com/alkiranet/alkira-client-go/alkira
 # github.com/apparentlymart/go-textseg/v15 v15.0.0
 ## explicit; go 1.16


### PR DESCRIPTION
- Update alkira-client-go dependency to match release 64 branch
- Rename ControllerScaleOptions -> NetworkEntityScaleOptions and NewControllerScaleOptions -> NewNetworkEntityScaleOptions to match updated client library
- Regenerate vendor directory