### PR TITLE
AK-65624 Add gitleaks pre-commit check

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,5 @@
+repos:
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.30.1
+    hooks:
+      - id: gitleaks


### PR DESCRIPTION
## What this change adds

A `.pre-commit-config.yaml` that wires up **gitleaks** as a git pre-commit hook. Every commit will be scanned locally for secrets (AWS/Azure/GCP keys, PEM private keys, provider-specific tokens, high-entropy strings) and **blocked** before the commit is created.

## Why

GitHub Advanced Security push protection only blocks long-lived `AKIA…` AWS keys. Other credential formats — most notably `ASIA…` STS temporary keys — fall through to GitHub's generic detector, which runs **post-push and does not block**. Gitleaks catches the broader set at commit time, so secrets never reach the remote. See [alkiranet/aeira secret-scanning alert #237](https://github.com/alkiranet/aeira/security/secret-scanning/237) for the incident that prompted this rollout.

Tracked in **AK-65624** / AK-67061.

## What every engineer must do after this PR merges

One-time, per laptop:
```
brew install pre-commit        # macOS — or `pipx install pre-commit`
```
You do **not** need to install gitleaks yourself; the pre-commit framework downloads the pinned `v8.30.1` binary automatically into `~/.cache/pre-commit/` on first run.

One-time, per local clone of this repo:
```
pre-commit install
```
This writes a shim to `.git/hooks/pre-commit`. Nothing global, nothing on PATH.

## Normal workflow

`git commit` now runs gitleaks on staged diffs. If a secret is detected the commit is blocked with exit code 1 and a redacted finding is shown. Remove the secret (env var / secrets manager), re-stage, commit again.

## False positives

Add a line-level allowlist right above the offending line:
```
# gitleaks:allow
```
Or, for repo-wide tuning, add a `.gitleaks.toml`. Do **not** disable gitleaks globally.

## References

- Parent ticket: AK-65624
- This rollout sub-task: AK-67061
- [gitleaks](https://github.com/gitleaks/gitleaks) · [pre-commit framework](https://pre-commit.com/)
