### PR TITLE
AK-66870: Fix AWS VPC connector vpc_cidr to vpc_subnet mode switch

### DIFF
--- a/alkira/resource_alkira_connector_aws_vpc.go
+++ b/alkira/resource_alkira_connector_aws_vpc.go
@@ -163,7 +163,6 @@ func resourceAlkiraConnectorAwsVpc() *schema.Resource {
 					"`vpc_subnet` is not specified.",
 				Type:          schema.TypeList,
 				Optional:      true,
-				Computed:      true,
 				ConflictsWith: []string{"vpc_subnet"},
 				Elem:          &schema.Schema{Type: schema.TypeString},
 			},
@@ -173,7 +172,6 @@ func resourceAlkiraConnectorAwsVpc() *schema.Resource {
 					"is not specified.",
 				Type:          schema.TypeSet,
 				Optional:      true,
-				Computed:      true,
 				ConflictsWith: []string{"vpc_cidr"},
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{

--- a/alkira/resource_alkira_connector_aws_vpc_helper.go
+++ b/alkira/resource_alkira_connector_aws_vpc_helper.go
@@ -198,23 +198,23 @@ func expandAwsVpcRouteTables(in *schema.Set) []alkira.RouteTables {
 // expandUserInputPrefixes generate UserInputPrefixes used in AWS-VPC connector
 func expandUserInputPrefixes(cidr []interface{}, subnets *schema.Set, overlaySubnets []interface{}) ([]alkira.InputPrefixes, error) {
 
-	if len(cidr) == 0 && subnets == nil {
-		return nil, fmt.Errorf("ERROR: either \"vpc_subnet\" or \"vpc_cidr\" must be specified")
-	}
+	hasCidr := len(cidr) > 0
+	hasSubnets := subnets != nil && subnets.Len() > 0
 
 	// Processing overlay_subnets
 	log.Printf("[DEBUG] Processing overlay_subnets %v", overlaySubnets)
 	overlaySubnetList := make([]alkira.InputPrefixes, len(overlaySubnets))
 
-	if len(overlaySubnets) > 0 {
-		for i, value := range overlaySubnets {
-			overlaySubnetList[i].Value = value.(string)
-			overlaySubnetList[i].Type = "OVERLAY_SUBNETS"
-		}
+	for i, value := range overlaySubnets {
+		overlaySubnetList[i].Value = value.(string)
+		overlaySubnetList[i].Type = "OVERLAY_SUBNETS"
 	}
 
-	// Processing vpc_cidr
-	if len(cidr) > 0 {
+	switch {
+	case hasCidr && hasSubnets:
+		return nil, fmt.Errorf("ERROR: \"vpc_cidr\" and \"vpc_subnet\" cannot both be specified")
+
+	case hasCidr:
 		log.Printf("[DEBUG] Processing vpc_cidr %v", cidr)
 		cidrList := make([]alkira.InputPrefixes, len(cidr))
 
@@ -223,34 +223,31 @@ func expandUserInputPrefixes(cidr []interface{}, subnets *schema.Set, overlaySub
 			cidrList[i].Type = "CIDR"
 		}
 
-		cidrList = append(cidrList, overlaySubnetList...)
-		return cidrList, nil
-	}
+		return append(cidrList, overlaySubnetList...), nil
 
-	// Processing vpc_subnet
-	log.Printf("[DEBUG] Processing vpc_subnet")
-	if subnets == nil || subnets.Len() == 0 {
-		log.Printf("[DEBUG] Empty vpc_subnet")
-		return nil, fmt.Errorf("ERROR: Invalid vpc_subnet")
-	}
+	case hasSubnets:
+		log.Printf("[DEBUG] Processing vpc_subnet")
+		prefixes := make([]alkira.InputPrefixes, subnets.Len())
 
-	prefixes := make([]alkira.InputPrefixes, subnets.Len())
-	for i, subnet := range subnets.List() {
-		r := alkira.InputPrefixes{}
-		t := subnet.(map[string]interface{})
-		if v, ok := t["id"].(string); ok {
-			r.Id = v
-		}
-		if v, ok := t["cidr"].(string); ok {
-			r.Value = v
+		for i, subnet := range subnets.List() {
+			r := alkira.InputPrefixes{}
+			t := subnet.(map[string]interface{})
+			if v, ok := t["id"].(string); ok {
+				r.Id = v
+			}
+			if v, ok := t["cidr"].(string); ok {
+				r.Value = v
+			}
+
+			r.Type = "SUBNET"
+			prefixes[i] = r
 		}
 
-		r.Type = "SUBNET"
-		prefixes[i] = r
-	}
+		return append(prefixes, overlaySubnetList...), nil
 
-	prefixes = append(prefixes, overlaySubnetList...)
-	return prefixes, nil
+	default:
+		return nil, fmt.Errorf("ERROR: either \"vpc_subnet\" or \"vpc_cidr\" must be specified")
+	}
 }
 
 // expandAwsVpcTgwAttachments expand tgw_attachment of connector_aws_vpc

--- a/alkira/resource_alkira_connector_aws_vpc_helper_test.go
+++ b/alkira/resource_alkira_connector_aws_vpc_helper_test.go
@@ -204,7 +204,7 @@ func TestExpandUserInputPrefixes(t *testing.T) {
 			expectError: false,
 		},
 		{
-			name: "mixed subnets and CIDR",
+			name: "mixed subnets and CIDR - should error",
 			cidr: []interface{}{"10.0.0.0/16"},
 			subnets: schema.NewSet(
 				func(i interface{}) int {
@@ -219,8 +219,125 @@ func TestExpandUserInputPrefixes(t *testing.T) {
 				},
 			),
 			overlaySubnets: []interface{}{"172.16.0.0/24"},
+			expected:       nil,
+			expectError:    true,
+			errorMsg:       "cannot both be specified",
+		},
+		{
+			name:           "empty cidr with valid subnets - subnet mode",
+			cidr:           []interface{}{},
+			subnets: schema.NewSet(
+				func(i interface{}) int {
+					m := i.(map[string]interface{})
+					return schema.HashString(m["id"].(string))
+				},
+				[]interface{}{
+					map[string]interface{}{
+						"id":   "subnet-123",
+						"cidr": "10.0.1.0/24",
+					},
+				},
+			),
+			overlaySubnets: []interface{}{},
+			expected: []alkira.InputPrefixes{
+				{Id: "subnet-123", Type: "SUBNET", Value: "10.0.1.0/24"},
+			},
+			expectError: false,
+		},
+		{
+			name:           "nil subnets with valid cidr - cidr mode",
+			cidr:           []interface{}{"10.0.0.0/16"},
+			subnets:        nil,
+			overlaySubnets: []interface{}{},
 			expected: []alkira.InputPrefixes{
 				{Type: "CIDR", Value: "10.0.0.0/16"},
+			},
+			expectError: false,
+		},
+		{
+			name: "empty cidr with multiple subnets",
+			cidr: []interface{}{},
+			subnets: schema.NewSet(
+				func(i interface{}) int {
+					m := i.(map[string]interface{})
+					return schema.HashString(m["id"].(string))
+				},
+				[]interface{}{
+					map[string]interface{}{
+						"id":   "subnet-123",
+						"cidr": "10.0.1.0/24",
+					},
+					map[string]interface{}{
+						"id":   "subnet-456",
+						"cidr": "10.0.2.0/24",
+					},
+				},
+			),
+			overlaySubnets: []interface{}{},
+			expected: []alkira.InputPrefixes{
+				{Id: "subnet-123", Type: "SUBNET", Value: "10.0.1.0/24"},
+				{Id: "subnet-456", Type: "SUBNET", Value: "10.0.2.0/24"},
+			},
+			expectError: false,
+		},
+		{
+			name: "empty subnets set with valid cidr - cidr mode",
+			cidr: []interface{}{"192.168.0.0/16"},
+			subnets: schema.NewSet(
+				func(i interface{}) int {
+					m := i.(map[string]interface{})
+					return schema.HashString(m["id"].(string))
+				},
+				[]interface{}{},
+			),
+			overlaySubnets: []interface{}{},
+			expected: []alkira.InputPrefixes{
+				{Type: "CIDR", Value: "192.168.0.0/16"},
+			},
+			expectError: false,
+		},
+		{
+			name:           "empty cidr and empty subnets - should error",
+			cidr:           []interface{}{},
+			subnets: schema.NewSet(
+				func(i interface{}) int {
+					m := i.(map[string]interface{})
+					return schema.HashString(m["id"].(string))
+				},
+				[]interface{}{},
+			),
+			overlaySubnets: []interface{}{},
+			expected:       nil,
+			expectError:    true,
+			errorMsg:       "either",
+		},
+		{
+			name:           "nil cidr and nil subnets - should error",
+			cidr:           nil,
+			subnets:        nil,
+			overlaySubnets: []interface{}{},
+			expected:       nil,
+			expectError:    true,
+			errorMsg:       "either",
+		},
+		{
+			name:           "subnets with overlay - combined payload",
+			cidr:           []interface{}{},
+			subnets: schema.NewSet(
+				func(i interface{}) int {
+					m := i.(map[string]interface{})
+					return schema.HashString(m["id"].(string))
+				},
+				[]interface{}{
+					map[string]interface{}{
+						"id":   "subnet-789",
+						"cidr": "10.0.3.0/24",
+					},
+				},
+			),
+			overlaySubnets: []interface{}{"172.16.0.0/24"},
+			expected: []alkira.InputPrefixes{
+				{Id: "subnet-789", Type: "SUBNET", Value: "10.0.3.0/24"},
 				{Type: "OVERLAY_SUBNETS", Value: "172.16.0.0/24"},
 			},
 			expectError: false,


### PR DESCRIPTION
## Summary

- Remove `Computed: true` from `vpc_cidr` and `vpc_subnet` schema fields to fix silent mode switch failure
- Retain `Computed: true` on `vpc_route_table` and `overlay_subnets` (no `ConflictsWith`, backend auto-populates)

## Problem

When updating an AWS VPC connector from `vpc_cidr` mode to `vpc_subnet` mode, the API receives stale CIDR prefixes instead of the new subnet prefixes. The connector silently stays in CIDR mode — no error, no drift warning.

**Root cause:** `expandUserInputPrefixes()` checks `len(cidr) > 0` first and returns CIDR data immediately, never reaching the subnet branch. With `Computed: true` on both fields, `d.Get("vpc_cidr")` returns stale state values even after the user removes `vpc_cidr` from config. The stale CIDRs short-circuit the expand function.

**Introduced by:** AK-65432 (Read populates routing fields) + AK-66346 (added `Computed: true` to prevent drift). Neither is in the published registry version — only on `dev`.

## Solution

Remove `Computed: true` from `vpc_cidr` and `vpc_subnet`. Without `Computed`, when the user switches modes:
- Terraform clears the removed field to its zero value in the plan
- `d.Get("vpc_cidr")` returns `[]` (empty)
- `expandUserInputPrefixes` reaches the subnet branch
- Correct `SUBNET` payload sent to API

This is safe because `expandUserInputPrefixes` requires at least one of the two fields, so users must always specify one in config. This matches the `connector_oci_vcn` pattern and the approach in PR #604 for `policy_prefix_list`.

## Changes

- `alkira/resource_alkira_connector_aws_vpc.go` — Remove `Computed: true` from `vpc_cidr` and `vpc_subnet`

## Testing Performed

### Live Testing

**Test environment:** `test/AK-66870-vpc-cidr-subnet-mode-switch/`

- Greenfield vpc_cidr (full config) — API payload `type:CIDR`, plan "No changes"
- Greenfield vpc_subnet (full config, 2 subnets) — API payload `type:SUBNET`, plan "No changes"
- Greenfield minimal vpc_cidr (no route table, no overlay) — Backend defaults handled, no drift
- Greenfield minimal vpc_subnet (no route table, no overlay) — No drift
- **KEY TEST:** Mode switch CIDR → SUBNET — API payload `type:SUBNET` (not stale `type:CIDR`)
- **KEY TEST:** Mode switch SUBNET → CIDR — API payload `type:CIDR` (not stale `type:SUBNET`)
- Mode switch CIDR → 2 subnets — API payload 2x `type:SUBNET`, no drift
- Brownfield upgrade (registry → fixed build) — No connector changes on upgrade plan
- Import vpc_cidr with `generate-config-out` — Generated config correct, no drift

### Code Quality

- `make lint` — 0 issues
- `go build` — clean
- Unit tests — All pass