### PR TITLE
AK-67039: making akamai_bgp_authentication_key sensitive true and Wri…

### DIFF
--- a/alkira/resource_alkira_connector_akamai_prolexic.go
+++ b/alkira/resource_alkira_connector_akamai_prolexic.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"os"
 
 	"github.com/alkiranet/alkira-client-go/alkira"
+	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -55,9 +57,16 @@ func resourceAlkiraConnectorAkamaiProlexic() *schema.Resource {
 				Required:    true,
 			},
 			"akamai_bgp_authentication_key": {
-				Description: "The Akamai BGP Authentication Key.",
-				Type:        schema.TypeString,
-				Required:    true,
+				Description: "The Akamai BGP Authentication Key. " +
+					"It could also be set by environment variable " +
+					"`AK_AKAMAI_BGP_AUTHENTICATION_KEY`. This value is " +
+					"stored as a credential in the Alkira backend and " +
+					"is never returned by the API, so it is not " +
+					"persisted in Terraform state.",
+				Type:      schema.TypeString,
+				Required:  true,
+				Sensitive: true,
+				WriteOnly: true,
 			},
 			"byoip_options": {
 				Description: "BYOIP options.",
@@ -253,6 +262,7 @@ func resourceConnectorAkamaiProlexicRead(ctx context.Context, d *schema.Resource
 
 	d.Set("akamai_bgp_asn", connector.AkamaiBgpAsn)
 	d.Set("billing_tag_ids", connector.BillingTags)
+	d.Set("credential_id", connector.CredentialId)
 	d.Set("cxp", connector.CXP)
 	d.Set("enabled", connector.Enabled)
 	d.Set("group", connector.Group)
@@ -260,6 +270,10 @@ func resourceConnectorAkamaiProlexicRead(ctx context.Context, d *schema.Resource
 	d.Set("name", connector.Name)
 	d.Set("size", connector.Size)
 	d.Set("description", connector.Description)
+
+	// akamai_bgp_authentication_key is WriteOnly and never returned
+	// by the API; it is maintained in the user's HCL configuration
+	// and not persisted to state.
 
 	// Get segment
 	numOfSegments := len(connector.Segments)
@@ -401,10 +415,23 @@ func generateConnectorAkamaiProlexicRequest(d *schema.ResourceData, m interface{
 		return nil, err
 	}
 
+	// Read the BGP authentication key. The field is WriteOnly so it
+	// is not persisted in state; pull it from raw config with an env
+	// var fallback.
+	bgpAuthKey, err := getAkamaiProlexicCredentialValue(
+		d,
+		"akamai_bgp_authentication_key",
+		"AK_AKAMAI_BGP_AUTHENTICATION_KEY",
+		true,
+	)
+	if err != nil {
+		return nil, err
+	}
+
 	// Create implicit akamai-prolexic credential
 	log.Printf("[INFO] Creating credential-akamai-prolexic")
 	c := alkira.CredentialAkamaiProlexic{
-		BgpAuthenticationKey: d.Get("akamai_bgp_authentication_key").(string),
+		BgpAuthenticationKey: bgpAuthKey,
 	}
 
 	client := m.(*alkira.AlkiraClient)
@@ -432,4 +459,28 @@ func generateConnectorAkamaiProlexicRequest(d *schema.ResourceData, m interface{
 	}
 
 	return connector, nil
+}
+
+// getAkamaiProlexicCredentialValue reads a credential value for the
+// Akamai Prolexic connector. WriteOnly fields are not persisted in
+// state, so the value is pulled from raw config first and falls back
+// to the given environment variable.
+func getAkamaiProlexicCredentialValue(d *schema.ResourceData, field string, envVar string, required bool) (string, error) {
+	attrPath := cty.Path{cty.GetAttrStep{Name: field}}
+	val, diags := d.GetRawConfigAt(attrPath)
+
+	if !diags.HasError() && !val.IsNull() && val.IsKnown() && val.Type() == cty.String {
+		if s := val.AsString(); s != "" {
+			return s, nil
+		}
+	}
+
+	if v := os.Getenv(envVar); v != "" {
+		return v, nil
+	}
+
+	if required {
+		return "", fmt.Errorf("required field '%s' is not set in configuration and environment variable '%s' is not set", field, envVar)
+	}
+	return "", nil
 }

--- a/alkira/resource_alkira_connector_akamai_prolexic.go
+++ b/alkira/resource_alkira_connector_akamai_prolexic.go
@@ -368,6 +368,10 @@ func resourceConnectorAkamaiProlexicDelete(ctx context.Context, d *schema.Resour
 	client := m.(*alkira.AlkiraClient)
 	api := alkira.NewConnectorAkamaiProlexic(m.(*alkira.AlkiraClient))
 
+	// Capture credential_id before the connector is deleted so we can
+	// clean up the implicit credential afterwards.
+	credentialId := d.Get("credential_id").(string)
+
 	provState, err, valErr, provErr := api.Delete(d.Id())
 
 	if err != nil {
@@ -378,6 +382,14 @@ func resourceConnectorAkamaiProlexicDelete(ctx context.Context, d *schema.Resour
 			return diag.FromErr(fmt.Errorf("%w alkira_connector_akamai_prolexic (name=%q id=%s)", err, nameStr, d.Id()))
 		}
 		return diag.FromErr(fmt.Errorf("%w alkira_connector_akamai_prolexic (id=%s)", err, d.Id()))
+	}
+
+	// Delete the implicit credential so it doesn't get orphaned on the tenant.
+	if credentialId != "" {
+		log.Printf("[INFO] Deleting credential-akamai-prolexic (id=%s)", credentialId)
+		if delErr := client.DeleteCredential(credentialId, alkira.CredentialTypeAkamaiProlexic); delErr != nil {
+			log.Printf("[WARN] Failed to delete credential %s: %v", credentialId, delErr)
+		}
 	}
 
 	d.SetId("")
@@ -428,20 +440,32 @@ func generateConnectorAkamaiProlexicRequest(d *schema.ResourceData, m interface{
 		return nil, err
 	}
 
-	// Create implicit akamai-prolexic credential
-	log.Printf("[INFO] Creating credential-akamai-prolexic")
+	// Manage the implicit akamai-prolexic credential.
+	// On Create (credential_id is empty), create a new credential.
+	// On Update (credential_id already set), reuse the same credential_id
+	// and push any changes via UpdateCredential so we don't leak a new
+	// credential on every apply.
 	c := alkira.CredentialAkamaiProlexic{
 		BgpAuthenticationKey: bgpAuthKey,
 	}
 
 	client := m.(*alkira.AlkiraClient)
-	credentialId, err := client.CreateCredential(d.Get("name").(string), alkira.CredentialTypeAkamaiProlexic, c, 0)
+	credentialId := d.Get("credential_id").(string)
 
-	if err != nil {
-		return nil, err
+	if credentialId == "" {
+		log.Printf("[INFO] Creating credential-akamai-prolexic")
+		newCredentialId, err := client.CreateCredential(d.Get("name").(string), alkira.CredentialTypeAkamaiProlexic, c, 0)
+		if err != nil {
+			return nil, err
+		}
+		credentialId = newCredentialId
+		d.Set("credential_id", credentialId)
+	} else {
+		log.Printf("[INFO] Updating credential-akamai-prolexic (id=%s)", credentialId)
+		if err := client.UpdateCredential(credentialId, d.Get("name").(string), alkira.CredentialTypeAkamaiProlexic, c, 0); err != nil {
+			return nil, err
+		}
 	}
-
-	d.Set("credential_id", credentialId)
 
 	connector := &alkira.ConnectorAkamaiProlexic{
 		AkamaiBgpAsn:         d.Get("akamai_bgp_asn").(int),

--- a/alkira/resource_alkira_connector_akamai_prolexic.go
+++ b/alkira/resource_alkira_connector_akamai_prolexic.go
@@ -271,9 +271,6 @@ func resourceConnectorAkamaiProlexicRead(ctx context.Context, d *schema.Resource
 	d.Set("size", connector.Size)
 	d.Set("description", connector.Description)
 
-	// akamai_bgp_authentication_key is WriteOnly and never returned
-	// by the API; it is maintained in the user's HCL configuration
-	// and not persisted to state.
 
 	// Get segment
 	numOfSegments := len(connector.Segments)


### PR DESCRIPTION
  Tested the following
  Scenario 1 — Create flow still works                                                                                          
  - Applied alkira_connector_akamai_prolexic resource with akamai_bgp_authentication_key = "dummy-auth-key"                     
  - Result: Connector created successfully (id 17159). akamai_bgp_authentication_key shown as (write-only attribute) in plan,   
  confirming WriteOnly: true is honored. tunnel_configuration output populated correctly.                                       
                                                                                                                                
  Scenario 2 — Import + -generate-config-out (the actual bug repro)                                                          
  - Ran terraform import + terraform plan -generate-config-out=generated.tf against connector id 17159                          
  - Before fix: generated config had akamai_bgp_authentication_key = null (no sensitive marker) and plan failed                 
  - After fix: generated config correctly emits akamai_bgp_authentication_key = null # sensitive — matches the expected output  
  in the bug description                                                          
  
  Did this additional testing:
   - Scenario 1 — Create: Fresh terraform apply in sun-staging-prolexic/ → connector 17163 created, credential_id
  captured as baseline
  - Scenario 2 — Non-credential update: Changed size SMALL → MEDIUM and applied → credential_id unchanged; log: [INFO]
   Updating credential-akamai-prolexic                                                                                
  - Scenario 3 — Auth key update: Changed akamai_bgp_authentication_key from "dummy-auth-key" → "dummy-auth-key-v2"   
  and applied → credential_id unchanged; log: [INFO] Updating credential-akamai-prolexic                              
  - Scenario 4 — Import + generate-config regression: In sun-staging-prolexic-import/, ran terraform plan          
  -generate-config-out=generated.tf against id 17163 → generated.tf correctly emits akamai_bgp_authentication_key =   
  null # sensitive                                                           
  - Scenario 5 — Destroy + credential cleanup: terraform destroy → connector gone; log: [INFO] Deleting               
  credential-akamai-prolexic, no [WARN] Failed to delete credential                                                    
                                                                                                                                
                                                             
