### PR TITLE
AK-67079 Bump fortinet acceptance test version to 7.4.11

### DIFF
--- a/acceptance/service_fortinet.tf
+++ b/acceptance/service_fortinet.tf
@@ -10,7 +10,7 @@ resource "alkira_service_fortinet" "test1" {
   segment_ids                  = [alkira_segment.test1.id, alkira_segment.test2.id]
   size                         = "SMALL"
   tunnel_protocol              = "IPSEC"
-  version                      = "7.0.3"
+  version                      = "7.4.11"
 
   instances {
     name                  = "a-ins1"

--- a/acceptance/service_fortinet.tf
+++ b/acceptance/service_fortinet.tf
@@ -10,7 +10,7 @@ resource "alkira_service_fortinet" "test1" {
   segment_ids                  = [alkira_segment.test1.id, alkira_segment.test2.id]
   size                         = "SMALL"
   tunnel_protocol              = "IPSEC"
-  version                      = "7.4.11"
+  version                      = "7.4.3"
 
   instances {
     name                  = "a-ins1"


### PR DESCRIPTION
## Why

`acceptance-test-preprod` has been failing on every recent PR (`dev`, [feature/AK-66323], [bugfix/AK-67039], [AK-65624-gitleaks-pre-commit], etc.) with:

```
Error: client-create(...): 400 "Validation failed"
field: version
message: "Fortinet firewall version '7.0.3' is not supported on cxp 'US-WEST-1'"
```

Cause: `7.0.3` is now `deprecated: true` for both `fortigate-byol` and `fortigate-payg` on `us-west-1` in [alkiranet/inventory-data/data/common/products/overrides/us-west-1.yaml](https://github.com/alkiranet/inventory-data/blob/main/data/common/products/overrides/us-west-1.yaml). The backend rejects deprecated versions on `client-create`.

## Fix

Bump `acceptance/service_fortinet.tf` from `7.0.3` → `7.4.11`. `7.4.11` is the latest non-deprecated version available on us-west-1 for both BYOL and PAYG (also OK for `fortigate-sdwan-*`).

Tracking: AK-67079.

## Impact

Unblocks every PR currently failing on the same check.