### PR TITLE
AK-67216 fix spurious PROVISION (DELETE) FAILED warning on policy res…

### DIFF
--- a/alkira/resource_alkira_policy.go
+++ b/alkira/resource_alkira_policy.go
@@ -225,7 +225,7 @@ func resourcePolicyDelete(ctx context.Context, d *schema.ResourceData, m interfa
 	client := m.(*alkira.AlkiraClient)
 	api := alkira.NewTrafficPolicy(m.(*alkira.AlkiraClient))
 
-	provState, err, valErr, provErr := api.Delete(d.Id())
+	_, err, valErr, provErr := api.Delete(d.Id())
 
 	if err != nil {
 		// Terraform may not print "with <resource address>" for destroys of objects
@@ -248,7 +248,7 @@ func resourcePolicyDelete(ctx context.Context, d *schema.ResourceData, m interfa
 
 	d.SetId("")
 
-	if client.Provision && provState != "SUCCESS" {
+	if client.Provision && provErr != nil {
 		return diag.Diagnostics{{
 			Severity: diag.Warning,
 			Summary:  "PROVISION (DELETE) FAILED",

--- a/alkira/resource_alkira_policy_rule.go
+++ b/alkira/resource_alkira_policy_rule.go
@@ -313,7 +313,7 @@ func resourcePolicyRuleDelete(ctx context.Context, d *schema.ResourceData, m int
 	client := m.(*alkira.AlkiraClient)
 	api := alkira.NewTrafficPolicyRule(m.(*alkira.AlkiraClient))
 
-	provState, err, valErr, provErr := api.Delete(d.Id())
+	_, err, valErr, provErr := api.Delete(d.Id())
 
 	if err != nil {
 		// Terraform may not print "with <resource address>" for destroys of objects
@@ -336,7 +336,7 @@ func resourcePolicyRuleDelete(ctx context.Context, d *schema.ResourceData, m int
 
 	d.SetId("")
 
-	if client.Provision && provState != "SUCCESS" {
+	if client.Provision && provErr != nil {
 		return diag.Diagnostics{{
 			Severity: diag.Warning,
 			Summary:  "PROVISION (DELETE) FAILED",

--- a/alkira/resource_alkira_policy_rule_list.go
+++ b/alkira/resource_alkira_policy_rule_list.go
@@ -207,7 +207,7 @@ func resourcePolicyRuleListDelete(ctx context.Context, d *schema.ResourceData, m
 	client := m.(*alkira.AlkiraClient)
 	api := alkira.NewPolicyRuleList(m.(*alkira.AlkiraClient))
 
-	provState, err, valErr, provErr := api.Delete(d.Id())
+	_, err, valErr, provErr := api.Delete(d.Id())
 
 	if err != nil {
 		// Terraform may not print "with <resource address>" for destroys of objects
@@ -228,7 +228,7 @@ func resourcePolicyRuleListDelete(ctx context.Context, d *schema.ResourceData, m
 		}}
 	}
 
-	if client.Provision && provState != "SUCCESS" {
+	if client.Provision && provErr != nil {
 		return diag.Diagnostics{{
 			Severity: diag.Warning,
 			Summary:  "PROVISION (DELETE) FAILED",


### PR DESCRIPTION
…ources

Gate the DELETE diagnostic on provErr != nil (matching CREATE/UPDATE) instead of provState != "SUCCESS". The SDK's delete() legitimately returns provState="" with nil err/valErr/provErr on 202 async-validation, 404 already-deleted, and provision-disabled paths; the old guard fired on all three and printed a warning whose Detail was %!s(<nil>), which ATF's stdout matcher read as a test failure.

Applies to alkira_policy, alkira_policy_rule, and alkira_policy_rule_list.