### PR TITLE
AK-67361: add dependency-review-action workflow for PRs

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,29 @@
+name: dependency-review
+on:
+  pull_request:
+    branches:
+      - dev
+      - main
+      - release/**
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  dependency-review:
+    if: '! github.event.pull_request.draft'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Dependency Review
+        uses: actions/dependency-review-action@v4
+        with:
+          fail-on-severity: moderate
+          comment-summary-in-pr: on-failure


### PR DESCRIPTION
Runs actions/dependency-review-action@v4 on PRs targeting dev, main, or release/** with fail-on-severity: moderate and comment-summary-in-pr: on-failure.