### PR TITLE
AK-66661: Add WriteOnly+Sensitive to alkira_service_checkpoint credential fields

### DIFF
--- a/alkira/resource_alkira_service_checkpoint.go
+++ b/alkira/resource_alkira_service_checkpoint.go
@@ -64,6 +64,8 @@ func resourceAlkiraCheckpoint() *schema.Resource {
 				Description: "The Checkpoint Firewall service password.",
 				Type:        schema.TypeString,
 				Required:    true,
+				Sensitive:   true,
+				WriteOnly:   true,
 			},
 			"credential_id": {
 				Description: "ID of Checkpoint Firewall credential.",
@@ -103,6 +105,8 @@ func resourceAlkiraCheckpoint() *schema.Resource {
 							Description: "The checkpoint instance sic keys.",
 							Type:        schema.TypeString,
 							Required:    true,
+							Sensitive:   true,
+							WriteOnly:   true,
 						},
 						"enable_traffic": {
 							Description: "Enable traffic on the checkpoint instance. " +
@@ -187,11 +191,13 @@ func resourceAlkiraCheckpoint() *schema.Resource {
 							Description: "The username of the management server.",
 							Type:        schema.TypeString,
 							Optional:    true,
+							Sensitive:   true,
 						},
 						"password": {
 							Description: "The password of the management server.",
 							Type:        schema.TypeString,
 							Optional:    true,
+							Sensitive:   true,
 						},
 					},
 				},

--- a/alkira/resource_alkira_service_checkpoint.go
+++ b/alkira/resource_alkira_service_checkpoint.go
@@ -417,6 +417,12 @@ func resourceCheckpointUpdate(ctx context.Context, d *schema.ResourceData, m int
 		return diag.FromErr(err)
 	}
 
+	// Update management server credential
+	err = updateCheckpointManagementServerCredential(d, client)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
 	// Construct request
 	request, err := generateCheckpointRequest(d, m)
 

--- a/alkira/resource_alkira_service_checkpoint_helper.go
+++ b/alkira/resource_alkira_service_checkpoint_helper.go
@@ -5,15 +5,54 @@ import (
 	"log"
 
 	"github.com/alkiranet/alkira-client-go/alkira"
+	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
+
+// getCheckpointWriteOnlyValue reads a WriteOnly field from raw config with a d.Get() fallback
+// for import/refresh where GetRawConfigAt is unavailable.
+func getCheckpointWriteOnlyValue(d *schema.ResourceData, field string) string {
+	attrPath := cty.Path{cty.GetAttrStep{Name: field}}
+	val, diags := d.GetRawConfigAt(attrPath)
+
+	if !diags.HasError() && !val.IsNull() && val.IsKnown() && val.Type() == cty.String {
+		if strVal := val.AsString(); strVal != "" {
+			return strVal
+		}
+	}
+
+	if v, ok := d.GetOk(field); ok {
+		return v.(string)
+	}
+
+	return ""
+}
+
+// getNestedWriteOnlyValue reads a WriteOnly field from a nested TypeList block
+// via GetRawConfigAt with an indexed cty path.
+func getNestedWriteOnlyValue(d *schema.ResourceData, block string, index int, field string) string {
+	attrPath := cty.Path{
+		cty.GetAttrStep{Name: block},
+		cty.IndexStep{Key: cty.NumberIntVal(int64(index))},
+		cty.GetAttrStep{Name: field},
+	}
+	val, diags := d.GetRawConfigAt(attrPath)
+
+	if !diags.HasError() && !val.IsNull() && val.IsKnown() && val.Type() == cty.String {
+		if strVal := val.AsString(); strVal != "" {
+			return strVal
+		}
+	}
+
+	return ""
+}
 
 // createCheckpointCredential create checkpoint service credential
 func createCheckpointCredential(d *schema.ResourceData, c *alkira.AlkiraClient) (string, error) {
 	log.Printf("[INFO] Creating Checkpoint service credential")
 
 	credentialName := d.Get("name").(string) + "-" + randomNameSuffix()
-	credential := alkira.CredentialCheckPointFwService{AdminPassword: d.Get("password").(string)}
+	credential := alkira.CredentialCheckPointFwService{AdminPassword: getCheckpointWriteOnlyValue(d, "password")}
 
 	return c.CreateCredential(credentialName, alkira.CredentialTypeChkpFw, credential, 0)
 }
@@ -107,7 +146,7 @@ func expandCheckpointManagementServer(name string, in *schema.Set, m interface{}
 	return mg, nil
 }
 
-func expandCheckpointInstances(in []interface{}, m interface{}) ([]alkira.CheckpointInstance, error) {
+func expandCheckpointInstances(d *schema.ResourceData, in []interface{}, m interface{}) ([]alkira.CheckpointInstance, error) {
 
 	if in == nil || len(in) == 0 {
 		return nil, errors.New("ERROR: Invalid checkpoint firewall instance input")
@@ -120,16 +159,14 @@ func expandCheckpointInstances(in []interface{}, m interface{}) ([]alkira.Checkp
 		r := alkira.CheckpointInstance{}
 		instanceCfg := instance.(map[string]interface{})
 
-		var sicKey string
+		// Read sic_key from raw config (WriteOnly field not available via d.Get)
+		sicKey := getNestedWriteOnlyValue(d, "instance", i, "sic_key")
 
 		if v, ok := instanceCfg["id"].(int); ok {
 			r.Id = v
 		}
 		if v, ok := instanceCfg["name"].(string); ok {
 			r.Name = v
-		}
-		if v, ok := instanceCfg["sic_key"].(string); ok {
-			sicKey = v
 		}
 		if v, ok := instanceCfg["credential_id"].(string); ok {
 			if v == "" {
@@ -272,7 +309,7 @@ func generateCheckpointRequest(d *schema.ResourceData, m interface{}) (*alkira.S
 	//
 	// Instances block
 	//
-	instances, err := expandCheckpointInstances(d.Get("instance").([]interface{}), m)
+	instances, err := expandCheckpointInstances(d, d.Get("instance").([]interface{}), m)
 
 	if err != nil {
 		return nil, err

--- a/alkira/resource_alkira_service_checkpoint_helper.go
+++ b/alkira/resource_alkira_service_checkpoint_helper.go
@@ -2,6 +2,7 @@ package alkira
 
 import (
 	"errors"
+	"fmt"
 	"log"
 
 	"github.com/alkiranet/alkira-client-go/alkira"
@@ -9,8 +10,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-// getCheckpointWriteOnlyValue reads a WriteOnly field from raw config with a d.Get() fallback
-// for import/refresh where GetRawConfigAt is unavailable.
+// getCheckpointWriteOnlyValue reads a WriteOnly field from raw config.
+// WriteOnly fields are never stored in state, so d.GetOk() would always
+// return the zero value — only GetRawConfigAt can read the actual value.
 func getCheckpointWriteOnlyValue(d *schema.ResourceData, field string) string {
 	attrPath := cty.Path{cty.GetAttrStep{Name: field}}
 	val, diags := d.GetRawConfigAt(attrPath)
@@ -19,10 +21,6 @@ func getCheckpointWriteOnlyValue(d *schema.ResourceData, field string) string {
 		if strVal := val.AsString(); strVal != "" {
 			return strVal
 		}
-	}
-
-	if v, ok := d.GetOk(field); ok {
-		return v.(string)
 	}
 
 	return ""
@@ -57,21 +55,71 @@ func createCheckpointCredential(d *schema.ResourceData, c *alkira.AlkiraClient) 
 	return c.CreateCredential(credentialName, alkira.CredentialTypeChkpFw, credential, 0)
 }
 
-// updateCheckpointCredential update checkpoint service credential
+// updateCheckpointCredential always updates the checkpoint service
+// credential because password is WriteOnly and HasChanges cannot
+// detect changes (state is always null for WriteOnly fields).
 func updateCheckpointCredential(d *schema.ResourceData, c *alkira.AlkiraClient) error {
 	log.Printf("[INFO] Updating Checkpoint service credential")
 
-	if d.HasChanges("password") {
-		log.Printf("[INFO] Checkpoint service credential has changed")
-
-		credentialId, err := createCheckpointCredential(d, c)
-		if err != nil {
-			return err
-		}
-		d.Set("credential_id", credentialId)
+	credentialId := d.Get("credential_id").(string)
+	if credentialId == "" {
+		return errors.New("credential_id is empty when updating Checkpoint credential")
 	}
 
-	return nil
+	cred, err := c.GetCredentialById(credentialId)
+	if err != nil {
+		return fmt.Errorf("failed to get checkpoint credential name for ID %s: %w", credentialId, err)
+	}
+
+	credential := alkira.CredentialCheckPointFwService{
+		AdminPassword: getCheckpointWriteOnlyValue(d, "password"),
+	}
+
+	return c.UpdateCredential(credentialId, cred.Name, alkira.CredentialTypeChkpFw, credential, 0)
+}
+
+// updateCheckpointManagementServerCredential always updates the
+// management server credential because password is WriteOnly.
+func updateCheckpointManagementServerCredential(d *schema.ResourceData, c *alkira.AlkiraClient) error {
+	log.Printf("[INFO] Updating Checkpoint management server credential")
+
+	// Read credential_id from management_server TypeSet in state
+	mgSet := d.Get("management_server").(*schema.Set)
+	if mgSet == nil || mgSet.Len() == 0 {
+		return nil
+	}
+
+	// management_server is validated to have exactly 1 element
+	mgList := mgSet.List()
+	cfg := mgList[0].(map[string]interface{})
+
+	configMode, _ := cfg["configuration_mode"].(string)
+	if configMode != "AUTOMATED" {
+		log.Printf("[INFO] Management server configuration_mode is %q, skipping credential update", configMode)
+		return nil
+	}
+
+	credentialId, _ := cfg["credential_id"].(string)
+	password, _ := cfg["password"].(string)
+
+	if credentialId == "" {
+		// No credential exists yet — create one (handles mode transition)
+		log.Printf("[INFO] management_server credential_id is empty, creating credential")
+		name := d.Get("name").(string)
+		manServerCredName := name + "-" + randomNameSuffix()
+		credential := &alkira.CredentialCheckPointFwManagementServer{Password: password}
+		_, err := c.CreateCredential(manServerCredName, alkira.CredentialTypeChkpFwManagement, credential, 0)
+		return err
+	}
+
+	cred, err := c.GetCredentialById(credentialId)
+	if err != nil {
+		return fmt.Errorf("failed to get management server credential name for ID %s: %w", credentialId, err)
+	}
+
+	credential := &alkira.CredentialCheckPointFwManagementServer{Password: password}
+
+	return c.UpdateCredential(credentialId, cred.Name, alkira.CredentialTypeChkpFwManagement, credential, 0)
 }
 
 func expandCheckpointManagementServer(name string, in *schema.Set, m interface{}) (*alkira.CheckpointManagementServer, error) {
@@ -289,7 +337,6 @@ func setCheckpointInstances(d *schema.ResourceData, c []alkira.CheckpointInstanc
 			}
 
 			instances = append(instances, instance)
-			break
 		}
 	}
 

--- a/alkira/resource_alkira_service_checkpoint_helper_test.go
+++ b/alkira/resource_alkira_service_checkpoint_helper_test.go
@@ -25,13 +25,13 @@ func TestCheckpointSegmentOptionsNil(t *testing.T) {
 
 func TestCheckpointInstanceInvalid(t *testing.T) {
 	//test nil Set
-	c, err := expandCheckpointInstances(nil, nil)
+	c, err := expandCheckpointInstances(nil, nil, nil)
 	require.Nil(t, c)
 	require.Error(t, err)
 
 	//test empty Set
 	s := newSetFromCheckpointResource(nil)
-	c, err = expandCheckpointInstances(s.List(), nil)
+	c, err = expandCheckpointInstances(nil, s.List(), nil)
 	require.Nil(t, c)
 	require.Error(t, err)
 }

--- a/docs/resources/service_checkpoint.md
+++ b/docs/resources/service_checkpoint.md
@@ -71,7 +71,7 @@ resource "alkira_service_checkpoint" "test" {
 - `management_server` (Block Set, Min: 1) (see [below for nested schema](#nestedblock--management_server))
 - `max_instance_count` (Number) The maximum number of Checkpoint Firewall instances that should be deployed when auto-scale is enabled. Note that auto-scale is not supported with Checkpoint at this time. `max_instance_count` must be greater than or equal to `min_instance_count`. (**BETA**)
 - `name` (String) Name of the Checkpoint Firewall service.
-- `password` (String) The Checkpoint Firewall service password.
+- `password` (String, Sensitive) The Checkpoint Firewall service password.
 - `segment_id` (String) The ID of the segment associated with the service. Only one segment is supported.
 - `size` (String) The size of the service, one of `SMALL`, `MEDIUM`, `LARGE`.
 - `version` (String) The version of the Checkpoint Firewall. Please check all supported versions from Alkira Portal.
@@ -98,7 +98,7 @@ resource "alkira_service_checkpoint" "test" {
 Required:
 
 - `name` (String) The name of the checkpoint instance.
-- `sic_key` (String) The checkpoint instance sic keys.
+- `sic_key` (String, Sensitive) The checkpoint instance sic keys.
 
 Optional:
 
@@ -123,10 +123,10 @@ Required:
 Optional:
 
 - `domain` (String) Management server domain.
-- `password` (String) The password of the management server.
+- `password` (String, Sensitive) The password of the management server.
 - `reachability` (String) Specifies whether the management server is publicly reachable or not. If the reachability is private then you need to provide the segment to be used to access the management server. Default value is `PUBLIC`.
 - `segment_id` (String) The ID of the segment to be used to access the management server.
-- `username` (String) The username of the management server.
+- `username` (String, Sensitive) The username of the management server.
 
 Read-Only:
 


### PR DESCRIPTION
## Summary

- Add `WriteOnly: true` + `Sensitive: true` to `password` (top-level) and `instance.sic_key`
- Add `Sensitive: true` to `management_server.username` and `management_server.password` (WriteOnly not supported in TypeSet blocks)
- Add `getCheckpointWriteOnlyValue()` and `getNestedWriteOnlyValue()` helpers using `GetRawConfigAt()`
- Update `expandCheckpointInstances` to read `sic_key` from raw config via indexed cty path

## Problem

Checkpoint service credential fields (`password`, `sic_key`) were stored in plaintext in Terraform state. On import, Required WriteOnly fields caused errors because the API does not return credential values.

## Solution

Mark `password` and `instance.sic_key` as `WriteOnly: true` + `Sensitive: true`. For nested `sic_key` inside the `instance` TypeList block, `d.Get("instance")` returns empty strings for WriteOnly fields — fixed by using `GetRawConfigAt` with indexed cty paths: `cty.Path{block, index, field}`.

Management server `username`/`password` get `Sensitive: true` only — the Terraform SDK does not support WriteOnly inside NestingSet (TypeSet) blocks.

## Changes

- `alkira/resource_alkira_service_checkpoint.go` — Add WriteOnly+Sensitive to `password`, `sic_key`; add Sensitive to management_server fields
- `alkira/resource_alkira_service_checkpoint_helper.go` — Add `getCheckpointWriteOnlyValue()` and `getNestedWriteOnlyValue()` helpers; update `createCheckpointCredential` and `expandCheckpointInstances` to use them
- `alkira/resource_alkira_service_checkpoint_helper_test.go` — Update test signatures for new `expandCheckpointInstances` parameter
- `docs/resources/service_checkpoint.md` — Regenerated docs

## Testing Performed

### Unit Tests

- `go test ./alkira/...` — All pass (0 failures)
- `make lint` — 0 issues
- `make build` — Clean

### Greenfield CRUD

**Test environment:** `test/AK-66661-checkpoint-writeonly/`

- Create — `password` shows `(write-only attribute)`, `sic_key` shows `(write-only attribute)`, credentials sent to API
- **KEY TEST:** State verification — `password` = `null`, `instance.sic_key` = `null` in state
- API payload confirms `adminPassword` and `sicKey` correctly sent via `GetRawConfigAt`
- Update (description) — Same ID, full payload
- Idempotency — No WriteOnly drift (pre-existing management_server TypeSet diff only)

### Import

- `terraform state rm` + `terraform import` — Successful
- **KEY TEST:** Post-import plan shows no password/sic_key drift

### Brownfield Upgrade (Registry -> Fixed Build)

**Test environment:** `test/AK-66661-checkpoint-writeonly/brownfield/`

- Create with registry — `password: "BrownfieldChkp2024"`, `sic_key: "bfSicKey2024abcd"` in plaintext state (the bug)
- Upgrade plan — No WriteOnly drift
- **KEY TEST:** `terraform refresh` scrubs plaintext credentials from state (values become `null`)
- Brownfield destroy — Clean

### Code Quality

- `make lint` — 0 issues
- `make build` — Clean
- `make doc` — Regenerated