### PR TITLE
[CLONE-63] AK-66454 - Add segment_ids validation for Bluecat service to prevent 500 error

### DIFF
--- a/alkira/resource_alkira_service_bluecat.go
+++ b/alkira/resource_alkira_service_bluecat.go
@@ -235,6 +235,7 @@ func resourceAlkiraBluecat() *schema.Resource {
 				Description: "IDs of segments associated with the service.",
 				Type:        schema.TypeSet,
 				Required:    true,
+				MinItems:    1,
 				Elem:        &schema.Schema{Type: schema.TypeString},
 			},
 			"service_group_name": {

--- a/alkira/resource_alkira_service_bluecat_test.go
+++ b/alkira/resource_alkira_service_bluecat_test.go
@@ -291,6 +291,7 @@ func TestAlkiraServiceBluecat_resourceSchema(t *testing.T) {
 	if segmentIdsSchema, exists := resource.Schema["segment_ids"]; exists {
 		assert.Equal(t, schema.TypeSet, segmentIdsSchema.Type, "Segment IDs should be set type")
 		assert.True(t, segmentIdsSchema.Required, "Segment IDs should be required")
+		assert.Equal(t, 1, segmentIdsSchema.MinItems, "Segment IDs should require at least 1 element")
 	}
 
 	if instanceSchema, exists := resource.Schema["instance"]; exists {
@@ -300,6 +301,18 @@ func TestAlkiraServiceBluecat_resourceSchema(t *testing.T) {
 
 	// Basic test - just verify the resource can be created
 	assert.True(t, true, "Bluecat resource schema test completed successfully")
+}
+
+func TestAlkiraServiceBluecat_segmentIdsMinItems(t *testing.T) {
+	resource := resourceAlkiraBluecat()
+
+	segmentIdsSchema, exists := resource.Schema["segment_ids"]
+	require.True(t, exists, "segment_ids schema field must exist")
+
+	// MinItems: 1 ensures Terraform rejects empty segment_ids at plan
+	// time rather than sending null to the API (which returns HTTP 500).
+	assert.Equal(t, 1, segmentIdsSchema.MinItems,
+		"segment_ids must enforce MinItems=1; the backend requires at least 1 segment")
 }
 
 func TestAlkiraServiceBluecat_validateLicenseType(t *testing.T) {


### PR DESCRIPTION
Cherry-pick of PR #576 for REL 63 release.

**Original Issue:** AK-65889
**Clone for REL 63:** AK-66454

## Summary

- Add `MinItems: 1` validation to `segment_ids` schema field in Bluecat service
- Backend requires at least 1 segment (`@SoftLimit(min = 1, max = 1)`)
- Previously, empty `segment_ids` sent `null` for segments to the API, causing HTTP 500 after ~5 minutes of retries
- Now Terraform rejects empty `segment_ids` at plan time with a clear validation error

## Changes

- Add `MinItems: 1` to `segment_ids` schema definition
- Add unit tests verifying the MinItems constraint

## Original PR
#576

## Cherry-picked Commit(s)
- 2e898451320ef48c2169820a1d57bc1ca52ae1d8