### PR TITLE
[CLONE-64] AK-66765: Fix AWS VPC connector drift from backend-defaulted routing fields

### DIFF
--- a/alkira/resource_alkira_connector_aws_vpc.go
+++ b/alkira/resource_alkira_connector_aws_vpc.go
@@ -163,6 +163,7 @@ func resourceAlkiraConnectorAwsVpc() *schema.Resource {
 					"`vpc_subnet` is not specified.",
 				Type:          schema.TypeList,
 				Optional:      true,
+				Computed:      true,
 				ConflictsWith: []string{"vpc_subnet"},
 				Elem:          &schema.Schema{Type: schema.TypeString},
 			},
@@ -172,6 +173,7 @@ func resourceAlkiraConnectorAwsVpc() *schema.Resource {
 					"is not specified.",
 				Type:          schema.TypeSet,
 				Optional:      true,
+				Computed:      true,
 				ConflictsWith: []string{"vpc_cidr"},
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
@@ -219,6 +221,7 @@ func resourceAlkiraConnectorAwsVpc() *schema.Resource {
 					},
 				},
 				Optional: true,
+				Computed: true,
 			},
 			"scale_group_id": {
 				Description: "The ID of the scale group associated with the connector.",
@@ -229,6 +232,7 @@ func resourceAlkiraConnectorAwsVpc() *schema.Resource {
 				Description: "Overlay subnet.",
 				Type:        schema.TypeList,
 				Optional:    true,
+				Computed:    true,
 				Elem:        &schema.Schema{Type: schema.TypeString},
 			},
 			"description": {

--- a/alkira/resource_alkira_connector_aws_vpc_helper.go
+++ b/alkira/resource_alkira_connector_aws_vpc_helper.go
@@ -77,16 +77,15 @@ func setAwsVpcExportPrefixes(exportOptions interface{}, d *schema.ResourceData) 
 		}
 	}
 
-	// Only set non-empty fields to preserve config when field is not in config
+	// Only set non-empty export fields to preserve config when field is not in config
+	// overlay_subnets is always set (even if empty) because backend always returns it
 	if len(cidrList) > 0 {
 		d.Set("vpc_cidr", cidrList)
 	}
 	if len(subnetList) > 0 {
 		d.Set("vpc_subnet", subnetList)
 	}
-	if len(overlaySubnets) > 0 {
-		d.Set("overlay_subnets", overlaySubnets)
-	}
+	d.Set("overlay_subnets", overlaySubnets)
 }
 
 // setAwsVpcImportRouteTables sets vpc_route_table from ImportOptions

--- a/alkira/resource_alkira_connector_aws_vpc_helper.go
+++ b/alkira/resource_alkira_connector_aws_vpc_helper.go
@@ -39,7 +39,10 @@ func setAwsVpcRoutingOptions(connector *alkira.ConnectorAwsVpc, d *schema.Resour
 // setAwsVpcExportPrefixes sets export-related fields from ExportOptions
 func setAwsVpcExportPrefixes(exportOptions interface{}, d *schema.ResourceData) {
 	if exportOptions == nil {
-		log.Printf("[DEBUG] Export options is nil, skipping export prefixes")
+		log.Printf("[DEBUG] Export options is nil, clearing export prefixes")
+		d.Set("vpc_cidr", []interface{}{})
+		d.Set("vpc_subnet", []interface{}{})
+		d.Set("overlay_subnets", []interface{}{})
 		return
 	}
 
@@ -101,10 +104,6 @@ func setAwsVpcImportRouteTables(importOptions interface{}, d *schema.ResourceDat
 	var importOpts alkira.ImportOptions
 	if err := json.Unmarshal(importJSON, &importOpts); err != nil {
 		log.Printf("[ERROR] Failed to unmarshal ImportOptions: %v", err)
-		return
-	}
-
-	if len(importOpts.RouteTables) == 0 {
 		return
 	}
 

--- a/alkira/resource_alkira_connector_aws_vpc_helper.go
+++ b/alkira/resource_alkira_connector_aws_vpc_helper.go
@@ -77,14 +77,10 @@ func setAwsVpcExportPrefixes(exportOptions interface{}, d *schema.ResourceData) 
 		}
 	}
 
-	// Only set non-empty export fields to preserve config when field is not in config
-	// overlay_subnets is always set (even if empty) because backend always returns it
-	if len(cidrList) > 0 {
-		d.Set("vpc_cidr", cidrList)
-	}
-	if len(subnetList) > 0 {
-		d.Set("vpc_subnet", subnetList)
-	}
+	// Always set all export fields because they are Computed
+	// Backend returns userInputPrefixes with type entries; empty set if none specified
+	d.Set("vpc_cidr", cidrList)
+	d.Set("vpc_subnet", subnetList)
 	d.Set("overlay_subnets", overlaySubnets)
 }
 


### PR DESCRIPTION
Cherry-pick of PR #588 for REL 64 release.

**Original Issue:** AK-66346
**Clone for REL 64:** AK-66765

## Summary

- Add `Computed: true` to `vpc_cidr`, `vpc_subnet`, `vpc_route_table`, and `overlay_subnets` to prevent drift when backend auto-populates default routing values
- Always set all routing fields in Read (export and import), even when empty, to keep state consistent with the `Optional + Computed` contract
- Clear export fields to `[]` when `exportOptions` is nil (defensive edge case)

## Changes

- `alkira/resource_alkira_connector_aws_vpc.go` — Add `Computed: true` to `vpc_cidr`, `vpc_subnet`, `vpc_route_table`, `overlay_subnets`
- `alkira/resource_alkira_connector_aws_vpc_helper.go` — Always set all routing fields in Read, even when empty; clear export fields on nil exportOptions

## Original PR
#588

## Cherry-picked Commits
- 261a9bf64d6b0648807e7f6f4752a2787203349a
- e021e41c2f2d54f30f81dedba2ecf6ac8cb64732
- fc504f85f90c00535d43e5e98f548a94215fd73a