### PR TITLE
fix: Add explicit depends_on for billing tags in acceptance tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ terraform.tfstate.*
 *.pem
 .env
 test/*
+.claude

--- a/acceptance/connector_ipsec.tf
+++ b/acceptance/connector_ipsec.tf
@@ -59,4 +59,8 @@ resource "alkira_connector_ipsec" "test" {
     preshared_keys      = ["1234", "1235"]
     billing_tag_ids     = [alkira_billing_tag.test1.id]
   }
+
+  # Billing tags cannot be deleted while referenced by connectors.
+  # Explicitly declare the dependency to ensure correct destroy ordering.
+  depends_on = [alkira_billing_tag.test1]
 }

--- a/acceptance/service_checkpoint.tf
+++ b/acceptance/service_checkpoint.tf
@@ -78,4 +78,7 @@ resource "alkira_service_checkpoint" "test2" {
     segment_id = alkira_segment.test1.id
     zone_name  = "DEFAULT"
   }
+
+  # Billing tags cannot be deleted while referenced by services.
+  depends_on = [alkira_billing_tag.test1]
 }


### PR DESCRIPTION
## Summary
- Add `depends_on = [alkira_billing_tag.test1]` to `alkira_connector_ipsec.test` and `alkira_service_checkpoint.test2` in acceptance tests
- Billing tags cannot be deleted while still referenced by connectors/services. The implicit dependency via `billing_tag_ids` inside nested `endpoint` blocks was not being enforced during `terraform destroy`, causing the destroy to fail with `cannot delete tag as it is in use`
- Add `.claude` to `.gitignore`

## Test plan
- [ ] Run acceptance tests and verify `terraform destroy` completes without billing tag deletion errors