### PR TITLE
AK-66894: adding the missing controller host field.

### DIFF
--- a/alkira/resource_alkira_connector_versa_sdwan.go
+++ b/alkira/resource_alkira_connector_versa_sdwan.go
@@ -284,6 +284,7 @@ func resourceConnectorVersaSdwanRead(ctx context.Context, d *schema.ResourceData
 	d.Set("tunnel_protocol", connector.TunnelProtocol)
 	d.Set("description", connector.Description)
 	d.Set("global_tenant_id", connector.GlobalTenantId)
+	d.Set("versa_controller_host", connector.VersaControllerHost)
 
 	// Set Instances
 	setVersaSdwanInstance(d, connector)


### PR DESCRIPTION
  Tested the following scenario 

  Scenario 1 — Create + Read
  - Ran terraform apply with fixed binary to create the connector
  - Result: Connector created successfully; versa_controller_host appeared in state and in the output block — Read path
  populates the field correctly.

  Scenario 2 — Import + -generate-config-out (the actual bug repro)
  - Fresh directory with only an import block → terraform plan -generate-config-out=generated.tf
  - Before fix: plan failed with Error: Missing required argument — "versa_controller_host" is required, but no definition was
  found.
  - After fix: plan succeeded (1 to import, 0 to add, 0 to change, 0 to destroy); generated.tf contains versa_controller_host =
  "172.16.0.1" — confirming Read now sets the field in state and config generation picks it up.

  Scenario 3 — Brownfield import
  - Directory with a full resource block matching the live connector + an import block
  - Ran terraform plan
  - Result: 1 to import, 0 to add, 0 to change, 0 to destroy — no drift detected between imported state and declared config.

