### PR TITLE
[CLONE-63] AK-66691 - Fix deprecated prefixes field in policy_prefix_list

### DIFF
--- a/alkira/resource_alkira_policy_prefix_list.go
+++ b/alkira/resource_alkira_policy_prefix_list.go
@@ -106,7 +106,6 @@ func resourceAlkiraPolicyPrefixList() *schema.Resource {
 					"**Deprecated:** Use `prefix` block instead.",
 				Type:          schema.TypeSet,
 				Optional:      true,
-				Computed:      true,
 				Deprecated:    "Use the 'prefix' block instead",
 				Elem:          &schema.Schema{Type: schema.TypeString},
 				ConflictsWith: []string{"prefix"},
@@ -246,19 +245,37 @@ func resourcePolicyPrefixListRead(ctx context.Context, d *schema.ResourceData, m
 	d.Set("name", list.Name)
 	d.Set("description", list.Description)
 
-	// Set deprecated "prefixes" field for backward compatibility
-	if list.Prefixes != nil && len(list.Prefixes) > 0 {
-		prefixes := make([]interface{}, len(list.Prefixes))
-		for i, p := range list.Prefixes {
-			prefixes[i] = p
+	// Deprecated: populate "prefixes" when user's config uses the old field.
+	// Remove this block when "prefixes" is removed from schema.
+	usingDeprecatedField := false
+	rawConfig := d.GetRawConfig()
+	if rawConfig.IsKnown() && !rawConfig.IsNull() {
+		rawPrefixes := rawConfig.GetAttr("prefixes")
+		if !rawPrefixes.IsNull() && rawPrefixes.IsKnown() && rawPrefixes.LengthInt() > 0 {
+			usingDeprecatedField = true
 		}
-		d.Set("prefixes", schema.NewSet(schema.HashString, prefixes))
+	} else {
+		// Import/refresh — no raw config available, fall back to state
+		if v, ok := d.GetOk("prefixes"); ok && v.(*schema.Set).Len() > 0 {
+			usingDeprecatedField = true
+		}
 	}
 
-	// Set "prefix" block
-	setPrefix(d, list.Prefixes, list.PrefixDetails)
+	if usingDeprecatedField {
+		if len(list.Prefixes) > 0 {
+			prefixes := make([]interface{}, len(list.Prefixes))
+			for i, p := range list.Prefixes {
+				prefixes[i] = p
+			}
+			d.Set("prefixes", schema.NewSet(schema.HashString, prefixes))
+		} else {
+			d.Set("prefixes", schema.NewSet(schema.HashString, nil))
+		}
+		d.Set("prefix", schema.NewSet(prefixHash, nil))
+	} else {
+		setPrefix(d, list.Prefixes, list.PrefixDetails)
+	}
 
-	// Set "prefix_ranges" block
 	setPrefixRanges(d, list.PrefixRanges)
 
 	// Set provision state

--- a/alkira/resource_alkira_policy_prefix_list.go
+++ b/alkira/resource_alkira_policy_prefix_list.go
@@ -102,10 +102,14 @@ func resourceAlkiraPolicyPrefixList() *schema.Resource {
 				Computed:    true,
 			},
 			"prefixes": {
-				Description: "A list of prefixes. (**DEPRECATED**)",
-				Type:        schema.TypeSet,
-				Optional:    true,
-				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: "A list of prefixes. " +
+					"**Deprecated:** Use `prefix` block instead.",
+				Type:          schema.TypeSet,
+				Optional:      true,
+				Computed:      true,
+				Deprecated:    "Use the 'prefix' block instead",
+				Elem:          &schema.Schema{Type: schema.TypeString},
+				ConflictsWith: []string{"prefix"},
 			},
 			"prefix": {
 				Description: "Prefix with description. This new block should " +
@@ -241,6 +245,15 @@ func resourcePolicyPrefixListRead(ctx context.Context, d *schema.ResourceData, m
 
 	d.Set("name", list.Name)
 	d.Set("description", list.Description)
+
+	// Set deprecated "prefixes" field for backward compatibility
+	if list.Prefixes != nil && len(list.Prefixes) > 0 {
+		prefixes := make([]interface{}, len(list.Prefixes))
+		for i, p := range list.Prefixes {
+			prefixes[i] = p
+		}
+		d.Set("prefixes", schema.NewSet(schema.HashString, prefixes))
+	}
 
 	// Set "prefix" block
 	setPrefix(d, list.Prefixes, list.PrefixDetails)

--- a/alkira/resource_alkira_policy_prefix_list_helper.go
+++ b/alkira/resource_alkira_policy_prefix_list_helper.go
@@ -125,7 +125,12 @@ func generatePolicyPrefixListRequest(d *schema.ResourceData) (*alkira.PolicyPref
 		return nil, err
 	}
 
-	if d.Get("prefixes").(*schema.Set).Len() > 0 {
+	// Check if the user explicitly set "prefixes" in their config (not
+	// just computed from state by Read). GetRawConfig returns the raw
+	// config value which is null for fields not explicitly set.
+	rawConfig := d.GetRawConfig()
+	rawPrefixes := rawConfig.GetAttr("prefixes")
+	if !rawPrefixes.IsNull() && rawPrefixes.IsKnown() && rawPrefixes.LengthInt() > 0 {
 		return nil, fmt.Errorf("ERROR: Please use the new 'prefix' block to replace the old 'prefixes' field")
 	}
 

--- a/alkira/resource_alkira_policy_prefix_list_helper.go
+++ b/alkira/resource_alkira_policy_prefix_list_helper.go
@@ -1,7 +1,6 @@
 package alkira
 
 import (
-	"fmt"
 	"log"
 
 	"github.com/alkiranet/alkira-client-go/alkira"
@@ -125,16 +124,27 @@ func generatePolicyPrefixListRequest(d *schema.ResourceData) (*alkira.PolicyPref
 		return nil, err
 	}
 
-	// Check if the user explicitly set "prefixes" in their config (not
-	// just computed from state by Read). GetRawConfig returns the raw
-	// config value which is null for fields not explicitly set.
+	// Deprecated: accept "prefixes" from config for backward compat.
+	// Remove this block when "prefixes" is removed from schema.
+	var prefixes []string
+	var prefixDetailsMap map[string]*alkira.PolicyPrefixListDetails
+
+	usingDeprecated := false
 	rawConfig := d.GetRawConfig()
-	rawPrefixes := rawConfig.GetAttr("prefixes")
-	if !rawPrefixes.IsNull() && rawPrefixes.IsKnown() && rawPrefixes.LengthInt() > 0 {
-		return nil, fmt.Errorf("ERROR: Please use the new 'prefix' block to replace the old 'prefixes' field")
+	if rawConfig.IsKnown() && !rawConfig.IsNull() {
+		rawPrefixes := rawConfig.GetAttr("prefixes")
+		if !rawPrefixes.IsNull() && rawPrefixes.IsKnown() && rawPrefixes.LengthInt() > 0 {
+			usingDeprecated = true
+		}
+	} else if v, ok := d.GetOk("prefixes"); ok && v.(*schema.Set).Len() > 0 {
+		usingDeprecated = true
 	}
 
-	prefixes, prefixDetailsMap := expandPrefixListPrefixes(d)
+	if usingDeprecated {
+		prefixes = convertTypeSetToStringList(d.Get("prefixes").(*schema.Set))
+	} else {
+		prefixes, prefixDetailsMap = expandPrefixListPrefixes(d)
+	}
 
 	list := &alkira.PolicyPrefixList{
 		Description:   d.Get("description").(string),

--- a/alkira/resource_alkira_policy_prefix_list_helper_test.go
+++ b/alkira/resource_alkira_policy_prefix_list_helper_test.go
@@ -504,19 +504,27 @@ func TestSetPrefixRanges(t *testing.T) {
 	}
 }
 
-func TestResourcePolicyPrefixListRead_SetsDeprecatedPrefixes(t *testing.T) {
-	// Create a mock ResourceData with both "prefix" and "prefixes" fields
+func TestReadFieldSelection_FallbackToState(t *testing.T) {
+	// Tests the import/refresh fallback path where GetRawConfig is not
+	// available. In this case Read falls back to GetOk("prefixes") to
+	// determine which field to populate.
+	//
+	// NOTE: The GetRawConfig path (plan/apply) cannot be unit tested
+	// because TestResourceData does not support raw config. Those paths
+	// are covered by live tests (see test/AK-66046-retest/).
 	r := &schema.Resource{
 		Schema: map[string]*schema.Schema{
 			"name":        {Type: schema.TypeString},
 			"description": {Type: schema.TypeString},
 			"prefixes": {
-				Type: schema.TypeSet,
-				Elem: &schema.Schema{Type: schema.TypeString},
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 			"prefix": {
-				Type: schema.TypeSet,
-				Set:  prefixHash,
+				Type:     schema.TypeSet,
+				Optional: true,
+				Set:      prefixHash,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"cidr":        {Type: schema.TypeString},
@@ -527,88 +535,216 @@ func TestResourcePolicyPrefixListRead_SetsDeprecatedPrefixes(t *testing.T) {
 		},
 	}
 
-	tests := []struct {
-		name     string
-		prefixes []string
-		details  map[string]*alkira.PolicyPrefixListDetails
-		validate func(t *testing.T, d *schema.ResourceData)
-	}{
-		{
-			name:     "nil prefixes - no deprecated field set",
-			prefixes: nil,
-			details:  nil,
-			validate: func(t *testing.T, d *schema.ResourceData) {
-				result := d.Get("prefixes").(*schema.Set)
-				assert.Empty(t, result.List())
-			},
-		},
-		{
-			name:     "empty prefixes - no deprecated field set",
-			prefixes: []string{},
-			details:  nil,
-			validate: func(t *testing.T, d *schema.ResourceData) {
-				result := d.Get("prefixes").(*schema.Set)
-				assert.Empty(t, result.List())
-			},
-		},
-		{
-			name:     "prefixes populated for backward compatibility",
-			prefixes: []string{"192.168.1.0/24", "10.0.0.0/8"},
-			details:  nil,
-			validate: func(t *testing.T, d *schema.ResourceData) {
-				result := d.Get("prefixes").(*schema.Set)
-				assert.Len(t, result.List(), 2)
+	apiPrefixes := []string{"10.0.0.0/8", "172.16.0.0/12"}
+	var apiDetails map[string]*alkira.PolicyPrefixListDetails
 
-				// Verify deprecated field contains all prefixes (order may vary with Set)
-				resultList := result.List()
-				prefixSet := make(map[string]bool)
-				for _, item := range resultList {
-					prefixSet[item.(string)] = true
-				}
-				assert.True(t, prefixSet["192.168.1.0/24"])
-				assert.True(t, prefixSet["10.0.0.0/8"])
-			},
-		},
-		{
-			name:     "prefixes with details - deprecated field still populated",
-			prefixes: []string{"192.168.1.0/24", "10.0.0.0/8"},
-			details: map[string]*alkira.PolicyPrefixListDetails{
-				"192.168.1.0/24": {Description: "internal network"},
-				"10.0.0.0/8":     {Description: "corporate network"},
-			},
-			validate: func(t *testing.T, d *schema.ResourceData) {
-				result := d.Get("prefixes").(*schema.Set)
-				assert.Len(t, result.List(), 2)
+	t.Run("state has prefixes - populate only prefixes", func(t *testing.T) {
+		d := r.TestResourceData()
+		d.Set("prefixes", schema.NewSet(schema.HashString, []interface{}{"10.0.0.0/8", "172.16.0.0/12"}))
 
-				// Verify deprecated field contains all prefixes (descriptions ignored)
-				resultList := result.List()
-				prefixSet := make(map[string]bool)
-				for _, item := range resultList {
-					prefixSet[item.(string)] = true
-				}
-				assert.True(t, prefixSet["192.168.1.0/24"])
-				assert.True(t, prefixSet["10.0.0.0/8"])
-			},
-		},
-	}
+		// Simulate the fallback path: GetOk returns state value
+		usingDeprecatedField := false
+		if v, ok := d.GetOk("prefixes"); ok && v.(*schema.Set).Len() > 0 {
+			usingDeprecatedField = true
+		}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			d := r.TestResourceData()
-
-			// Set both "prefix" and "prefixes" fields as Read would
-			setPrefix(d, tt.prefixes, tt.details)
-
-			// Set deprecated "prefixes" field
-			if tt.prefixes != nil && len(tt.prefixes) > 0 {
-				prefixes := make([]interface{}, len(tt.prefixes))
-				for i, p := range tt.prefixes {
-					prefixes[i] = p
-				}
-				d.Set("prefixes", schema.NewSet(schema.HashString, prefixes))
+		if usingDeprecatedField {
+			prefixes := make([]interface{}, len(apiPrefixes))
+			for i, p := range apiPrefixes {
+				prefixes[i] = p
 			}
+			d.Set("prefixes", schema.NewSet(schema.HashString, prefixes))
+		} else {
+			setPrefix(d, apiPrefixes, apiDetails)
+		}
 
-			tt.validate(t, d)
+		assert.True(t, usingDeprecatedField)
+		result := d.Get("prefixes").(*schema.Set)
+		assert.Len(t, result.List(), 2)
+		prefixBlocks := d.Get("prefix").(*schema.Set)
+		assert.Empty(t, prefixBlocks.List(), "prefix blocks should NOT be populated when using deprecated field")
+	})
+
+	t.Run("state has no prefixes - populate only prefix blocks", func(t *testing.T) {
+		d := r.TestResourceData()
+
+		usingDeprecatedField := false
+		if v, ok := d.GetOk("prefixes"); ok && v.(*schema.Set).Len() > 0 {
+			usingDeprecatedField = true
+		}
+
+		if usingDeprecatedField {
+			t.Fatal("should not be using deprecated field")
+		} else {
+			setPrefix(d, apiPrefixes, apiDetails)
+		}
+
+		assert.False(t, usingDeprecatedField)
+		prefixBlocks := d.Get("prefix").(*schema.Set)
+		assert.Len(t, prefixBlocks.List(), 2)
+		cidrs := make(map[string]bool)
+		for _, item := range prefixBlocks.List() {
+			m := item.(map[string]interface{})
+			cidrs[m["cidr"].(string)] = true
+		}
+		assert.True(t, cidrs["10.0.0.0/8"])
+		assert.True(t, cidrs["172.16.0.0/12"])
+	})
+
+	t.Run("state has prefixes but API returns empty - clear prefixes", func(t *testing.T) {
+		d := r.TestResourceData()
+		d.Set("prefixes", schema.NewSet(schema.HashString, []interface{}{"10.0.0.0/8"}))
+
+		usingDeprecatedField := false
+		if v, ok := d.GetOk("prefixes"); ok && v.(*schema.Set).Len() > 0 {
+			usingDeprecatedField = true
+		}
+		assert.True(t, usingDeprecatedField)
+
+		emptyPrefixes := []string{}
+		if usingDeprecatedField {
+			if len(emptyPrefixes) > 0 {
+				t.Fatal("should be empty")
+			} else {
+				d.Set("prefixes", schema.NewSet(schema.HashString, nil))
+			}
+		}
+
+		result := d.Get("prefixes").(*schema.Set)
+		assert.Empty(t, result.List(), "prefixes should be cleared when API returns empty")
+	})
+
+	t.Run("deprecated path clears stale prefix blocks", func(t *testing.T) {
+		d := r.TestResourceData()
+		d.Set("prefixes", schema.NewSet(schema.HashString, []interface{}{"10.0.0.0/8"}))
+		d.Set("prefix", []interface{}{
+			map[string]interface{}{"cidr": "10.0.0.0/8", "description": "stale"},
 		})
+
+		usingDeprecatedField := false
+		if v, ok := d.GetOk("prefixes"); ok && v.(*schema.Set).Len() > 0 {
+			usingDeprecatedField = true
+		}
+		assert.True(t, usingDeprecatedField)
+
+		d.Set("prefix", schema.NewSet(prefixHash, nil))
+		prefixBlocks := d.Get("prefix").(*schema.Set)
+		assert.Empty(t, prefixBlocks.List(), "stale prefix blocks should be cleared")
+	})
+
+	t.Run("prefix path does not touch prefixes", func(t *testing.T) {
+		d := r.TestResourceData()
+		d.Set("prefixes", schema.NewSet(schema.HashString, []interface{}{"10.0.0.0/8"}))
+
+		// Simulate the prefix block path — only sets prefix, leaves prefixes alone
+		setPrefix(d, []string{"10.0.0.0/8"}, nil)
+
+		// prefixes is untouched — without Computed, Terraform won't show drift
+		result := d.Get("prefixes").(*schema.Set)
+		assert.Len(t, result.List(), 1, "prefixes should be left alone on prefix block path")
+		prefixBlocks := d.Get("prefix").(*schema.Set)
+		assert.Len(t, prefixBlocks.List(), 1)
+	})
+}
+
+func TestGenerateRequest_PrefixBlockPath(t *testing.T) {
+	// Tests the generateRequest when user uses the new "prefix" block.
+	// The GetRawConfig check for "prefixes" returns null/unknown in
+	// TestResourceData, so this always takes the prefix block path.
+	r := &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"name":        {Type: schema.TypeString},
+			"description": {Type: schema.TypeString, Optional: true},
+			"prefixes": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"prefix": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Set:      prefixHash,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"cidr":        {Type: schema.TypeString},
+						"description": {Type: schema.TypeString},
+					},
+				},
+			},
+			"prefix_range": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Set:      prefixRangeHash,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"prefix":      {Type: schema.TypeString},
+						"description": {Type: schema.TypeString},
+						"le":          {Type: schema.TypeInt},
+						"ge":          {Type: schema.TypeInt},
+					},
+				},
+			},
+		},
 	}
+
+	t.Run("prefix blocks produce correct API request", func(t *testing.T) {
+		d := r.TestResourceData()
+		d.Set("name", "test-list")
+		d.Set("description", "test desc")
+		d.Set("prefix", []interface{}{
+			map[string]interface{}{"cidr": "10.0.0.0/8", "description": "corporate"},
+			map[string]interface{}{"cidr": "192.168.0.0/16", "description": "private"},
+		})
+
+		result, err := generatePolicyPrefixListRequest(d)
+		assert.NoError(t, err)
+		assert.Equal(t, "test-list", result.Name)
+		assert.Equal(t, "test desc", result.Description)
+		assert.Len(t, result.Prefixes, 2)
+
+		prefixSet := make(map[string]bool)
+		for _, p := range result.Prefixes {
+			prefixSet[p] = true
+		}
+		assert.True(t, prefixSet["10.0.0.0/8"])
+		assert.True(t, prefixSet["192.168.0.0/16"])
+		assert.Len(t, result.PrefixDetails, 2)
+	})
+
+	t.Run("empty prefix blocks produce empty request", func(t *testing.T) {
+		d := r.TestResourceData()
+		d.Set("name", "empty-list")
+		d.Set("description", "")
+
+		result, err := generatePolicyPrefixListRequest(d)
+		assert.NoError(t, err)
+		assert.Equal(t, "empty-list", result.Name)
+		assert.Nil(t, result.Prefixes)
+		assert.Empty(t, result.PrefixDetails)
+	})
+
+	t.Run("prefix blocks with prefix_range produce correct API request", func(t *testing.T) {
+		d := r.TestResourceData()
+		d.Set("name", "combined-list")
+		d.Set("description", "")
+		d.Set("prefix", []interface{}{
+			map[string]interface{}{"cidr": "10.0.0.0/8", "description": ""},
+		})
+		d.Set("prefix_range", []interface{}{
+			map[string]interface{}{
+				"prefix":      "172.16.0.0/12",
+				"le":          24,
+				"ge":          16,
+				"description": "",
+			},
+		})
+
+		result, err := generatePolicyPrefixListRequest(d)
+		assert.NoError(t, err)
+		assert.Len(t, result.Prefixes, 1)
+		assert.Len(t, result.PrefixRanges, 1)
+		assert.Equal(t, "172.16.0.0/12", result.PrefixRanges[0].Prefix)
+		assert.Equal(t, 24, result.PrefixRanges[0].Le)
+		assert.Equal(t, 16, result.PrefixRanges[0].Ge)
+	})
 }

--- a/alkira/resource_alkira_policy_prefix_list_helper_test.go
+++ b/alkira/resource_alkira_policy_prefix_list_helper_test.go
@@ -503,3 +503,112 @@ func TestSetPrefixRanges(t *testing.T) {
 		})
 	}
 }
+
+func TestResourcePolicyPrefixListRead_SetsDeprecatedPrefixes(t *testing.T) {
+	// Create a mock ResourceData with both "prefix" and "prefixes" fields
+	r := &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"name":        {Type: schema.TypeString},
+			"description": {Type: schema.TypeString},
+			"prefixes": {
+				Type: schema.TypeSet,
+				Elem: &schema.Schema{Type: schema.TypeString},
+			},
+			"prefix": {
+				Type: schema.TypeSet,
+				Set:  prefixHash,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"cidr":        {Type: schema.TypeString},
+						"description": {Type: schema.TypeString},
+					},
+				},
+			},
+		},
+	}
+
+	tests := []struct {
+		name     string
+		prefixes []string
+		details  map[string]*alkira.PolicyPrefixListDetails
+		validate func(t *testing.T, d *schema.ResourceData)
+	}{
+		{
+			name:     "nil prefixes - no deprecated field set",
+			prefixes: nil,
+			details:  nil,
+			validate: func(t *testing.T, d *schema.ResourceData) {
+				result := d.Get("prefixes").(*schema.Set)
+				assert.Empty(t, result.List())
+			},
+		},
+		{
+			name:     "empty prefixes - no deprecated field set",
+			prefixes: []string{},
+			details:  nil,
+			validate: func(t *testing.T, d *schema.ResourceData) {
+				result := d.Get("prefixes").(*schema.Set)
+				assert.Empty(t, result.List())
+			},
+		},
+		{
+			name:     "prefixes populated for backward compatibility",
+			prefixes: []string{"192.168.1.0/24", "10.0.0.0/8"},
+			details:  nil,
+			validate: func(t *testing.T, d *schema.ResourceData) {
+				result := d.Get("prefixes").(*schema.Set)
+				assert.Len(t, result.List(), 2)
+
+				// Verify deprecated field contains all prefixes (order may vary with Set)
+				resultList := result.List()
+				prefixSet := make(map[string]bool)
+				for _, item := range resultList {
+					prefixSet[item.(string)] = true
+				}
+				assert.True(t, prefixSet["192.168.1.0/24"])
+				assert.True(t, prefixSet["10.0.0.0/8"])
+			},
+		},
+		{
+			name:     "prefixes with details - deprecated field still populated",
+			prefixes: []string{"192.168.1.0/24", "10.0.0.0/8"},
+			details: map[string]*alkira.PolicyPrefixListDetails{
+				"192.168.1.0/24": {Description: "internal network"},
+				"10.0.0.0/8":     {Description: "corporate network"},
+			},
+			validate: func(t *testing.T, d *schema.ResourceData) {
+				result := d.Get("prefixes").(*schema.Set)
+				assert.Len(t, result.List(), 2)
+
+				// Verify deprecated field contains all prefixes (descriptions ignored)
+				resultList := result.List()
+				prefixSet := make(map[string]bool)
+				for _, item := range resultList {
+					prefixSet[item.(string)] = true
+				}
+				assert.True(t, prefixSet["192.168.1.0/24"])
+				assert.True(t, prefixSet["10.0.0.0/8"])
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := r.TestResourceData()
+
+			// Set both "prefix" and "prefixes" fields as Read would
+			setPrefix(d, tt.prefixes, tt.details)
+
+			// Set deprecated "prefixes" field
+			if tt.prefixes != nil && len(tt.prefixes) > 0 {
+				prefixes := make([]interface{}, len(tt.prefixes))
+				for i, p := range tt.prefixes {
+					prefixes[i] = p
+				}
+				d.Set("prefixes", schema.NewSet(schema.HashString, prefixes))
+			}
+
+			tt.validate(t, d)
+		})
+	}
+}

--- a/docs/resources/policy_prefix_list.md
+++ b/docs/resources/policy_prefix_list.md
@@ -79,7 +79,7 @@ resource "alkira_policy_prefix_list" "ranges" {
 - `description` (String) The description of the prefix list.
 - `prefix` (Block Set) Prefix with description. This new block should replace the old `prefixes` field. (see [below for nested schema](#nestedblock--prefix))
 - `prefix_range` (Block Set) A valid prefix range that could be used to define a prefix of type `ROUTE`. (see [below for nested schema](#nestedblock--prefix_range))
-- `prefixes` (Set of String) A list of prefixes. (**DEPRECATED**)
+- `prefixes` (Set of String, Deprecated) A list of prefixes. **Deprecated:** Use `prefix` block instead.
 
 ### Read-Only
 


### PR DESCRIPTION
## Summary

Cherry-pick of #568 to release branch `release/2026-01-26-63`.

- Populate deprecated `prefixes` field in Read for backward compatibility
- Add `Computed`, `Deprecated`, and `ConflictsWith` attributes to `prefixes` schema
- Use `GetRawConfig` to distinguish user-set vs computed `prefixes` in request generation

## Cherry-picked commits

| Commit | Message |
|--------|---------|
| `4016daf5a1c7b334de04ea7425e851a7ab2c9831` | AK-65444: Fix deprecated prefixes field not populated in Read |

## Original PR

- #568

## Jira

- AK-66691