### PR TITLE
AK-66346: Fix AWS VPC connector drift from backend-defaulted routing fields

### DIFF
--- a/alkira/resource_alkira_connector_aws_vpc.go
+++ b/alkira/resource_alkira_connector_aws_vpc.go
@@ -163,6 +163,7 @@ func resourceAlkiraConnectorAwsVpc() *schema.Resource {
 					"`vpc_subnet` is not specified.",
 				Type:          schema.TypeList,
 				Optional:      true,
+				Computed:      true,
 				ConflictsWith: []string{"vpc_subnet"},
 				Elem:          &schema.Schema{Type: schema.TypeString},
 			},
@@ -172,6 +173,7 @@ func resourceAlkiraConnectorAwsVpc() *schema.Resource {
 					"is not specified.",
 				Type:          schema.TypeSet,
 				Optional:      true,
+				Computed:      true,
 				ConflictsWith: []string{"vpc_cidr"},
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
@@ -219,6 +221,7 @@ func resourceAlkiraConnectorAwsVpc() *schema.Resource {
 					},
 				},
 				Optional: true,
+				Computed: true,
 			},
 			"scale_group_id": {
 				Description: "The ID of the scale group associated with the connector.",
@@ -229,6 +232,7 @@ func resourceAlkiraConnectorAwsVpc() *schema.Resource {
 				Description: "Overlay subnet.",
 				Type:        schema.TypeList,
 				Optional:    true,
+				Computed:    true,
 				Elem:        &schema.Schema{Type: schema.TypeString},
 			},
 			"description": {

--- a/alkira/resource_alkira_connector_aws_vpc_helper.go
+++ b/alkira/resource_alkira_connector_aws_vpc_helper.go
@@ -77,16 +77,15 @@ func setAwsVpcExportPrefixes(exportOptions interface{}, d *schema.ResourceData) 
 		}
 	}
 
-	// Only set non-empty fields to preserve config when field is not in config
+	// Only set non-empty export fields to preserve config when field is not in config
+	// overlay_subnets is always set (even if empty) because backend always returns it
 	if len(cidrList) > 0 {
 		d.Set("vpc_cidr", cidrList)
 	}
 	if len(subnetList) > 0 {
 		d.Set("vpc_subnet", subnetList)
 	}
-	if len(overlaySubnets) > 0 {
-		d.Set("overlay_subnets", overlaySubnets)
-	}
+	d.Set("overlay_subnets", overlaySubnets)
 }
 
 // setAwsVpcImportRouteTables sets vpc_route_table from ImportOptions

--- a/alkira/resource_alkira_connector_aws_vpc_helper.go
+++ b/alkira/resource_alkira_connector_aws_vpc_helper.go
@@ -39,7 +39,10 @@ func setAwsVpcRoutingOptions(connector *alkira.ConnectorAwsVpc, d *schema.Resour
 // setAwsVpcExportPrefixes sets export-related fields from ExportOptions
 func setAwsVpcExportPrefixes(exportOptions interface{}, d *schema.ResourceData) {
 	if exportOptions == nil {
-		log.Printf("[DEBUG] Export options is nil, skipping export prefixes")
+		log.Printf("[DEBUG] Export options is nil, clearing export prefixes")
+		d.Set("vpc_cidr", []interface{}{})
+		d.Set("vpc_subnet", []interface{}{})
+		d.Set("overlay_subnets", []interface{}{})
 		return
 	}
 
@@ -101,10 +104,6 @@ func setAwsVpcImportRouteTables(importOptions interface{}, d *schema.ResourceDat
 	var importOpts alkira.ImportOptions
 	if err := json.Unmarshal(importJSON, &importOpts); err != nil {
 		log.Printf("[ERROR] Failed to unmarshal ImportOptions: %v", err)
-		return
-	}
-
-	if len(importOpts.RouteTables) == 0 {
 		return
 	}
 

--- a/alkira/resource_alkira_connector_aws_vpc_helper.go
+++ b/alkira/resource_alkira_connector_aws_vpc_helper.go
@@ -77,14 +77,10 @@ func setAwsVpcExportPrefixes(exportOptions interface{}, d *schema.ResourceData) 
 		}
 	}
 
-	// Only set non-empty export fields to preserve config when field is not in config
-	// overlay_subnets is always set (even if empty) because backend always returns it
-	if len(cidrList) > 0 {
-		d.Set("vpc_cidr", cidrList)
-	}
-	if len(subnetList) > 0 {
-		d.Set("vpc_subnet", subnetList)
-	}
+	// Always set all export fields because they are Computed
+	// Backend returns userInputPrefixes with type entries; empty set if none specified
+	d.Set("vpc_cidr", cidrList)
+	d.Set("vpc_subnet", subnetList)
 	d.Set("overlay_subnets", overlaySubnets)
 }
 


### PR DESCRIPTION
## Summary

- Add `Computed: true` to `vpc_cidr`, `vpc_subnet`, `vpc_route_table`, and `overlay_subnets` to prevent drift when backend auto-populates default routing values
- Always set all routing fields in Read (export and import), even when empty, to keep state consistent with the `Optional + Computed` contract
- Clear export fields to `[]` when `exportOptions` is nil (defensive edge case)

## Problem

PR #539 (AK-65432) added `setAwsVpcRoutingOptions()` to the Read function so import/generate-config produces complete configs. This introduced two drift issues:

1. **Schema drift (original bug):** When users omit routing fields from their config, the backend auto-populates `vpcRouting` defaults (all VPC CIDRs + all route tables). Read writes these API-returned values to state, but without `Computed: true`, Terraform sees "state has values, config doesn't" — permanent drift on every plan.

2. **Empty-set drift (discovered during testing):** When a user specifies `vpc_subnet` instead of `vpc_cidr`, the backend returns only SUBNET entries in `userInputPrefixes` — no CIDR entries. The conditional logic `if len(cidrList) > 0 { d.Set("vpc_cidr", ...) }` skips setting `vpc_cidr`, leaving state with `null`. On the next plan, Terraform sees Computed field not set → `vpc_cidr = (known after apply)` drift. Same issue existed for `overlay_subnets` and `vpc_route_table`.

## Solution

### Schema Changes

Add `Computed: true` to four routing fields in `resourceAlkiraConnectorAwsVpc()`:
- `vpc_cidr` — VPC CIDR blocks for routing export
- `vpc_subnet` — Specific VPC subnets for routing export
- `vpc_route_table` — Route tables for routing import
- `overlay_subnets` — Overlay subnets for routing export

`Optional + Computed` tells Terraform: "the API may set these fields even if the user doesn't specify them," which eliminates drift caused by backend-populated defaults.

### Read Function Changes

1. **Always set export fields** — `setAwsVpcExportPrefixes()` now always calls `d.Set()` for all three export fields (`vpc_cidr`, `vpc_subnet`, `overlay_subnets`), even when the parsed lists are empty. Empty `[]` in state is stable for `Optional+Computed` fields.

2. **Clear fields on nil exportOptions** — When `exportOptions` is nil, explicitly set all three export fields to `[]` instead of returning early with no state changes.

3. **Always set import fields** — `setAwsVpcImportRouteTables()` no longer returns early when `RouteTables` is empty. `vpc_route_table` is always explicitly set, even as `[]`.

## Changes

- `alkira/resource_alkira_connector_aws_vpc.go` — Add `Computed: true` to `vpc_cidr`, `vpc_subnet`, `vpc_route_table`, `overlay_subnets`
- `alkira/resource_alkira_connector_aws_vpc_helper.go` — Always set all routing fields in Read, even when empty; clear export fields on nil exportOptions

## Testing Performed

### Greenfield CRUD — Minimal Config
- Create with only `vpc_cidr` specified (omit `vpc_route_table`, `overlay_subnets`, `tgw_attachment`) — Apply succeeds
- Plan after refresh shows "No changes" — backend auto-populated `vpc_route_table`, `Computed: true` prevents drift

### Greenfield CRUD — Full Config
- Create with all routing fields explicitly set — Apply succeeds
- Refresh — "No changes"; API PUT payload contains full `vpcRouting`
- Update description — Only description in diff, same resource ID

### Import — Minimal Config
- Import existing connector with minimal config — Import succeeds
- Plan shows "No changes" — Read populates `vpc_route_table` from API, `Computed: true` prevents drift

### vpc_subnet Instead of vpc_cidr
- Create with `vpc_subnet` blocks + explicit `vpc_route_table` — Apply succeeds
- Plan shows "No changes" — always-set logic stores `vpc_cidr = []` in state

### vpc_subnet Without vpc_route_table
- Create with `vpc_subnet` blocks only, no `vpc_route_table` — Apply succeeds
- State has `vpc_route_table = []` (unconditional set working)
- Plan shows "No changes"

### Empty overlay_subnets
- Backend returns empty `overlay_subnets` — state stores `[]`
- Plan shows "No changes"

### Mutation Tests
- M1: Explicit value matching state → "No changes"
- M2: Changed `vpc_cidr` value → diff detected correctly
- M3: Remove `vpc_route_table` from config → "No changes" (Computed defers to state)
- M4: Update description only → Only description in diff; API PUT preserves all routing fields

### Brownfield — Registry 1.4.4 → Fixed Build
- Create connector with registry provider 1.4.4
- Plan with fixed build shows "No changes" — upgrade is seamless
- After refresh: `overlay_subnets` transitions `null → []` — one-time, stable

### Import on Registry 1.4.4 → Upgrade (3 Config Shapes)
- **Shape A — Full config**: No changes after upgrade
- **Shape B — Minimal config**: No changes after upgrade
- **Shape C — No routing fields**: No changes after upgrade