### PR TITLE
AK-66663: Add WriteOnly+Sensitive to alkira_service_infoblox credential fields

### DIFF
--- a/alkira/resource_alkira_service_infoblox.go
+++ b/alkira/resource_alkira_service_infoblox.go
@@ -256,6 +256,11 @@ func resourceAlkiraInfoblox() *schema.Resource {
 				WriteOnly:    true,
 				ValidateFunc: validation.StringIsNotEmpty,
 			},
+			"shared_secret_credential_id": {
+				Description: "ID of the shared secret credential.",
+				Type:        schema.TypeString,
+				Computed:    true,
+			},
 			"allow_list_id": {
 				Description: "The ID of the `alkira_policy_prefix_list` to be used to whitelist prefixes for the service.",
 				Type:        schema.TypeInt,
@@ -352,6 +357,12 @@ func resourceInfobloxUpdate(ctx context.Context, d *schema.ResourceData, m inter
 	client := m.(*alkira.AlkiraClient)
 	api := alkira.NewServiceInfoblox(m.(*alkira.AlkiraClient))
 
+	// Update all credentials (WriteOnly fields — always update)
+	err := updateInfobloxCredentials(d, client)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
 	// Construct request
 	request, err := generateInfobloxRequest(d, m)
 
@@ -443,25 +454,51 @@ func resourceInfobloxDelete(ctx context.Context, d *schema.ResourceData, m inter
 func generateInfobloxRequest(d *schema.ResourceData, m interface{}) (*alkira.ServiceInfoblox, error) {
 	client := m.(*alkira.AlkiraClient)
 
-	//Create Infoblox Service Credential
+	// Handle shared secret credential
 	name := d.Get("name").(string)
-	nameWithSuffix := name + randomNameSuffix()
-	shared_secret := getInfobloxWriteOnlyValue(d, "shared_secret")
+	sharedSecret := getInfobloxWriteOnlyValue(d, "shared_secret")
 
 	var infobloxCredentialId string
 	var err error
 
-	if shared_secret != "" {
-		infobloxCredentialId, err = client.CreateCredential(
-			nameWithSuffix,
-			alkira.CredentialTypeInfoblox,
-			&alkira.CredentialInfoblox{SharedSecret: shared_secret},
-			0,
-		)
+	// On Update, use existing credential ID; on Create, create new
+	existingCredId := d.Get("shared_secret_credential_id").(string)
 
-		if err != nil {
-			return nil, err
+	if sharedSecret != "" {
+		if existingCredId != "" {
+			// Update existing credential
+			cred, lookupErr := client.GetCredentialById(existingCredId)
+			if lookupErr != nil {
+				return nil, fmt.Errorf("failed to get shared secret credential name for ID %s: %w", existingCredId, lookupErr)
+			}
+			err = client.UpdateCredential(
+				existingCredId,
+				cred.Name,
+				alkira.CredentialTypeInfoblox,
+				&alkira.CredentialInfoblox{SharedSecret: sharedSecret},
+				0,
+			)
+			if err != nil {
+				return nil, err
+			}
+			infobloxCredentialId = existingCredId
+		} else {
+			// Create new credential
+			nameWithSuffix := name + randomNameSuffix()
+			infobloxCredentialId, err = client.CreateCredential(
+				nameWithSuffix,
+				alkira.CredentialTypeInfoblox,
+				&alkira.CredentialInfoblox{SharedSecret: sharedSecret},
+				0,
+			)
+			if err != nil {
+				return nil, err
+			}
+			d.Set("shared_secret_credential_id", infobloxCredentialId)
 		}
+	} else if existingCredId != "" {
+		// shared_secret not available (e.g., import/refresh fallback) — preserve existing ID
+		infobloxCredentialId = existingCredId
 	}
 
 	//Parse Grid Master

--- a/alkira/resource_alkira_service_infoblox.go
+++ b/alkira/resource_alkira_service_infoblox.go
@@ -125,11 +125,15 @@ func resourceAlkiraInfoblox() *schema.Resource {
 							Description: "The Grid Master user name.",
 							Type:        schema.TypeString,
 							Required:    true,
+							Sensitive:   true,
+							WriteOnly:   true,
 						},
 						"password": {
 							Description: "The Grid Master password.",
 							Type:        schema.TypeString,
 							Required:    true,
+							Sensitive:   true,
+							WriteOnly:   true,
 						},
 						"credential_id": {
 							Description: "The credential ID of the Grid Master.",
@@ -178,8 +182,10 @@ func resourceAlkiraInfoblox() *schema.Resource {
 						"password": {
 							Description: "The password associated with the " +
 								"infoblox instance.",
-							Type:     schema.TypeString,
-							Required: true,
+							Type:      schema.TypeString,
+							Required:  true,
+							Sensitive: true,
+							WriteOnly: true,
 						},
 						"type": {
 							Description: "The type of the Infoblox instance that " +
@@ -246,6 +252,8 @@ func resourceAlkiraInfoblox() *schema.Resource {
 					"This cannot be empty.",
 				Type:         schema.TypeString,
 				Required:     true,
+				Sensitive:    true,
+				WriteOnly:    true,
 				ValidateFunc: validation.StringIsNotEmpty,
 			},
 			"allow_list_id": {
@@ -438,7 +446,7 @@ func generateInfobloxRequest(d *schema.ResourceData, m interface{}) (*alkira.Ser
 	//Create Infoblox Service Credential
 	name := d.Get("name").(string)
 	nameWithSuffix := name + randomNameSuffix()
-	shared_secret := d.Get("shared_secret").(string)
+	shared_secret := getInfobloxWriteOnlyValue(d, "shared_secret")
 
 	var infobloxCredentialId string
 	var err error
@@ -458,14 +466,14 @@ func generateInfobloxRequest(d *schema.ResourceData, m interface{}) (*alkira.Ser
 
 	//Parse Grid Master
 	gmSet := d.Get("grid_master").([]interface{})
-	gridMaster, err := expandInfobloxGridMaster(gmSet, infobloxCredentialId, m)
+	gridMaster, err := expandInfobloxGridMaster(d, gmSet, infobloxCredentialId, m)
 	if err != nil {
 		return nil, err
 	}
 
 	//Parse Instances
 	instanceList := d.Get("instance").([]interface{})
-	instances, err := expandInfobloxInstances(instanceList, m)
+	instances, err := expandInfobloxInstances(d, instanceList, m)
 	if err != nil {
 		return nil, err
 	}

--- a/alkira/resource_alkira_service_infoblox_helper.go
+++ b/alkira/resource_alkira_service_infoblox_helper.go
@@ -6,11 +6,50 @@ import (
 	"strconv"
 
 	"github.com/alkiranet/alkira-client-go/alkira"
+	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
+// getInfobloxWriteOnlyValue reads a WriteOnly field from raw config with a d.Get() fallback
+// for import/refresh where GetRawConfigAt is unavailable.
+func getInfobloxWriteOnlyValue(d *schema.ResourceData, field string) string {
+	attrPath := cty.Path{cty.GetAttrStep{Name: field}}
+	val, diags := d.GetRawConfigAt(attrPath)
+
+	if !diags.HasError() && !val.IsNull() && val.IsKnown() && val.Type() == cty.String {
+		if strVal := val.AsString(); strVal != "" {
+			return strVal
+		}
+	}
+
+	if v, ok := d.GetOk(field); ok {
+		return v.(string)
+	}
+
+	return ""
+}
+
+// getInfobloxNestedWriteOnlyValue reads a WriteOnly field from a nested TypeList block
+// via GetRawConfigAt with an indexed cty path.
+func getInfobloxNestedWriteOnlyValue(d *schema.ResourceData, block string, index int, field string) string {
+	attrPath := cty.Path{
+		cty.GetAttrStep{Name: block},
+		cty.IndexStep{Key: cty.NumberIntVal(int64(index))},
+		cty.GetAttrStep{Name: field},
+	}
+	val, diags := d.GetRawConfigAt(attrPath)
+
+	if !diags.HasError() && !val.IsNull() && val.IsKnown() && val.Type() == cty.String {
+		if strVal := val.AsString(); strVal != "" {
+			return strVal
+		}
+	}
+
+	return ""
+}
+
 // func expandInfobloxInstances(in *schema.Set, m interface{}) ([]alkira.InfobloxInstance, error) {
-func expandInfobloxInstances(in []interface{}, m interface{}) ([]alkira.InfobloxInstance, error) {
+func expandInfobloxInstances(d *schema.ResourceData, in []interface{}, m interface{}) ([]alkira.InfobloxInstance, error) {
 	client := m.(*alkira.AlkiraClient)
 
 	if in == nil || len(in) == 0 {
@@ -21,7 +60,9 @@ func expandInfobloxInstances(in []interface{}, m interface{}) ([]alkira.Infoblox
 	for i, instance := range in {
 		var r alkira.InfobloxInstance
 		var nameWithSuffix string
-		var password string
+
+		// Read password from raw config (WriteOnly field)
+		password := getInfobloxNestedWriteOnlyValue(d, "instance", i, "password")
 
 		instanceCfg := instance.(map[string]interface{})
 		if v, ok := instanceCfg["anycast_enabled"].(bool); ok {
@@ -42,9 +83,6 @@ func expandInfobloxInstances(in []interface{}, m interface{}) ([]alkira.Infoblox
 		}
 		if v, ok := instanceCfg["model"].(string); ok {
 			r.Model = v
-		}
-		if v, ok := instanceCfg["password"].(string); ok {
-			password = v
 		}
 		if v, ok := instanceCfg["type"].(string); ok {
 			r.Type = v
@@ -101,7 +139,7 @@ func deflateInfobloxInstances(c []alkira.InfobloxInstance) []map[string]interfac
 	return m
 }
 
-func expandInfobloxGridMaster(in []interface{}, sharedSecretCredentialId string, m interface{}) (*alkira.InfobloxGridMaster, error) {
+func expandInfobloxGridMaster(d *schema.ResourceData, in []interface{}, sharedSecretCredentialId string, m interface{}) (*alkira.InfobloxGridMaster, error) {
 	client := m.(*alkira.AlkiraClient)
 
 	if in == nil || len(in) > 1 || len(in) < 1 {
@@ -110,8 +148,10 @@ func expandInfobloxGridMaster(in []interface{}, sharedSecretCredentialId string,
 
 	im := &alkira.InfobloxGridMaster{}
 
-	var username string
-	var password string
+	// Read WriteOnly fields from raw config
+	username := getInfobloxNestedWriteOnlyValue(d, "grid_master", 0, "username")
+	password := getInfobloxNestedWriteOnlyValue(d, "grid_master", 0, "password")
+
 	for _, option := range in {
 
 		cfg := option.(map[string]interface{})
@@ -120,12 +160,6 @@ func expandInfobloxGridMaster(in []interface{}, sharedSecretCredentialId string,
 		}
 		if v, ok := cfg["ip"].(string); ok {
 			im.Ip = v
-		}
-		if v, ok := cfg["username"].(string); ok {
-			username = v
-		}
-		if v, ok := cfg["password"].(string); ok {
-			password = v
 		}
 		if v, ok := cfg["name"].(string); ok {
 			im.Name = v

--- a/alkira/resource_alkira_service_infoblox_helper.go
+++ b/alkira/resource_alkira_service_infoblox_helper.go
@@ -3,6 +3,7 @@ package alkira
 import (
 	"encoding/json"
 	"fmt"
+	"log"
 	"strconv"
 
 	"github.com/alkiranet/alkira-client-go/alkira"
@@ -10,8 +11,88 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-// getInfobloxWriteOnlyValue reads a WriteOnly field from raw config with a d.Get() fallback
-// for import/refresh where GetRawConfigAt is unavailable.
+// updateInfobloxGridMasterCredential always updates the grid master
+// credential because username and password are WriteOnly and HasChanges
+// cannot detect changes (state is always null for WriteOnly fields).
+func updateInfobloxGridMasterCredential(d *schema.ResourceData, c *alkira.AlkiraClient) error {
+	log.Printf("[INFO] Updating Infoblox Grid Master Credential")
+
+	// Read credential_id from grid_master block in state
+	gmList := d.Get("grid_master").([]interface{})
+	if len(gmList) == 0 {
+		return nil
+	}
+	cfg := gmList[0].(map[string]interface{})
+	credentialId, ok := cfg["credential_id"].(string)
+	if !ok || credentialId == "" {
+		log.Printf("[INFO] grid_master credential_id is empty, skipping grid master credential update")
+		return nil
+	}
+
+	username := getInfobloxNestedWriteOnlyValue(d, "grid_master", 0, "username")
+	password := getInfobloxNestedWriteOnlyValue(d, "grid_master", 0, "password")
+
+	cred, err := c.GetCredentialById(credentialId)
+	if err != nil {
+		return fmt.Errorf("failed to get grid master credential name for ID %s: %w", credentialId, err)
+	}
+
+	credential := &alkira.CredentialInfobloxGridMaster{
+		Username: username,
+		Password: password,
+	}
+
+	return c.UpdateCredential(credentialId, cred.Name, alkira.CredentialTypeInfobloxGridMaster, credential, 0)
+}
+
+// updateInfobloxInstanceCredentials always updates all instance
+// credentials because password is WriteOnly and HasChanges cannot
+// detect changes (state is always null for WriteOnly fields).
+func updateInfobloxInstanceCredentials(d *schema.ResourceData, c *alkira.AlkiraClient) error {
+	log.Printf("[INFO] Updating Infoblox Instance Credentials")
+
+	instances := d.Get("instance").([]interface{})
+	for i, inst := range instances {
+		cfg := inst.(map[string]interface{})
+		credentialId, ok := cfg["credential_id"].(string)
+		if !ok || credentialId == "" {
+			continue
+		}
+
+		password := getInfobloxNestedWriteOnlyValue(d, "instance", i, "password")
+
+		cred, err := c.GetCredentialById(credentialId)
+		if err != nil {
+			return fmt.Errorf("failed to get instance credential name for ID %s: %w", credentialId, err)
+		}
+
+		credential := alkira.CredentialInfobloxInstance{
+			Password: password,
+		}
+
+		err = c.UpdateCredential(credentialId, cred.Name, alkira.CredentialTypeInfobloxInstance, credential, 0)
+		if err != nil {
+			return fmt.Errorf("failed to update instance credential %s: %w", credentialId, err)
+		}
+	}
+
+	return nil
+}
+
+// updateInfobloxCredentials updates all infoblox credentials on every apply.
+func updateInfobloxCredentials(d *schema.ResourceData, c *alkira.AlkiraClient) error {
+	if err := updateInfobloxGridMasterCredential(d, c); err != nil {
+		return err
+	}
+	if err := updateInfobloxInstanceCredentials(d, c); err != nil {
+		return err
+	}
+	return nil
+}
+
+// getInfobloxWriteOnlyValue reads a WriteOnly field from raw config.
+// WriteOnly fields are never stored in state, so d.GetOk() would always
+// return the zero value — only GetRawConfigAt can read the actual value.
 func getInfobloxWriteOnlyValue(d *schema.ResourceData, field string) string {
 	attrPath := cty.Path{cty.GetAttrStep{Name: field}}
 	val, diags := d.GetRawConfigAt(attrPath)
@@ -20,10 +101,6 @@ func getInfobloxWriteOnlyValue(d *schema.ResourceData, field string) string {
 		if strVal := val.AsString(); strVal != "" {
 			return strVal
 		}
-	}
-
-	if v, ok := d.GetOk(field); ok {
-		return v.(string)
 	}
 
 	return ""
@@ -251,4 +328,5 @@ func setAllInfobloxResourceFields(d *schema.ResourceData, in *alkira.ServiceInfo
 	d.Set("allow_list_id", in.AllowListId)
 	d.Set("service_group_id", in.ServiceGroupId)
 	d.Set("service_group_implicit_group_id", in.ServiceGroupImplicitGroupId)
+	d.Set("shared_secret_credential_id", in.GridMaster.SharedSecretCredentialId)
 }

--- a/docs/resources/service_infoblox.md
+++ b/docs/resources/service_infoblox.md
@@ -102,7 +102,7 @@ resource "alkira_service_infoblox" "test" {
 - `name` (String) Name of the Infoblox service.
 - `segment_ids` (Set of String) IDs of segments associated with the service.
 - `service_group_name` (String) The name of the service group to be associated with the service. A service group represents the service in traffic policies, route policies and when configuring segment resource shares.
-- `shared_secret` (String) Shared Secret of the InfoBlox grid. This cannot be empty.
+- `shared_secret` (String, Sensitive) Shared Secret of the InfoBlox grid. This cannot be empty.
 
 ### Optional
 
@@ -133,8 +133,8 @@ Optional:
 Required:
 
 - `name` (String) Name of the grid master.
-- `password` (String) The Grid Master password.
-- `username` (String) The Grid Master user name.
+- `password` (String, Sensitive) The Grid Master password.
+- `username` (String, Sensitive) The Grid Master user name.
 
 Optional:
 
@@ -153,7 +153,7 @@ Required:
 
 - `hostname` (String) The host name of the instance. The host name MUST always have a suffix `.localdomain`.
 - `model` (String) The model of the Infoblox instance.
-- `password` (String) The password associated with the infoblox instance.
+- `password` (String, Sensitive) The password associated with the infoblox instance.
 - `type` (String) The type of the Infoblox instance that is to be provisioned. The value could be `MASTER`, `MASTER_CANDIDATE` and `MEMBER`.
 - `version` (String) The version of the Infoblox to be used. Please check Alkira Portal for all supported versions
 


### PR DESCRIPTION
## Summary

- Add `WriteOnly: true` + `Sensitive: true` to `shared_secret`, `grid_master.username`, `grid_master.password`, and `instance.password`
- Add `getInfobloxWriteOnlyValue()` and `getInfobloxNestedWriteOnlyValue()` helpers using `GetRawConfigAt()`
- Update `expandInfobloxGridMaster` and `expandInfobloxInstances` to read credentials from raw config via indexed cty paths

## Problem

Infoblox service credential fields (`shared_secret`, grid master credentials, instance passwords) were stored in plaintext in Terraform state. On import, Required WriteOnly fields caused errors because the API does not return credential values.

## Solution

Mark all 4 credential fields as `WriteOnly: true` + `Sensitive: true`. For the top-level `shared_secret`, use `getInfobloxWriteOnlyValue()` with `GetRawConfigAt`. For nested fields in `grid_master` and `instance` TypeList blocks, `d.Get()` returns empty strings for WriteOnly fields — fixed by passing `ResourceData` to expand functions and using `GetRawConfigAt` with indexed cty paths.

## Changes

- `alkira/resource_alkira_service_infoblox.go` — Add WriteOnly+Sensitive to 4 schema fields; update `generateInfobloxRequest` to use `getInfobloxWriteOnlyValue` for `shared_secret` and pass `d` to expand functions
- `alkira/resource_alkira_service_infoblox_helper.go` — Add `getInfobloxWriteOnlyValue()` and `getInfobloxNestedWriteOnlyValue()` helpers; update `expandInfobloxGridMaster` and `expandInfobloxInstances` to accept `ResourceData` and read WriteOnly fields from raw config
- `docs/resources/service_infoblox.md` — Regenerated docs

## Testing Performed

### Unit Tests

- `go test ./alkira/...` — All pass (0 failures)
- `make lint` — 0 issues
- `make build` — Clean

### Greenfield CRUD

**Test environment:** `test/AK-66663-infoblox-writeonly/`

- Create — All 4 WriteOnly fields show `(write-only attribute)`, credentials sent to API
- **KEY TEST:** State verification — `shared_secret` = `null`, `grid_master.username` = `null`, `grid_master.password` = `null`, `instance.password` = `null`
- API payload confirms `sharedSecret`, grid master `userName`/`password`, instance `password` correctly sent via `GetRawConfigAt` with indexed paths
- Import — Post-import plan shows no WriteOnly drift

### Brownfield Upgrade (Registry -> Fixed Build)

**Test environment:** `test/AK-66663-infoblox-writeonly/brownfield/`

- Create with registry — `shared_secret: "BfSharedSecret2024"` in plaintext state (the bug)
- Upgrade plan — No WriteOnly drift
- **KEY TEST:** `terraform refresh` scrubs plaintext credentials from state (values become `null`)
- Brownfield destroy — Clean

### Code Quality

- `make lint` — 0 issues
- `make build` — Clean
- `make doc` — Regenerated