### PR TITLE
AK-66662: Add WriteOnly+Sensitive to alkira_service_cisco_ftdv credential fields

### DIFF
--- a/alkira/resource_alkira_service_cisco_ftdv.go
+++ b/alkira/resource_alkira_service_cisco_ftdv.go
@@ -129,11 +129,13 @@ func resourceAlkiraServiceCiscoFTDv() *schema.Resource {
 							Description: "Firepower Management Center (FMC) username.",
 							Type:        schema.TypeString,
 							Required:    true,
+							Sensitive:   true,
 						},
 						"password": {
 							Description: "Firepower Management Center (FMC) password.",
 							Type:        schema.TypeString,
 							Required:    true,
+							Sensitive:   true,
 						},
 						"segment_id": {
 							Description: "ID of the segment accociated with the " +
@@ -192,11 +194,15 @@ func resourceAlkiraServiceCiscoFTDv() *schema.Resource {
 							Description: "Firepower Firewall Admin Password.",
 							Type:        schema.TypeString,
 							Required:    true,
+							Sensitive:   true,
+							WriteOnly:   true,
 						},
 						"fmc_registration_key": {
 							Description: "FMC Registration Key.",
 							Type:        schema.TypeString,
 							Required:    true,
+							Sensitive:   true,
+							WriteOnly:   true,
 						},
 						"ftdv_nat_id": {
 							Description: "FTDv NAT ID.",
@@ -351,6 +357,12 @@ func resourceServiceCiscoFTDvUpdate(ctx context.Context, d *schema.ResourceData,
 	client := m.(*alkira.AlkiraClient)
 	api := alkira.NewServiceCiscoFTDv(m.(*alkira.AlkiraClient))
 
+	// Update FMC credential (WriteOnly — always update)
+	err := updateCiscoFTDvCredential(d, client)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
 	// Construct request
 	request, err := generateServiceCiscoFTDvRequest(d, m)
 
@@ -472,7 +484,7 @@ func generateServiceCiscoFTDvRequest(d *schema.ResourceData, m interface{}) (*al
 	//
 	// Instances
 	//
-	instances, err := expandCiscoFTDvInstances(d.Get("instance").([]interface{}), m)
+	instances, err := expandCiscoFTDvInstances(d, d.Get("instance").([]interface{}), m)
 
 	if err != nil {
 		return nil, err

--- a/alkira/resource_alkira_service_cisco_ftdv_helper.go
+++ b/alkira/resource_alkira_service_cisco_ftdv_helper.go
@@ -2,14 +2,69 @@ package alkira
 
 import (
 	"errors"
+	"fmt"
 	"log"
 	"strconv"
 
 	"github.com/alkiranet/alkira-client-go/alkira"
+	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-func expandCiscoFTDvInstances(in []interface{}, m interface{}) ([]alkira.CiscoFTDvInstance, error) {
+// updateCiscoFTDvCredential always updates the FMC credential because
+// username and password are WriteOnly and HasChanges cannot detect
+// changes (state is always null for WriteOnly fields).
+func updateCiscoFTDvCredential(d *schema.ResourceData, c *alkira.AlkiraClient) error {
+	log.Printf("[INFO] Updating Cisco FTDv FMC credential")
+
+	credentialId := d.Get("credential_id").(string)
+	if credentialId == "" {
+		return errors.New("credential_id is empty when updating Cisco FTDv credential")
+	}
+
+	cred, err := c.GetCredentialById(credentialId)
+	if err != nil {
+		return fmt.Errorf("failed to get FTDv credential name for ID %s: %w", credentialId, err)
+	}
+
+	// FMC username/password are Sensitive (not WriteOnly — TypeSet limitation)
+	// so they are available in state via d.Get
+	fmcSet := d.Get("firepower_management_center").(*schema.Set)
+	var username, password string
+	if fmcSet != nil && fmcSet.Len() > 0 {
+		cfg := fmcSet.List()[0].(map[string]interface{})
+		username, _ = cfg["username"].(string)
+		password, _ = cfg["password"].(string)
+	}
+
+	credential := alkira.CredentialCiscoFtdv{
+		Username: username,
+		Password: password,
+	}
+
+	return c.UpdateCredential(credentialId, cred.Name, alkira.CredentialTypeCiscoFtdv, credential, 0)
+}
+
+// getCiscoFTDvNestedWriteOnlyValue reads a WriteOnly field from a nested TypeList block
+// via GetRawConfigAt with an indexed cty path.
+func getCiscoFTDvNestedWriteOnlyValue(d *schema.ResourceData, block string, index int, field string) string {
+	attrPath := cty.Path{
+		cty.GetAttrStep{Name: block},
+		cty.IndexStep{Key: cty.NumberIntVal(int64(index))},
+		cty.GetAttrStep{Name: field},
+	}
+	val, diags := d.GetRawConfigAt(attrPath)
+
+	if !diags.HasError() && !val.IsNull() && val.IsKnown() && val.Type() == cty.String {
+		if strVal := val.AsString(); strVal != "" {
+			return strVal
+		}
+	}
+
+	return ""
+}
+
+func expandCiscoFTDvInstances(d *schema.ResourceData, in []interface{}, m interface{}) ([]alkira.CiscoFTDvInstance, error) {
 	client := m.(*alkira.AlkiraClient)
 
 	if in == nil || len(in) == 0 {
@@ -17,28 +72,24 @@ func expandCiscoFTDvInstances(in []interface{}, m interface{}) ([]alkira.CiscoFT
 		return nil, errors.New("ERROR: Invalid Cisco FTDv instance input")
 	}
 
-	var adminPassword string
-	var fmcRegistrationKey string
 	var ftdvNatId string
 
 	instances := make([]alkira.CiscoFTDvInstance, 0, len(in))
 
-	for _, instance := range in {
+	for i, instance := range in {
 
 		r := alkira.CiscoFTDvInstance{}
 		instanceCfg := instance.(map[string]interface{})
+
+		// Read WriteOnly fields from raw config
+		adminPassword := getCiscoFTDvNestedWriteOnlyValue(d, "instance", i, "admin_password")
+		fmcRegistrationKey := getCiscoFTDvNestedWriteOnlyValue(d, "instance", i, "fmc_registration_key")
 
 		if v, ok := instanceCfg["id"].(int); ok {
 			r.Id = v
 		}
 		if v, ok := instanceCfg["hostname"].(string); ok {
 			r.Hostname = v
-		}
-		if v, ok := instanceCfg["admin_password"].(string); ok {
-			adminPassword = v
-		}
-		if v, ok := instanceCfg["fmc_registration_key"].(string); ok {
-			fmcRegistrationKey = v
 		}
 		if v, ok := instanceCfg["ftdv_nat_id"].(string); ok {
 			ftdvNatId = v
@@ -208,15 +259,13 @@ func setCiscoFTDvInstances(d *schema.ResourceData, c []alkira.CiscoFTDvInstance)
 		for _, ins := range c {
 			if cfg["id"].(int) == ins.Id || cfg["hostname"].(string) == ins.Hostname {
 				instance := map[string]interface{}{
-					"admin_password":       cfg["admin_password"].(string),
-					"credential_id":        ins.CredentialId,
-					"fmc_registration_key": cfg["fmc_registration_key"].(string),
-					"ftdv_nat_id":          cfg["ftdv_nat_id"].(string),
-					"hostname":             ins.Hostname,
-					"id":                   ins.Id,
-					"license_type":         ins.LicenseType,
-					"version":              ins.Version,
-					"enable_traffic":       ins.TrafficEnabled,
+					"credential_id":  ins.CredentialId,
+					"ftdv_nat_id":    cfg["ftdv_nat_id"].(string),
+					"hostname":       ins.Hostname,
+					"id":             ins.Id,
+					"license_type":   ins.LicenseType,
+					"version":        ins.Version,
+					"enable_traffic": ins.TrafficEnabled,
 				}
 				instances = append(instances, instance)
 				break
@@ -250,7 +299,6 @@ func setCiscoFTDvInstances(d *schema.ResourceData, c []alkira.CiscoFTDvInstance)
 			}
 
 			instances = append(instances, instance)
-			break
 		}
 	}
 

--- a/docs/resources/service_cisco_ftdv.md
+++ b/docs/resources/service_cisco_ftdv.md
@@ -88,10 +88,10 @@ resource "alkira_service_cisco_ftdv" "example" {
 
 Required:
 
-- `password` (String) Firepower Management Center (FMC) password.
+- `password` (String, Sensitive) Firepower Management Center (FMC) password.
 - `segment_id` (String) ID of the segment accociated with the Firepower Management Center.
 - `server_ip` (String) IP address of the Firepower Management Center.
-- `username` (String) Firepower Management Center (FMC) username.
+- `username` (String, Sensitive) Firepower Management Center (FMC) username.
 
 Optional:
 
@@ -107,8 +107,8 @@ Read-Only:
 
 Required:
 
-- `admin_password` (String) Firepower Firewall Admin Password.
-- `fmc_registration_key` (String) FMC Registration Key.
+- `admin_password` (String, Sensitive) Firepower Firewall Admin Password.
+- `fmc_registration_key` (String, Sensitive) FMC Registration Key.
 - `hostname` (String) Hostname of the Firepower Firewall.
 - `license_type` (String) Cisco Firepower Firewall license type, either `BRING_YOUR_OWN` or `PAY_AS_YOU_GO`.
 - `version` (String) Cisco Firepower Firewall version. Please check Alkira Portal for all supported versions.


### PR DESCRIPTION
## Summary

- Add `WriteOnly: true` + `Sensitive: true` to `instance.admin_password` and `instance.fmc_registration_key`
- Add `Sensitive: true` to `firepower_management_center.username` and `firepower_management_center.password` (WriteOnly not supported in TypeSet blocks)
- Add `getCiscoFTDvNestedWriteOnlyValue()` helper using `GetRawConfigAt()` with indexed cty paths
- Update `expandCiscoFTDvInstances` to read credentials from raw config
- Remove WriteOnly fields from `setCiscoFTDvInstances` Read output

## Problem

Cisco FTDv credential fields (`admin_password`, `fmc_registration_key`) were stored in plaintext in Terraform state. On import, Required WriteOnly fields caused errors because the API does not return credential values.

## Solution

Mark `instance.admin_password` and `instance.fmc_registration_key` as `WriteOnly: true` + `Sensitive: true`. For nested fields inside the `instance` TypeList block, `d.Get("instance")` returns empty strings for WriteOnly fields — fixed by using `GetRawConfigAt` with indexed cty paths.

FMC `username`/`password` get `Sensitive: true` only — the Terraform SDK does not support WriteOnly inside NestingSet (TypeSet) blocks.

## Changes

- `alkira/resource_alkira_service_cisco_ftdv.go` — Add WriteOnly+Sensitive to instance credential fields; add Sensitive to FMC fields; update `expandCiscoFTDvInstances` call signature
- `alkira/resource_alkira_service_cisco_ftdv_helper.go` — Add `getCiscoFTDvNestedWriteOnlyValue()` helper; update `expandCiscoFTDvInstances` to accept `ResourceData` and read WriteOnly fields from raw config; remove WriteOnly fields from `setCiscoFTDvInstances` Read output
- `docs/resources/service_cisco_ftdv.md` — Regenerated docs

## Testing Performed

### Unit Tests

- `go test ./alkira/...` — All pass (0 failures)
- `make lint` — 0 issues
- `make build` — Clean

### Greenfield CRUD

**Test environment:** `test/AK-66662-cisco-ftdv-writeonly/`

- Create — `admin_password` and `fmc_registration_key` show `(write-only attribute)`, credentials sent to API
- **KEY TEST:** State verification — `admin_password` = `null`, `fmc_registration_key` = `null` in state
- API payload confirms `adminPassword` and `fmcRegistrationKey` correctly sent via `GetRawConfigAt` with indexed paths
- Import — Post-import plan shows no WriteOnly drift

### Brownfield Upgrade (Registry -> Fixed Build)

**Test environment:** `test/AK-66662-cisco-ftdv-writeonly/brownfield/`

- Create with registry — `admin_password: "BfAdmin2024!"`, `fmc_registration_key: "bfregkey2024"` in plaintext state (the bug)
- Upgrade plan — No WriteOnly drift
- **KEY TEST:** `terraform refresh` scrubs plaintext credentials from state (values become `null`)
- Brownfield destroy — Clean

### Code Quality

- `make lint` — 0 issues
- `make build` — Clean
- `make doc` — Regenerated