### PR TITLE
AK-67049: Filter backend-injected ALKIRA_MGMT_ZONE from segment_options

### DIFF
--- a/alkira/helper.go
+++ b/alkira/helper.go
@@ -74,11 +74,21 @@ func expandSegmentOptions(in *schema.Set, m interface{}) (alkira.SegmentNameToZo
 	return segmentOptions, nil
 }
 
+// alkiraManagementZoneName is the backend-injected management zone
+// that should be filtered from Terraform state to prevent perpetual
+// drift. The backend auto-creates this zone for all firewall services
+// but users never configure it in HCL.
+const alkiraManagementZoneName = "ALKIRA_MGMT_ZONE"
+
 func deflateSegmentOptions(c alkira.SegmentNameToZone) []map[string]interface{} {
 	var options []map[string]interface{}
 
 	for _, outerZoneToGroups := range c {
 		for zone, groups := range outerZoneToGroups.ZonesToGroups {
+			if zone == alkiraManagementZoneName {
+				log.Printf("[DEBUG] Filtering out backend-injected %s from segment_options", alkiraManagementZoneName)
+				continue
+			}
 			i := map[string]interface{}{
 				"segment_id": strconv.Itoa(outerZoneToGroups.SegmentId),
 				"zone_name":  zone,

--- a/alkira/helper_test.go
+++ b/alkira/helper_test.go
@@ -455,6 +455,56 @@ func TestDeflateSegmentOptionsCanBeSetInTerraformState(t *testing.T) {
 	assert.True(t, foundUntrustZone, "untrust-zone should be in segment_options")
 }
 
+func TestDeflateSegmentOptionsFiltersManagementZone(t *testing.T) {
+	zonesToGroups := make(alkira.ZoneToGroups)
+	zonesToGroups["trust-zone"] = []string{"group1"}
+	zonesToGroups["ALKIRA_MGMT_ZONE"] = []string{}
+
+	segmentOptions := make(alkira.SegmentNameToZone)
+	segmentOptions["segment1"] = alkira.OuterZoneToGroups{
+		SegmentId:     100,
+		ZonesToGroups: zonesToGroups,
+	}
+
+	result := deflateSegmentOptions(segmentOptions)
+
+	assert.Len(t, result, 1, "ALKIRA_MGMT_ZONE should be filtered out")
+	assert.Equal(t, "trust-zone", result[0]["zone_name"])
+	assert.Equal(t, "100", result[0]["segment_id"])
+}
+
+func TestDeflateSegmentOptionsFiltersManagementZoneMultipleSegments(t *testing.T) {
+	zones1 := make(alkira.ZoneToGroups)
+	zones1["trust-zone"] = []string{"group1"}
+	zones1["ALKIRA_MGMT_ZONE"] = []string{}
+
+	zones2 := make(alkira.ZoneToGroups)
+	zones2["untrust-zone"] = []string{"group2"}
+	zones2["ALKIRA_MGMT_ZONE"] = nil
+
+	segmentOptions := make(alkira.SegmentNameToZone)
+	segmentOptions["seg1"] = alkira.OuterZoneToGroups{
+		SegmentId:     100,
+		ZonesToGroups: zones1,
+	}
+	segmentOptions["seg2"] = alkira.OuterZoneToGroups{
+		SegmentId:     200,
+		ZonesToGroups: zones2,
+	}
+
+	result := deflateSegmentOptions(segmentOptions)
+
+	assert.Len(t, result, 2, "Only non-mgmt zones should remain")
+
+	zoneNames := make(map[string]bool)
+	for _, opt := range result {
+		zoneNames[opt["zone_name"].(string)] = true
+	}
+	assert.True(t, zoneNames["trust-zone"])
+	assert.True(t, zoneNames["untrust-zone"])
+	assert.False(t, zoneNames["ALKIRA_MGMT_ZONE"])
+}
+
 func TestConvertInputTimeToEpoch(t *testing.T) {
 	tests := []struct {
 		name        string

--- a/alkira/resource_alkira_connector_aws_vpc_helper_test.go
+++ b/alkira/resource_alkira_connector_aws_vpc_helper_test.go
@@ -224,8 +224,8 @@ func TestExpandUserInputPrefixes(t *testing.T) {
 			errorMsg:       "cannot both be specified",
 		},
 		{
-			name:           "empty cidr with valid subnets - subnet mode",
-			cidr:           []interface{}{},
+			name: "empty cidr with valid subnets - subnet mode",
+			cidr: []interface{}{},
 			subnets: schema.NewSet(
 				func(i interface{}) int {
 					m := i.(map[string]interface{})
@@ -297,8 +297,8 @@ func TestExpandUserInputPrefixes(t *testing.T) {
 			expectError: false,
 		},
 		{
-			name:           "empty cidr and empty subnets - should error",
-			cidr:           []interface{}{},
+			name: "empty cidr and empty subnets - should error",
+			cidr: []interface{}{},
 			subnets: schema.NewSet(
 				func(i interface{}) int {
 					m := i.(map[string]interface{})
@@ -321,8 +321,8 @@ func TestExpandUserInputPrefixes(t *testing.T) {
 			errorMsg:       "either",
 		},
 		{
-			name:           "subnets with overlay - combined payload",
-			cidr:           []interface{}{},
+			name: "subnets with overlay - combined payload",
+			cidr: []interface{}{},
 			subnets: schema.NewSet(
 				func(i interface{}) int {
 					m := i.(map[string]interface{})


### PR DESCRIPTION
## Summary

- Filter out backend-injected `ALKIRA_MGMT_ZONE` entries in `deflateSegmentOptions()` before writing to Terraform state
- Add constant `alkiraManagementZoneName` for the management zone name
- Add unit tests for single-segment and multi-segment filtering

## Problem

The backend auto-injects an `ALKIRA_MGMT_ZONE` zone into `segmentOptions` for all firewall services (PAN, Fortinet, Checkpoint, Cisco FTDv). Users never configure this zone in HCL — it is a backend-managed internal zone used for management traffic. The provider's `deflateSegmentOptions()` was faithfully storing it in Terraform state, causing perpetual drift on every `plan`/`apply` cycle: Terraform would always show a removal diff for `ALKIRA_MGMT_ZONE` since it wasn't declared in the user's config.

## Solution

Add a filter in `deflateSegmentOptions()` to skip `ALKIRA_MGMT_ZONE` entries before writing to state. This matches the backend's own pattern — the provisioning service already excludes management zones from zone limit counting and other user-facing logic.

The fix is in the single shared helper function, so all four firewall service Read functions benefit automatically:
- `alkira_service_pan`
- `alkira_service_fortinet`
- `alkira_service_checkpoint`
- `alkira_service_cisco_ftdv`

## Changes

- `alkira/helper.go` — Add `alkiraManagementZoneName` constant, skip matching zones in `deflateSegmentOptions()`
- `alkira/helper_test.go` — Add `TestDeflateSegmentOptionsFiltersManagementZone` and `TestDeflateSegmentOptionsFiltersManagementZoneMultipleSegments`
- `alkira/resource_alkira_connector_aws_vpc_helper_test.go` — gofmt alignment cleanup

## Testing Performed

### Unit Tests

- `TestDeflateSegmentOptionsFiltersManagementZone` — Single segment with ALKIRA_MGMT_ZONE: filtered out, only user zones remain
- `TestDeflateSegmentOptionsFiltersManagementZoneMultipleSegments` — Multiple segments each with ALKIRA_MGMT_ZONE: all mgmt zones filtered, user zones preserved
- All existing `deflateSegmentOptions` tests still pass

### Live Testing (PAN Service)

**Test environment:** `test/AK-67049-pan-mgmt-zone/`

- Greenfield create with `segment_options` (trust-zone, untrust-zone) — Apply succeeds, debug log shows `ALKIRA_MGMT_ZONE` filtered during Read
- **KEY TEST:** Post-create plan — "No changes" (ALKIRA_MGMT_ZONE not leaking into state)
- Update (description change) — In-place update, only changed field in diff
- Post-update plan — "No changes"
- Import — segment_options clean, no ALKIRA_MGMT_ZONE drift

### Brownfield Testing (Registry → Fixed Build)

- **BUG CONFIRMED on registry version:** Plan shows perpetual drift — `ALKIRA_MGMT_ZONE -> null` removal on every plan
- **KEY TEST:** Upgrade to fixed build — Plan shows "No changes" (drift eliminated, backwards compatible)

### Code Quality

- `make lint` — 0 issues
- `make test` — All pass
- `go build` — clean