### PR TITLE
[CLONE-63] AK-66651 - Fix export_all_subnets regression when vpc_subnet blocks removed

### DIFF
--- a/alkira/resource_alkira_connector_gcp_vpc.go
+++ b/alkira/resource_alkira_connector_gcp_vpc.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/alkiranet/alkira-client-go/alkira"
+	"github.com/hashicorp/go-cty/cty"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -33,13 +34,30 @@ func resourceAlkiraConnectorGcpVpc() *schema.Resource {
 				routing := gcpRouting.([]interface{})
 				if len(routing) > 0 {
 					routingCfg := routing[0].(map[string]interface{})
-					if exportAll, ok := routingCfg["export_all_subnets"].(bool); ok && exportAll {
-						if vpcSubnets, ok := d.GetOk("vpc_subnet"); ok {
-							if vpcSubnets.(*schema.Set).Len() > 0 {
-								return fmt.Errorf("vpc_subnet cannot be specified when export_all_subnets is true. " +
-									"When exporting all subnets, specific vpc_subnet entries should not be provided")
-							}
-						}
+					exportAll, _ := routingCfg["export_all_subnets"].(bool)
+
+					hasVpcSubnets := d.Get("vpc_subnet").(*schema.Set).Len() > 0
+
+					// Detect if export_all_subnets was explicitly written in config
+					// (as opposed to being computed from state)
+					exportAllExplicitlySet := false
+					rawConfig := d.GetRawConfig()
+					gcpRoutingRaw := rawConfig.GetAttr("gcp_routing")
+					if !gcpRoutingRaw.IsNull() && gcpRoutingRaw.IsKnown() && gcpRoutingRaw.LengthInt() > 0 {
+						exportAllRaw := gcpRoutingRaw.Index(cty.NumberIntVal(0)).GetAttr("export_all_subnets")
+						exportAllExplicitlySet = !exportAllRaw.IsNull()
+					}
+
+					// export_all_subnets=true WITH vpc_subnet entries is invalid
+					if exportAll && hasVpcSubnets {
+						return fmt.Errorf("vpc_subnet cannot be specified when export_all_subnets is true. " +
+							"When exporting all subnets, specific vpc_subnet entries should not be provided")
+					}
+
+					// export_all_subnets=false explicitly WITHOUT vpc_subnet entries is invalid
+					if exportAllExplicitlySet && !exportAll && !hasVpcSubnets {
+						return fmt.Errorf("vpc_subnet must be specified when export_all_subnets is false. " +
+							"Either set export_all_subnets to true or provide vpc_subnet entries")
 					}
 				}
 			}

--- a/alkira/resource_alkira_connector_gcp_vpc.go
+++ b/alkira/resource_alkira_connector_gcp_vpc.go
@@ -34,7 +34,7 @@ func resourceAlkiraConnectorGcpVpc() *schema.Resource {
 				routing := gcpRouting.([]interface{})
 				if len(routing) > 0 {
 					routingCfg := routing[0].(map[string]interface{})
-					exportAll, _ := routingCfg["export_all_subnets"].(bool)
+					exportAll, ok := routingCfg["export_all_subnets"].(bool)
 
 					hasVpcSubnets := d.Get("vpc_subnet").(*schema.Set).Len() > 0
 
@@ -49,13 +49,13 @@ func resourceAlkiraConnectorGcpVpc() *schema.Resource {
 					}
 
 					// export_all_subnets=true WITH vpc_subnet entries is invalid
-					if exportAll && hasVpcSubnets {
+					if ok && exportAll && hasVpcSubnets {
 						return fmt.Errorf("vpc_subnet cannot be specified when export_all_subnets is true. " +
 							"When exporting all subnets, specific vpc_subnet entries should not be provided")
 					}
 
 					// export_all_subnets=false explicitly WITHOUT vpc_subnet entries is invalid
-					if exportAllExplicitlySet && !exportAll && !hasVpcSubnets {
+					if ok && exportAllExplicitlySet && !exportAll && !hasVpcSubnets {
 						return fmt.Errorf("vpc_subnet must be specified when export_all_subnets is false. " +
 							"Either set export_all_subnets to true or provide vpc_subnet entries")
 					}

--- a/alkira/resource_alkira_connector_gcp_vpc.go
+++ b/alkira/resource_alkira_connector_gcp_vpc.go
@@ -36,7 +36,10 @@ func resourceAlkiraConnectorGcpVpc() *schema.Resource {
 					routingCfg := routing[0].(map[string]interface{})
 					exportAll, ok := routingCfg["export_all_subnets"].(bool)
 
-					hasVpcSubnets := d.Get("vpc_subnet").(*schema.Set).Len() > 0
+					var hasVpcSubnets bool
+					if v, ok := d.GetOk("vpc_subnet"); ok {
+						hasVpcSubnets = v.(*schema.Set).Len() > 0
+					}
 
 					// Detect if export_all_subnets was explicitly written in config
 					// (as opposed to being computed from state)

--- a/alkira/resource_alkira_connector_gcp_vpc.go
+++ b/alkira/resource_alkira_connector_gcp_vpc.go
@@ -29,43 +29,7 @@ func resourceAlkiraConnectorGcpVpc() *schema.Resource {
 				d.SetNew("provision_state", "SUCCESS")
 			}
 
-			// Validate export_all_subnets and vpc_subnet mutual exclusion
-			if gcpRouting, ok := d.GetOk("gcp_routing"); ok {
-				routing := gcpRouting.([]interface{})
-				if len(routing) > 0 {
-					routingCfg := routing[0].(map[string]interface{})
-					exportAll, ok := routingCfg["export_all_subnets"].(bool)
-
-					var hasVpcSubnets bool
-					if v, ok := d.GetOk("vpc_subnet"); ok {
-						hasVpcSubnets = v.(*schema.Set).Len() > 0
-					}
-
-					// Detect if export_all_subnets was explicitly written in config
-					// (as opposed to being computed from state)
-					exportAllExplicitlySet := false
-					rawConfig := d.GetRawConfig()
-					gcpRoutingRaw := rawConfig.GetAttr("gcp_routing")
-					if !gcpRoutingRaw.IsNull() && gcpRoutingRaw.IsKnown() && gcpRoutingRaw.LengthInt() > 0 {
-						exportAllRaw := gcpRoutingRaw.Index(cty.NumberIntVal(0)).GetAttr("export_all_subnets")
-						exportAllExplicitlySet = !exportAllRaw.IsNull()
-					}
-
-					// export_all_subnets=true WITH vpc_subnet entries is invalid
-					if ok && exportAll && hasVpcSubnets {
-						return fmt.Errorf("vpc_subnet cannot be specified when export_all_subnets is true. " +
-							"When exporting all subnets, specific vpc_subnet entries should not be provided")
-					}
-
-					// export_all_subnets=false explicitly WITHOUT vpc_subnet entries is invalid
-					if ok && exportAllExplicitlySet && !exportAll && !hasVpcSubnets {
-						return fmt.Errorf("vpc_subnet must be specified when export_all_subnets is false. " +
-							"Either set export_all_subnets to true or provide vpc_subnet entries")
-					}
-				}
-			}
-
-			return nil
+			return validateExportAllSubnets(d)
 		},
 		Importer: &schema.ResourceImporter{
 			StateContext: importWithReadValidation(resourceConnectorGcpVpcRead),
@@ -450,6 +414,58 @@ func resourceConnectorGcpVpcDelete(ctx context.Context, d *schema.ResourceData, 
 			Summary:  "PROVISION (DELETE) FAILED",
 			Detail:   fmt.Sprintf("%s", provErr),
 		}}
+	}
+
+	return nil
+}
+
+// validateExportAllSubnets checks that export_all_subnets and vpc_subnet
+// are not contradictory when the user explicitly set export_all_subnets.
+// Values carried from state (computed) are allowed through —
+// expandGcpRouting() auto-corrects them during Create/Update.
+func validateExportAllSubnets(d *schema.ResourceDiff) error {
+	gcpRouting, ok := d.GetOk("gcp_routing")
+	if !ok {
+		return nil
+	}
+
+	routing := gcpRouting.([]interface{})
+	if len(routing) == 0 {
+		return nil
+	}
+
+	routingCfg := routing[0].(map[string]interface{})
+	exportAll, ok := routingCfg["export_all_subnets"].(bool)
+	if !ok {
+		return nil
+	}
+
+	// Check if the user explicitly wrote export_all_subnets in their HCL
+	// (vs. value carried from state). Only explicit writes trigger validation.
+	rawConfig := d.GetRawConfig()
+	gcpRoutingRaw := rawConfig.GetAttr("gcp_routing")
+	if gcpRoutingRaw.IsNull() || !gcpRoutingRaw.IsKnown() || gcpRoutingRaw.LengthInt() == 0 {
+		return nil
+	}
+
+	exportAllRaw := gcpRoutingRaw.Index(cty.NumberIntVal(0)).GetAttr("export_all_subnets")
+	if exportAllRaw.IsNull() {
+		return nil
+	}
+
+	var hasVpcSubnets bool
+	if v, ok := d.GetOk("vpc_subnet"); ok {
+		hasVpcSubnets = v.(*schema.Set).Len() > 0
+	}
+
+	if exportAll && hasVpcSubnets {
+		return fmt.Errorf("vpc_subnet cannot be specified when export_all_subnets is true. " +
+			"When exporting all subnets, specific vpc_subnet entries should not be provided")
+	}
+
+	if !exportAll && !hasVpcSubnets {
+		return fmt.Errorf("vpc_subnet must be specified when export_all_subnets is false. " +
+			"Either set export_all_subnets to true or provide vpc_subnet entries")
 	}
 
 	return nil

--- a/alkira/resource_alkira_connector_gcp_vpc_helper.go
+++ b/alkira/resource_alkira_connector_gcp_vpc_helper.go
@@ -5,7 +5,6 @@ import (
 	"log"
 
 	"github.com/alkiranet/alkira-client-go/alkira"
-	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
@@ -30,10 +29,6 @@ func expandGcpRouting(in []interface{}, subnets *schema.Set) (*alkira.ConnectorG
 			if v, ok := cfg["custom_prefix"].(string); ok {
 				importOptions.RouteImportMode = v
 			}
-
-			if v, ok := cfg["export_all_subnets"].(bool); ok {
-				exportOptions.ExportAllSubnets = v
-			}
 		}
 	}
 
@@ -48,8 +43,10 @@ func expandGcpRouting(in []interface{}, subnets *schema.Set) (*alkira.ConnectorG
 	// Subnet entries and exportAllSubnets are mutually exclusive.
 	// Subnets present → exportAllSubnets must be false.
 	// No subnets → exportAllSubnets must be true.
-	// This handles both Create and Update (RCA: state carried false into Update
-	// after vpc_subnet blocks were removed, causing API 400).
+	// Enforced bidirectionally: if subnets are present exportAllSubnets must be
+	// false; if absent it must be true. Without the else branch, a stale state
+	// value of false is sent to the API when vpc_subnet blocks are removed,
+	// causing a 400 error.
 	if len(prefixes) > 0 {
 		exportOptions.ExportAllSubnets = false
 	} else {
@@ -153,25 +150,6 @@ func generateConnectorGcpVpcRequest(d *schema.ResourceData, m interface{}) (*alk
 	if err != nil {
 		log.Printf("[ERROR] failed to convert gcp routing")
 		return nil, err
-	}
-
-	// For Optional+Computed booleans, the SDK cannot distinguish between
-	// "user explicitly set false" and "user didn't set it" in the config
-	// map (both appear as false). Use GetRawConfig to check if the user
-	// actually wrote export_all_subnets in their HCL. If they didn't,
-	// default to true (export all subnets).
-	// This only applies during Create (d.Id() is empty). During Update,
-	// the plan already includes the correct state value for unset
-	// Computed fields, so overriding would silently change the value.
-	if d.Id() == "" {
-		rawConfig := d.GetRawConfig()
-		gcpRoutingRaw := rawConfig.GetAttr("gcp_routing")
-		if !gcpRoutingRaw.IsNull() && gcpRoutingRaw.IsKnown() && gcpRoutingRaw.LengthInt() > 0 {
-			exportAll := gcpRoutingRaw.Index(cty.NumberIntVal(0)).GetAttr("export_all_subnets")
-			if exportAll.IsNull() && len(gcpRouting.ExportOptions.Prefixes) == 0 {
-				gcpRouting.ExportOptions.ExportAllSubnets = true
-			}
-		}
 	}
 
 	//

--- a/alkira/resource_alkira_connector_gcp_vpc_helper.go
+++ b/alkira/resource_alkira_connector_gcp_vpc_helper.go
@@ -46,9 +46,14 @@ func expandGcpRouting(in []interface{}, subnets *schema.Set) (*alkira.ConnectorG
 	exportOptions.Prefixes = prefixes
 
 	// Subnet entries and exportAllSubnets are mutually exclusive.
-	// If specific subnets are provided, exportAllSubnets must be false.
+	// Subnets present → exportAllSubnets must be false.
+	// No subnets → exportAllSubnets must be true.
+	// This handles both Create and Update (RCA: state carried false into Update
+	// after vpc_subnet blocks were removed, causing API 400).
 	if len(prefixes) > 0 {
 		exportOptions.ExportAllSubnets = false
+	} else {
+		exportOptions.ExportAllSubnets = true
 	}
 
 	gcp := &alkira.ConnectorGcpVpcRouting{

--- a/alkira/resource_alkira_connector_gcp_vpc_helper_test.go
+++ b/alkira/resource_alkira_connector_gcp_vpc_helper_test.go
@@ -731,6 +731,31 @@ func TestExpandGcpRouting(t *testing.T) {
 			),
 			expectError: true,
 		},
+		{
+			// Regression test for AK-66113: When vpc_subnet blocks are removed from config,
+			// export_all_subnets=false is carried from state, but expandGcpRouting must
+			// force ExportAllSubnets=true when subnets are empty (else branch).
+			name: "regression: export_all_subnets=false with empty subnets — must force true",
+			gcpRouting: []interface{}{
+				map[string]interface{}{
+					"custom_prefix":      "ADVERTISE_DEFAULT_ROUTE",
+					"prefix_list_ids":    schema.NewSet(schema.HashInt, []interface{}{}),
+					"export_all_subnets": false, // Carried from state after vpc_subnet removal
+				},
+			},
+			subnets:     nil, // No subnets
+			expectError: false,
+			expected: &alkira.ConnectorGcpVpcRouting{
+				ExportOptions: alkira.ConnectorGcpVpcExportOptions{
+					ExportAllSubnets: true, // Forced to true by else branch
+					Prefixes:         []alkira.UserInputPrefixes{},
+				},
+				ImportOptions: alkira.ConnectorGcpVpcImportOptions{
+					RouteImportMode: "ADVERTISE_DEFAULT_ROUTE",
+					PrefixListIds:   nil,
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -1048,6 +1073,14 @@ func validateExportAllSubnetsWithVpcSubnet(d *schema.ResourceData, client *alkir
 	routingCfg := routing[0].(map[string]interface{})
 	exportAll, exportAllOk := routingCfg["export_all_subnets"].(bool)
 
+	// NOTE: The test helper cannot replicate CustomizeDiff's GetRawConfig() + IsNull()
+	// semantics for distinguishing "user explicitly wrote false" from "computed/state carried false".
+	// For a TypeBool Optional+Computed field, schema.ResourceData.Get() always returns a typed
+	// false (never nil), so exportAllOk is true whenever gcp_routing is present, regardless of
+	// whether the user actually wrote export_all_subnets in their HCL. The production CustomizeDiff
+	// correctly uses GetRawConfig() to detect explicit writes. This limitation means Case 2 below
+	// may fire in unit tests for configs where production CustomizeDiff would correctly stay silent.
+	// Full coverage of Case 2 requires acceptance tests with real ResourceDiff behavior.
 	exportAllExplicitlySet := exportAllOk
 
 	vpcSubnets := d.Get("vpc_subnet")

--- a/alkira/resource_alkira_connector_gcp_vpc_helper_test.go
+++ b/alkira/resource_alkira_connector_gcp_vpc_helper_test.go
@@ -612,7 +612,7 @@ func TestExpandGcpRouting(t *testing.T) {
 		{
 			// no gcp_routing block at all, but vpc_subnet present.
 			// exportAllSubnets must be false when subnets are provided.
-			name: "no gcp_routing block with vpc_subnet present — must force false",
+			name:       "no gcp_routing block with vpc_subnet present — must force false",
 			gcpRouting: nil,
 			subnets: schema.NewSet(
 				func(i interface{}) int {
@@ -893,7 +893,7 @@ func TestGcpVpcValidateExportAllSubnetsWithVpcSubnet(t *testing.T) {
 			expectError: false,
 		},
 		{
-			name: "export_all_subnets=false without vpc_subnet - valid (TPS will error)",
+			name: "export_all_subnets=false without vpc_subnet - invalid (validation error)",
 			config: map[string]interface{}{
 				"name":          "test-connector",
 				"cxp":           "us-west1",
@@ -910,7 +910,8 @@ func TestGcpVpcValidateExportAllSubnetsWithVpcSubnet(t *testing.T) {
 					},
 				},
 			},
-			expectError: false,
+			expectError:   true,
+			errorContains: "vpc_subnet must be specified when export_all_subnets is false",
 		},
 		{
 			name: "no gcp_routing with vpc_subnet - valid",
@@ -1045,25 +1046,30 @@ func validateExportAllSubnetsWithVpcSubnet(d *schema.ResourceData, client *alkir
 	}
 
 	routingCfg := routing[0].(map[string]interface{})
-	exportAll, ok := routingCfg["export_all_subnets"].(bool)
-	if !ok || !exportAll {
-		return nil
-	}
+	exportAll, exportAllOk := routingCfg["export_all_subnets"].(bool)
 
-	// If export_all_subnets is true, vpc_subnet must be empty
+	exportAllExplicitlySet := exportAllOk
+
 	vpcSubnets := d.Get("vpc_subnet")
-	if vpcSubnets == nil {
-		return nil
+	var vpcSubnetSet *schema.Set
+	if vpcSubnets != nil {
+		set, ok := vpcSubnets.(*schema.Set)
+		if ok {
+			vpcSubnetSet = set
+		}
 	}
+	hasVpcSubnets := vpcSubnetSet != nil && vpcSubnetSet.Len() > 0
 
-	vpcSubnetSet, ok := vpcSubnets.(*schema.Set)
-	if !ok {
-		return nil
-	}
-
-	if vpcSubnetSet.Len() > 0 {
+	// Case 1: export_all_subnets=true WITH vpc_subnet entries → error
+	if exportAll && hasVpcSubnets {
 		return fmt.Errorf("vpc_subnet cannot be specified when export_all_subnets is true. " +
 			"When exporting all subnets, specific vpc_subnet entries should not be provided")
+	}
+
+	// Case 2: export_all_subnets=false WITHOUT vpc_subnet entries → error if explicitly set
+	if exportAllOk && !exportAll && !hasVpcSubnets && exportAllExplicitlySet {
+		return fmt.Errorf("vpc_subnet must be specified when export_all_subnets is false. " +
+			"Either set export_all_subnets to true or provide vpc_subnet entries")
 	}
 
 	return nil

--- a/alkira/resource_alkira_connector_gcp_vpc_helper_test.go
+++ b/alkira/resource_alkira_connector_gcp_vpc_helper_test.go
@@ -835,6 +835,10 @@ func TestGcpVpcDataStructures(t *testing.T) {
 	})
 }
 
+// TestGcpVpcValidateExportAllSubnetsWithVpcSubnet tests the explicit-write
+// validation cases. State-transition cases (where export_all_subnets is
+// carried from state, not explicitly written) are covered by live tests
+// because unit tests cannot distinguish explicit writes from state values.
 func TestGcpVpcValidateExportAllSubnetsWithVpcSubnet(t *testing.T) {
 	resource := resourceAlkiraConnectorGcpVpc()
 
@@ -984,6 +988,19 @@ func TestGcpVpcValidateExportAllSubnetsWithVpcSubnet(t *testing.T) {
 			expectError: false,
 		},
 		{
+			name: "no gcp_routing and no vpc_subnet - valid",
+			config: map[string]interface{}{
+				"name":          "test-connector",
+				"cxp":           "us-west1",
+				"segment_id":    "1",
+				"size":          "SMALL",
+				"gcp_region":    "us-central1",
+				"gcp_vpc_name":  "test-vpc",
+				"credential_id": "cred-123",
+			},
+			expectError: false,
+		},
+		{
 			name: "export_all_subnets=true with multiple vpc_subnets - invalid",
 			config: map[string]interface{}{
 				"name":          "test-connector",
@@ -1053,13 +1070,10 @@ func TestGcpVpcValidateExportAllSubnetsWithVpcSubnet(t *testing.T) {
 	}
 }
 
-// validateExportAllSubnetsWithVpcSubnet extracts the validation logic
-// for testability. This mirrors the logic in CustomizeDiff.
-func validateExportAllSubnetsWithVpcSubnet(d *schema.ResourceData, client *alkira.AlkiraClient) error {
-	// This function contains the same logic as CustomizeDiff
-	// for validation of export_all_subnets and vpc_subnet mutual exclusion
-
-	// Get gcp_routing config
+// validateExportAllSubnetsWithVpcSubnet mirrors the validation logic in
+// validateExportAllSubnets (CustomizeDiff). Unit tests treat all values as
+// explicitly set; state-transition cases require live/acceptance tests.
+func validateExportAllSubnetsWithVpcSubnet(d *schema.ResourceData, _ *alkira.AlkiraClient) error {
 	gcpRouting := d.Get("gcp_routing")
 	if gcpRouting == nil {
 		return nil
@@ -1071,36 +1085,22 @@ func validateExportAllSubnetsWithVpcSubnet(d *schema.ResourceData, client *alkir
 	}
 
 	routingCfg := routing[0].(map[string]interface{})
-	exportAll, exportAllOk := routingCfg["export_all_subnets"].(bool)
-
-	// NOTE: The test helper cannot replicate CustomizeDiff's GetRawConfig() + IsNull()
-	// semantics for distinguishing "user explicitly wrote false" from "computed/state carried false".
-	// For a TypeBool Optional+Computed field, schema.ResourceData.Get() always returns a typed
-	// false (never nil), so exportAllOk is true whenever gcp_routing is present, regardless of
-	// whether the user actually wrote export_all_subnets in their HCL. The production CustomizeDiff
-	// correctly uses GetRawConfig() to detect explicit writes. This limitation means Case 2 below
-	// may fire in unit tests for configs where production CustomizeDiff would correctly stay silent.
-	// Full coverage of Case 2 requires acceptance tests with real ResourceDiff behavior.
-	exportAllExplicitlySet := exportAllOk
-
-	vpcSubnets := d.Get("vpc_subnet")
-	var vpcSubnetSet *schema.Set
-	if vpcSubnets != nil {
-		set, ok := vpcSubnets.(*schema.Set)
-		if ok {
-			vpcSubnetSet = set
-		}
+	exportAll, ok := routingCfg["export_all_subnets"].(bool)
+	if !ok {
+		return nil
 	}
-	hasVpcSubnets := vpcSubnetSet != nil && vpcSubnetSet.Len() > 0
 
-	// Case 1: export_all_subnets=true WITH vpc_subnet entries → error
+	var hasVpcSubnets bool
+	if v, ok := d.Get("vpc_subnet").(*schema.Set); ok && v != nil {
+		hasVpcSubnets = v.Len() > 0
+	}
+
 	if exportAll && hasVpcSubnets {
 		return fmt.Errorf("vpc_subnet cannot be specified when export_all_subnets is true. " +
 			"When exporting all subnets, specific vpc_subnet entries should not be provided")
 	}
 
-	// Case 2: export_all_subnets=false WITHOUT vpc_subnet entries → error if explicitly set
-	if exportAllOk && !exportAll && !hasVpcSubnets && exportAllExplicitlySet {
+	if !exportAll && !hasVpcSubnets {
 		return fmt.Errorf("vpc_subnet must be specified when export_all_subnets is false. " +
 			"Either set export_all_subnets to true or provide vpc_subnet entries")
 	}


### PR DESCRIPTION
Cherry-pick of PR #580 for REL 63 release.

**Original Issue:** AK-66113
**Clone for REL 63:** AK-66651

## Summary

- Fix regression where removing all `vpc_subnet` blocks from a GCP VPC connector config caused a 400 API error
- Add bidirectional enforcement in `expandGcpRouting`: subnets absent now forces `exportAllSubnets=true` (the missing direction)
- Add `CustomizeDiff` validation for explicit `export_all_subnets=false` without `vpc_subnet` entries
- Update unit tests to reflect the corrected validation behavior

## Problem

When a GCP VPC connector was created with `vpc_subnet` blocks, `export_all_subnets` was saved as `false` in state. When the user later removed all `vpc_subnet` blocks from config (without explicitly setting `export_all_subnets=true`), the provider sent:

```
{exportAllSubnets: false, userInputPrefixes: []}
```

The API rejected this with:
```
400: userInputPrefixes cannot be empty when exportAllSubnets is FALSE
```

The existing code only handled one direction of the mutual exclusion:
- ✅ `vpc_subnet` present → force `ExportAllSubnets=false`
- ❌ `vpc_subnet` absent → force `ExportAllSubnets=true` (was missing)

## Solution

**`resource_alkira_connector_gcp_vpc_helper.go`** — Fix `expandGcpRouting` to enforce both directions unconditionally:

```go
if len(prefixes) > 0 {
    exportOptions.ExportAllSubnets = false  // subnets present → false
} else {
    exportOptions.ExportAllSubnets = true   // subnets absent  → true (the fix)
}
```

**`resource_alkira_connector_gcp_vpc.go`** — Extend `CustomizeDiff` to catch the invalid case of explicit `export_all_subnets=false` without `vpc_subnet` at plan time. Uses `GetRawConfig` to distinguish "user explicitly set false" from "computed from state".

## Changes

- `alkira/resource_alkira_connector_gcp_vpc.go` — Add `cty` import; extend `CustomizeDiff` to validate explicit `false` without subnets; use `GetRawConfig` to detect user-set vs computed value
- `alkira/resource_alkira_connector_gcp_vpc_helper.go` — Add `else` branch to force `ExportAllSubnets=true` when no subnets
- `alkira/resource_alkira_connector_gcp_vpc_helper_test.go` — Update test expectation for `export_all_subnets=false` without `vpc_subnet` to expect validation error

## Testing Performed

All unit tests pass for GCP VPC connector functionality.

## Original PR
#580

## Cherry-picked Commit(s)
- 4a1989e5 AK-66113: Fix export_all_subnets regression when vpc_subnet blocks removed
- cf76c111 AK-66113: Fix export_all_subnets regression when vpc_subnet blocks removed
- 4c1c72ba fix: Use safer d.GetOk pattern for vpc_subnet nil check