### PR TITLE
Revert WriteOnly changes from credential resources (rel-64)

### DIFF
--- a/alkira/resource_alkira_credential_aws_vpc.go
+++ b/alkira/resource_alkira_credential_aws_vpc.go
@@ -5,12 +5,9 @@ import (
 	"errors"
 	"fmt"
 	"log"
-	"os"
-	"strings"
 
 	"github.com/alkiranet/alkira-client-go/alkira"
 
-	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -46,29 +43,33 @@ func resourceAlkiraCredentialAwsVpc() *schema.Resource {
 				Description: "AWS access key.",
 				Type:        schema.TypeString,
 				Optional:    true,
-				Sensitive:   true,
-				WriteOnly:   true,
+				DefaultFunc: schema.EnvDefaultFunc(
+					"AK_AWS_ACCESS_KEY_ID",
+					nil),
 			},
 			"aws_secret_key": {
 				Description: "AWS secret key.",
 				Type:        schema.TypeString,
 				Optional:    true,
-				Sensitive:   true,
-				WriteOnly:   true,
+				DefaultFunc: schema.EnvDefaultFunc(
+					"AK_AWS_SECRET_ACCESS_KEY",
+					nil),
 			},
 			"aws_role_arn": {
 				Description: "AWS Role ARN.",
 				Type:        schema.TypeString,
 				Optional:    true,
-				Sensitive:   true,
-				WriteOnly:   true,
+				DefaultFunc: schema.EnvDefaultFunc(
+					"AK_AWS_ROLE_ARN",
+					nil),
 			},
 			"aws_external_id": {
 				Description: "AWS Role External ID.",
 				Type:        schema.TypeString,
 				Optional:    true,
-				Sensitive:   true,
-				WriteOnly:   true,
+				DefaultFunc: schema.EnvDefaultFunc(
+					"AK_AWS_ROLE_EXTERNAL_ID",
+					nil),
 			},
 			"type": {
 				Description: "Type of AWS-VPC credential.",
@@ -99,27 +100,6 @@ func resourceCredentialAwsVpc(ctx context.Context, d *schema.ResourceData, meta 
 }
 
 func resourceCredentialAwsVpcRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client := meta.(*alkira.AlkiraClient)
-
-	credential, err := client.GetCredentialById(d.Id())
-	if err != nil {
-		if strings.Contains(err.Error(), "not found") {
-			d.SetId("")
-			return nil
-		}
-		return diag.FromErr(err)
-	}
-
-	d.Set("name", credential.Name)
-
-	if credential.SubType != "" {
-		d.Set("type", credential.SubType)
-	}
-
-	// Sensitive fields (access_key, secret_key, role_arn, external_id)
-	// are NOT returned by the API for security reasons and are
-	// maintained in the user's HCL configuration via WriteOnly.
-
 	return nil
 }
 
@@ -163,65 +143,22 @@ func resourceCredentialAwsVpcDelete(ctx context.Context, d *schema.ResourceData,
 	return nil
 }
 
-// getAwsVpcCredentialValue gets a value from config or environment variable.
-// For WriteOnly fields, reads from raw config since values are not stored in state.
-func getAwsVpcCredentialValue(d *schema.ResourceData, field string, envVar string, required bool) (string, error) {
-	// First try raw config (for WriteOnly fields)
-	attrPath := cty.Path{cty.GetAttrStep{Name: field}}
-	val, diags := d.GetRawConfigAt(attrPath)
-
-	if !diags.HasError() && !val.IsNull() && val.IsKnown() && val.Type() == cty.String {
-		strVal := val.AsString()
-		if strVal != "" {
-			return strVal, nil
-		}
-	}
-
-	// Fall back to environment variable
-	envValue := os.Getenv(envVar)
-	if envValue != "" {
-		return envValue, nil
-	}
-
-	if required {
-		return "", fmt.Errorf("required field '%s' is not set in configuration and environment variable '%s' is not set", field, envVar)
-	}
-	return "", nil
-}
-
 func generateCredentialAwsVpc(d *schema.ResourceData) (interface{}, error) {
 	credentialType := d.Get("type").(string)
 	var c interface{}
 
 	switch credentialType {
 	case "ACCESS_KEY":
-		accessKey, err := getAwsVpcCredentialValue(d, "aws_access_key", "AK_AWS_ACCESS_KEY_ID", true)
-		if err != nil {
-			return nil, err
-		}
-
-		secretKey, err := getAwsVpcCredentialValue(d, "aws_secret_key", "AK_AWS_SECRET_ACCESS_KEY", true)
-		if err != nil {
-			return nil, err
-		}
-
 		c = alkira.CredentialAwsVpcKey{
-			Ec2AccessKey: accessKey,
-			Ec2SecretKey: secretKey,
-			Type:         credentialType,
+			Ec2AccessKey: d.Get("aws_access_key").(string),
+			Ec2SecretKey: d.Get("aws_secret_key").(string),
+			Type:         d.Get("type").(string),
 		}
 	case "ROLE":
-		roleArn, err := getAwsVpcCredentialValue(d, "aws_role_arn", "AK_AWS_ROLE_ARN", true)
-		if err != nil {
-			return nil, err
-		}
-
-		externalId, _ := getAwsVpcCredentialValue(d, "aws_external_id", "AK_AWS_ROLE_EXTERNAL_ID", false)
-
 		c = alkira.CredentialAwsVpcRole{
-			Ec2RoleArn:    roleArn,
-			Ec2ExternalId: externalId,
-			Type:          credentialType,
+			Ec2RoleArn:    d.Get("aws_role_arn").(string),
+			Ec2ExternalId: d.Get("aws_external_id").(string),
+			Type:          d.Get("type").(string),
 		}
 	default:
 		return nil, errors.New("ERROR: Invalid AWS-VPC credential type")

--- a/alkira/resource_alkira_credential_azure_vnet.go
+++ b/alkira/resource_alkira_credential_azure_vnet.go
@@ -4,12 +4,9 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"os"
-	"strings"
 
 	"github.com/alkiranet/alkira-client-go/alkira"
 
-	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -39,29 +36,33 @@ func resourceAlkiraCredentialAzureVnet() *schema.Resource {
 				Description: "Azure Application ID.",
 				Type:        schema.TypeString,
 				Required:    true,
-				Sensitive:   true,
-				WriteOnly:   true,
+				DefaultFunc: schema.EnvDefaultFunc(
+					"AK_AZURE_APPLICATION_ID",
+					nil),
 			},
 			"subscription_id": {
 				Description: "Azure subscription ID.",
 				Type:        schema.TypeString,
 				Optional:    true,
-				Sensitive:   true,
-				WriteOnly:   true,
+				DefaultFunc: schema.EnvDefaultFunc(
+					"AK_AZURE_SUBSCRIPTION_ID",
+					nil),
 			},
 			"secret_key": {
 				Description: "Azure Secret Key.",
 				Type:        schema.TypeString,
 				Required:    true,
-				Sensitive:   true,
-				WriteOnly:   true,
+				DefaultFunc: schema.EnvDefaultFunc(
+					"AK_AZURE_SECRET_KEY",
+					nil),
 			},
 			"tenant_id": {
 				Description: "Azure Tenant ID.",
 				Type:        schema.TypeString,
 				Required:    true,
-				Sensitive:   true,
-				WriteOnly:   true,
+				DefaultFunc: schema.EnvDefaultFunc(
+					"AK_AZURE_TENANT_ID",
+					nil),
 			},
 			"environment": {
 				Description: "Azure environment can be `AZURE`, " +
@@ -77,71 +78,15 @@ func resourceAlkiraCredentialAzureVnet() *schema.Resource {
 	}
 }
 
-// getAzureVnetCredentialValue gets a value from config or environment variable
-// For WriteOnly fields, reads from raw config since values are not stored in state
-// Returns the value and an error if required but not found
-func getAzureVnetCredentialValue(d *schema.ResourceData, field string, envVar string, required bool) (string, error) {
-	// First try raw config (for WriteOnly fields and normal config values)
-	attrPath := cty.Path{cty.GetAttrStep{Name: field}}
-	val, diags := d.GetRawConfigAt(attrPath)
-
-	if !diags.HasError() && !val.IsNull() && val.IsKnown() && val.Type() == cty.String {
-		strVal := val.AsString()
-		if strVal != "" {
-			return strVal, nil
-		}
-	}
-
-	// Check environment variable
-	envValue := os.Getenv(envVar)
-	if envValue != "" {
-		return envValue, nil
-	}
-
-	if required {
-		return "", fmt.Errorf("required field '%s' is not set in configuration and environment variable '%s' is not set", field, envVar)
-	}
-	return "", nil
-}
-
-// buildAzureVnetCredential builds the CredentialAzureVnet struct from ResourceData
-func buildAzureVnetCredential(d *schema.ResourceData) (alkira.CredentialAzureVnet, error) {
-	// Get values from config or environment variables
-	applicationId, err := getAzureVnetCredentialValue(d, "application_id", "AK_AZURE_APPLICATION_ID", true)
-	if err != nil {
-		return alkira.CredentialAzureVnet{}, err
-	}
-
-	secretKey, err := getAzureVnetCredentialValue(d, "secret_key", "AK_AZURE_SECRET_KEY", true)
-	if err != nil {
-		return alkira.CredentialAzureVnet{}, err
-	}
-
-	tenantId, err := getAzureVnetCredentialValue(d, "tenant_id", "AK_AZURE_TENANT_ID", true)
-	if err != nil {
-		return alkira.CredentialAzureVnet{}, err
-	}
-
-	subscriptionId, _ := getAzureVnetCredentialValue(d, "subscription_id", "AK_AZURE_SUBSCRIPTION_ID", false)
-
-	// Environment is not WriteOnly, use d.Get() directly
-	environment := d.Get("environment").(string)
-
-	return alkira.CredentialAzureVnet{
-		ApplicationId:  applicationId,
-		SecretKey:      secretKey,
-		SubscriptionId: subscriptionId,
-		TenantId:       tenantId,
-		Environment:    environment,
-	}, nil
-}
-
 func resourceCredentialAzureVnet(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*alkira.AlkiraClient)
 
-	c, err := buildAzureVnetCredential(d)
-	if err != nil {
-		return diag.FromErr(err)
+	c := alkira.CredentialAzureVnet{
+		ApplicationId:  d.Get("application_id").(string),
+		SecretKey:      d.Get("secret_key").(string),
+		SubscriptionId: d.Get("subscription_id").(string),
+		TenantId:       d.Get("tenant_id").(string),
+		Environment:    d.Get("environment").(string),
 	}
 
 	log.Printf("[INFO] Creating Credential (AZURE-VNET)")
@@ -156,43 +101,22 @@ func resourceCredentialAzureVnet(ctx context.Context, d *schema.ResourceData, me
 }
 
 func resourceCredentialAzureVnetRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client := meta.(*alkira.AlkiraClient)
-
-	// Use GetCredentialById which now properly filters from GetCredentials
-	credential, err := client.GetCredentialById(d.Id())
-	if err != nil {
-		if strings.Contains(err.Error(), "not found") {
-			d.SetId("")
-			return nil
-		}
-		return diag.FromErr(err)
-	}
-
-	// Set fields returned by API
-	d.Set("name", credential.Name)
-
-	// Set environment from SubType if available
-	if credential.SubType != "" {
-		d.Set("environment", credential.SubType)
-	}
-
-	// Note: Sensitive fields (secret_key, application_id, tenant_id, subscription_id)
-	// are NOT returned by the API for security reasons and must be maintained
-	// in the user's HCL configuration.
-
 	return nil
 }
 
 func resourceCredentialAzureVnetUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*alkira.AlkiraClient)
 
-	c, err := buildAzureVnetCredential(d)
-	if err != nil {
-		return diag.FromErr(err)
+	c := alkira.CredentialAzureVnet{
+		ApplicationId:  d.Get("application_id").(string),
+		SecretKey:      d.Get("secret_key").(string),
+		SubscriptionId: d.Get("subscription_id").(string),
+		TenantId:       d.Get("tenant_id").(string),
+		Environment:    d.Get("environment").(string),
 	}
 
 	log.Printf("[INFO] Updating Credential (AZURE-VNET)")
-	err = client.UpdateCredential(d.Id(), d.Get("name").(string), alkira.CredentialTypeAzureVnet, c, 0)
+	err := client.UpdateCredential(d.Id(), d.Get("name").(string), alkira.CredentialTypeAzureVnet, c, 0)
 
 	if err != nil {
 		return diag.FromErr(err)

--- a/alkira/resource_alkira_credential_gcp_vpc.go
+++ b/alkira/resource_alkira_credential_gcp_vpc.go
@@ -4,11 +4,9 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"strings"
 
 	"github.com/alkiranet/alkira-client-go/alkira"
 
-	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -16,7 +14,7 @@ import (
 func resourceAlkiraCredentialGcpVpc() *schema.Resource {
 	return &schema.Resource{
 		Description:   "Manage Credential for GCP.",
-		CreateContext: resourceCredentialGcpVpcCreate,
+		CreateContext: resourceCredentialGcpVpc,
 		ReadContext:   resourceCredentialGcpVpcRead,
 		UpdateContext: resourceCredentialGcpVpcUpdate,
 		DeleteContext: resourceCredentialGcpVpcDelete,
@@ -46,43 +44,31 @@ func resourceAlkiraCredentialGcpVpc() *schema.Resource {
 				Description: "GCP Client email",
 				Type:        schema.TypeString,
 				Required:    true,
-				Sensitive:   true,
-				WriteOnly:   true,
 			},
 			"client_id": {
 				Description: "GCP Client ID",
 				Type:        schema.TypeString,
 				Required:    true,
-				Sensitive:   true,
-				WriteOnly:   true,
 			},
 			"client_x509_cert_url": {
 				Description: "GCP Client X509 Cert URL",
 				Type:        schema.TypeString,
 				Required:    true,
-				Sensitive:   true,
-				WriteOnly:   true,
 			},
 			"private_key_id": {
 				Description: "GCP Private Key ID",
 				Type:        schema.TypeString,
 				Required:    true,
-				Sensitive:   true,
-				WriteOnly:   true,
 			},
 			"private_key": {
 				Description: "GCP Private Key",
 				Type:        schema.TypeString,
 				Required:    true,
-				Sensitive:   true,
-				WriteOnly:   true,
 			},
 			"project_id": {
 				Description: "GCP Project ID",
 				Type:        schema.TypeString,
 				Required:    true,
-				Sensitive:   true,
-				WriteOnly:   true,
 			},
 			"token_uri": {
 				Description: "Token URI",
@@ -100,16 +86,24 @@ func resourceAlkiraCredentialGcpVpc() *schema.Resource {
 	}
 }
 
-func resourceCredentialGcpVpcCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceCredentialGcpVpc(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*alkira.AlkiraClient)
 
-	c, err := buildCredentialGcpVpc(d)
-	if err != nil {
-		return diag.FromErr(err)
+	c := alkira.CredentialGcpVpc{
+		AuthProvider:      d.Get("auth_provider").(string),
+		AuthUri:           d.Get("auth_uri").(string),
+		ClientEmail:       d.Get("client_email").(string),
+		ClientId:          d.Get("client_id").(string),
+		ClientX509CertUrl: d.Get("client_x509_cert_url").(string),
+		PrivateKey:        d.Get("private_key").(string),
+		PrivateKeyId:      d.Get("private_key_id").(string),
+		ProjectId:         d.Get("project_id").(string),
+		TokenUri:          d.Get("token_uri").(string),
+		Type:              d.Get("type").(string),
 	}
 
 	log.Printf("[INFO] Creating Credential (GCP-VPC)")
-	credentialId, err := client.CreateCredential(d.Get("name").(string), alkira.CredentialTypeGcpVpc, c, 0)
+	credentialId, err := client.CreateCredential(d.Get("name").(string), "gcpvpc", c, 0)
 
 	if err != nil {
 		return diag.FromErr(err)
@@ -120,36 +114,27 @@ func resourceCredentialGcpVpcCreate(ctx context.Context, d *schema.ResourceData,
 }
 
 func resourceCredentialGcpVpcRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client := meta.(*alkira.AlkiraClient)
-
-	credential, err := client.GetCredentialById(d.Id())
-	if err != nil {
-		if strings.Contains(err.Error(), "not found") {
-			d.SetId("")
-			return nil
-		}
-		return diag.FromErr(err)
-	}
-
-	d.Set("name", credential.Name)
-
-	// Note: Sensitive WriteOnly fields (client_email, client_id, client_x509_cert_url,
-	// private_key_id, private_key, project_id) are NOT returned by the API for security
-	// reasons and must be maintained in the user's HCL configuration.
-
 	return nil
 }
 
 func resourceCredentialGcpVpcUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*alkira.AlkiraClient)
 
-	c, err := buildCredentialGcpVpc(d)
-	if err != nil {
-		return diag.FromErr(err)
+	c := alkira.CredentialGcpVpc{
+		AuthProvider:      d.Get("auth_provider").(string),
+		AuthUri:           d.Get("auth_uri").(string),
+		ClientEmail:       d.Get("client_email").(string),
+		ClientId:          d.Get("client_id").(string),
+		ClientX509CertUrl: d.Get("client_x509_cert_url").(string),
+		PrivateKey:        d.Get("private_key").(string),
+		PrivateKeyId:      d.Get("private_key_id").(string),
+		ProjectId:         d.Get("project_id").(string),
+		TokenUri:          d.Get("token_uri").(string),
+		Type:              d.Get("type").(string),
 	}
 
 	log.Printf("[INFO] Updating Credential (GCP-VPC)")
-	err = client.UpdateCredential(d.Id(), d.Get("name").(string), alkira.CredentialTypeGcpVpc, c, 0)
+	err := client.UpdateCredential(d.Id(), d.Get("name").(string), "gcpvpc", c, 0)
 
 	if err != nil {
 		return diag.FromErr(err)
@@ -161,7 +146,7 @@ func resourceCredentialGcpVpcUpdate(ctx context.Context, d *schema.ResourceData,
 func resourceCredentialGcpVpcDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*alkira.AlkiraClient)
 
-	err := client.DeleteCredential(d.Id(), alkira.CredentialTypeGcpVpc)
+	err := client.DeleteCredential(d.Id(), "gcpvpc")
 
 	if err != nil {
 		// Terraform may not print "with <resource address>" for destroys of objects
@@ -175,72 +160,4 @@ func resourceCredentialGcpVpcDelete(ctx context.Context, d *schema.ResourceData,
 
 	d.SetId("")
 	return nil
-}
-
-// buildCredentialGcpVpc constructs the CredentialGcpVpc struct from ResourceData
-// For WriteOnly fields, reads from raw config since values are not stored in state
-func buildCredentialGcpVpc(d *schema.ResourceData) (alkira.CredentialGcpVpc, error) {
-	// Helper function to get WriteOnly field values from raw config
-	getWriteOnlyString := func(field string) (string, error) {
-		attrPath := cty.Path{cty.GetAttrStep{Name: field}}
-		val, diags := d.GetRawConfigAt(attrPath)
-
-		if diags.HasError() {
-			return "", fmt.Errorf("error reading %s from config: %v", field, diags)
-		}
-
-		if val.IsNull() || !val.IsKnown() {
-			return "", fmt.Errorf("required field '%s' is not set in configuration", field)
-		}
-
-		if val.Type() != cty.String {
-			return "", fmt.Errorf("field '%s' is not a string", field)
-		}
-
-		return val.AsString(), nil
-	}
-
-	// Get WriteOnly sensitive fields from raw config
-	clientEmail, err := getWriteOnlyString("client_email")
-	if err != nil {
-		return alkira.CredentialGcpVpc{}, err
-	}
-
-	clientId, err := getWriteOnlyString("client_id")
-	if err != nil {
-		return alkira.CredentialGcpVpc{}, err
-	}
-
-	clientX509CertUrl, err := getWriteOnlyString("client_x509_cert_url")
-	if err != nil {
-		return alkira.CredentialGcpVpc{}, err
-	}
-
-	privateKeyId, err := getWriteOnlyString("private_key_id")
-	if err != nil {
-		return alkira.CredentialGcpVpc{}, err
-	}
-
-	privateKey, err := getWriteOnlyString("private_key")
-	if err != nil {
-		return alkira.CredentialGcpVpc{}, err
-	}
-
-	projectId, err := getWriteOnlyString("project_id")
-	if err != nil {
-		return alkira.CredentialGcpVpc{}, err
-	}
-
-	return alkira.CredentialGcpVpc{
-		AuthProvider:      d.Get("auth_provider").(string),
-		AuthUri:           d.Get("auth_uri").(string),
-		ClientEmail:       clientEmail,
-		ClientId:          clientId,
-		ClientX509CertUrl: clientX509CertUrl,
-		PrivateKey:        privateKey,
-		PrivateKeyId:      privateKeyId,
-		ProjectId:         projectId,
-		TokenUri:          d.Get("token_uri").(string),
-		Type:              d.Get("type").(string),
-	}, nil
 }

--- a/alkira/resource_alkira_credential_oci_vcn.go
+++ b/alkira/resource_alkira_credential_oci_vcn.go
@@ -3,12 +3,9 @@ package alkira
 import (
 	"context"
 	"fmt"
-	"os"
-	"strings"
 
 	"github.com/alkiranet/alkira-client-go/alkira"
 
-	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -38,29 +35,33 @@ func resourceAlkiraCredentialOciVcn() *schema.Resource {
 				Description: "OCID of the user.",
 				Type:        schema.TypeString,
 				Required:    true,
-				Sensitive:   true,
-				WriteOnly:   true,
+				DefaultFunc: schema.EnvDefaultFunc(
+					"AK_OCI_USER_OCID",
+					nil),
 			},
 			"fingerprint": {
 				Description: "Fingerprint of the API key of the user.",
 				Type:        schema.TypeString,
 				Required:    true,
-				Sensitive:   true,
-				WriteOnly:   true,
+				DefaultFunc: schema.EnvDefaultFunc(
+					"AK_OCI_FINGERPRINT",
+					nil),
 			},
 			"key": {
 				Description: "API key of the user.",
 				Type:        schema.TypeString,
 				Required:    true,
-				Sensitive:   true,
-				WriteOnly:   true,
+				DefaultFunc: schema.EnvDefaultFunc(
+					"AK_OCI_KEY",
+					nil),
 			},
 			"tenant_ocid": {
 				Description: "OCID of the tenant.",
 				Type:        schema.TypeString,
 				Required:    true,
-				Sensitive:   true,
-				WriteOnly:   true,
+				DefaultFunc: schema.EnvDefaultFunc(
+					"AK_OCI_TENANT_OCID",
+					nil),
 			},
 		},
 	}
@@ -69,11 +70,7 @@ func resourceAlkiraCredentialOciVcn() *schema.Resource {
 func resourceCredentialOciVcn(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*alkira.AlkiraClient)
 
-	c, err := generateCredentialOciVcnRequest(d)
-
-	if err != nil {
-		return diag.FromErr(err)
-	}
+	c := generateCredentialOciVcnRequest(d)
 
 	credentialId, err := client.CreateCredential(d.Get("name").(string), alkira.CredentialTypeOciVcn, c, 0)
 
@@ -86,36 +83,15 @@ func resourceCredentialOciVcn(ctx context.Context, d *schema.ResourceData, meta 
 }
 
 func resourceCredentialOciVcnRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client := meta.(*alkira.AlkiraClient)
-
-	credential, err := client.GetCredentialById(d.Id())
-	if err != nil {
-		if strings.Contains(err.Error(), "not found") {
-			d.SetId("")
-			return nil
-		}
-		return diag.FromErr(err)
-	}
-
-	d.Set("name", credential.Name)
-
-	// Sensitive fields (user_ocid, fingerprint, key, tenant_ocid)
-	// are NOT returned by the API for security reasons and are
-	// maintained in the user's HCL configuration via WriteOnly.
-
 	return nil
 }
 
 func resourceCredentialOciVcnUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*alkira.AlkiraClient)
 
-	c, err := generateCredentialOciVcnRequest(d)
+	c := generateCredentialOciVcnRequest(d)
 
-	if err != nil {
-		return diag.FromErr(err)
-	}
-
-	err = client.UpdateCredential(d.Id(), d.Get("name").(string), alkira.CredentialTypeOciVcn, c, 0)
+	err := client.UpdateCredential(d.Id(), d.Get("name").(string), alkira.CredentialTypeOciVcn, c, 0)
 
 	if err != nil {
 		return diag.FromErr(err)
@@ -143,59 +119,13 @@ func resourceCredentialOciVcnDelete(ctx context.Context, d *schema.ResourceData,
 	return nil
 }
 
-// getOciVcnCredentialValue gets a value from config or environment variable.
-// For WriteOnly fields, reads from raw config since values are not stored in state.
-func getOciVcnCredentialValue(d *schema.ResourceData, field string, envVar string, required bool) (string, error) {
-	// First try raw config (for WriteOnly fields)
-	attrPath := cty.Path{cty.GetAttrStep{Name: field}}
-	val, diags := d.GetRawConfigAt(attrPath)
-
-	if !diags.HasError() && !val.IsNull() && val.IsKnown() && val.Type() == cty.String {
-		strVal := val.AsString()
-		if strVal != "" {
-			return strVal, nil
-		}
-	}
-
-	// Fall back to environment variable
-	envValue := os.Getenv(envVar)
-	if envValue != "" {
-		return envValue, nil
-	}
-
-	if required {
-		return "", fmt.Errorf("required field '%s' is not set in configuration and environment variable '%s' is not set", field, envVar)
-	}
-	return "", nil
-}
-
-func generateCredentialOciVcnRequest(d *schema.ResourceData) (alkira.CredentialOciVcn, error) {
-	userOcid, err := getOciVcnCredentialValue(d, "user_ocid", "AK_OCI_USER_OCID", true)
-	if err != nil {
-		return alkira.CredentialOciVcn{}, err
-	}
-
-	fingerprint, err := getOciVcnCredentialValue(d, "fingerprint", "AK_OCI_FINGERPRINT", true)
-	if err != nil {
-		return alkira.CredentialOciVcn{}, err
-	}
-
-	key, err := getOciVcnCredentialValue(d, "key", "AK_OCI_KEY", true)
-	if err != nil {
-		return alkira.CredentialOciVcn{}, err
-	}
-
-	tenantOcid, err := getOciVcnCredentialValue(d, "tenant_ocid", "AK_OCI_TENANT_OCID", true)
-	if err != nil {
-		return alkira.CredentialOciVcn{}, err
-	}
-
+func generateCredentialOciVcnRequest(d *schema.ResourceData) alkira.CredentialOciVcn {
 	c := alkira.CredentialOciVcn{
-		UserId:      userOcid,
-		FingerPrint: fingerprint,
-		Key:         key,
-		TenantId:    tenantOcid,
+		UserId:      d.Get("user_ocid").(string),
+		FingerPrint: d.Get("fingerprint").(string),
+		Key:         d.Get("key").(string),
+		TenantId:    d.Get("tenant_ocid").(string),
 	}
 
-	return c, nil
+	return c
 }

--- a/docs/resources/credential_azure_vnet.md
+++ b/docs/resources/credential_azure_vnet.md
@@ -5,7 +5,7 @@ subcategory: ""
 description: |-
   Credential for interacting with Azure.
   You could also provide your credentials via the following environmental variables:
-  AKAZUREAPPLICATION_IDAKAZURESUBSCRIPTION_IDAKAZURESECRET_KEYAKAZURETENANT_IDAKAZUREENVIRONMENT
+  AK_AZURE_APPLICATION_IDAK_AZURE_SUBSCRIPTION_IDAK_AZURE_SECRET_KEYAK_AZURE_TENANT_IDAK_AZURE_ENVIRONMENT
 ---
 
 # alkira_credential_azure_vnet (Resource)
@@ -49,5 +49,3 @@ resource "alkira_credential_azure_vnet" "test" {
 ### Read-Only
 
 - `id` (String) The ID of this resource.
-
-

--- a/docs/resources/credential_azure_vnet.md
+++ b/docs/resources/credential_azure_vnet.md
@@ -5,7 +5,7 @@ subcategory: ""
 description: |-
   Credential for interacting with Azure.
   You could also provide your credentials via the following environmental variables:
-  AK_AZURE_APPLICATION_IDAK_AZURE_SUBSCRIPTION_IDAK_AZURE_SECRET_KEYAK_AZURE_TENANT_IDAK_AZURE_ENVIRONMENT
+  AKAZUREAPPLICATION_IDAKAZURESUBSCRIPTION_IDAKAZURESECRET_KEYAKAZURETENANT_IDAKAZUREENVIRONMENT
 ---
 
 # alkira_credential_azure_vnet (Resource)
@@ -36,16 +36,18 @@ resource "alkira_credential_azure_vnet" "test" {
 
 ### Required
 
-- `application_id` (String, Sensitive) Azure Application ID.
+- `application_id` (String) Azure Application ID.
 - `name` (String) The name of the credential.
-- `secret_key` (String, Sensitive) Azure Secret Key.
-- `tenant_id` (String, Sensitive) Azure Tenant ID.
+- `secret_key` (String) Azure Secret Key.
+- `tenant_id` (String) Azure Tenant ID.
 
 ### Optional
 
 - `environment` (String) Azure environment can be `AZURE`, `AZURE_CHINA` or `AZURE_US_GOVERNMENT`. The default value is `AZURE`.
-- `subscription_id` (String, Sensitive) Azure subscription ID.
+- `subscription_id` (String) Azure subscription ID.
 
 ### Read-Only
 
 - `id` (String) The ID of this resource.
+
+

--- a/docs/resources/credential_gcp_vpc.md
+++ b/docs/resources/credential_gcp_vpc.md
@@ -36,13 +36,13 @@ resource "alkira_credential_gcp_vpc" "gcp" {
 
 ### Required
 
-- `client_email` (String, Sensitive) GCP Client email
-- `client_id` (String, Sensitive) GCP Client ID
-- `client_x509_cert_url` (String, Sensitive) GCP Client X509 Cert URL
+- `client_email` (String) GCP Client email
+- `client_id` (String) GCP Client ID
+- `client_x509_cert_url` (String) GCP Client X509 Cert URL
 - `name` (String) The name of the credential
-- `private_key` (String, Sensitive) GCP Private Key
-- `private_key_id` (String, Sensitive) GCP Private Key ID
-- `project_id` (String, Sensitive) GCP Project ID
+- `private_key` (String) GCP Private Key
+- `private_key_id` (String) GCP Private Key ID
+- `project_id` (String) GCP Project ID
 
 ### Optional
 
@@ -54,3 +54,5 @@ resource "alkira_credential_gcp_vpc" "gcp" {
 ### Read-Only
 
 - `id` (String) The ID of this resource.
+
+

--- a/docs/resources/credential_oci_vcn.md
+++ b/docs/resources/credential_oci_vcn.md
@@ -5,7 +5,7 @@ subcategory: ""
 description: |-
   Credential for accessing Oracle Cloud.
   You can provide your credentials via the following environmental variables:
-  AK_OCI_USER_OCIDAK_OCI_FINGERPRINTAK_OCI_KEYAK_OCI_TENANT_OCID
+  AKOCIUSER_OCIDAKOCIFINGERPRINTAKOCIKEYAKOCITENANT_OCID
 ---
 
 # alkira_credential_oci_vcn (Resource)
@@ -36,12 +36,14 @@ resource "alkira_credential_oci_vcn" "example" {
 
 ### Required
 
-- `fingerprint` (String, Sensitive) Fingerprint of the API key of the user.
-- `key` (String, Sensitive) API key of the user.
+- `fingerprint` (String) Fingerprint of the API key of the user.
+- `key` (String) API key of the user.
 - `name` (String) Name of the credential.
-- `tenant_ocid` (String, Sensitive) OCID of the tenant.
-- `user_ocid` (String, Sensitive) OCID of the user.
+- `tenant_ocid` (String) OCID of the tenant.
+- `user_ocid` (String) OCID of the user.
 
 ### Read-Only
 
 - `id` (String) The ID of this resource.
+
+

--- a/docs/resources/credential_oci_vcn.md
+++ b/docs/resources/credential_oci_vcn.md
@@ -5,7 +5,7 @@ subcategory: ""
 description: |-
   Credential for accessing Oracle Cloud.
   You can provide your credentials via the following environmental variables:
-  AKOCIUSER_OCIDAKOCIFINGERPRINTAKOCIKEYAKOCITENANT_OCID
+  AK_OCI_USER_OCIDAK_OCI_FINGERPRINTAK_OCI_KEYAK_OCI_TENANT_OCID
 ---
 
 # alkira_credential_oci_vcn (Resource)
@@ -45,5 +45,3 @@ resource "alkira_credential_oci_vcn" "example" {
 ### Read-Only
 
 - `id` (String) The ID of this resource.
-
-


### PR DESCRIPTION
## Summary

Cherry-pick of #631 (dev) for release/2026-03-16-64. Reverts WriteOnly+Sensitive changes from 4 credential resources (SSH key pair was not on this branch).

**Reverted PRs:**
- #540 — `alkira_credential_aws_vpc` (AK-65426) — surgical revert, preserves go.mod/vendor client upgrade
- #545 — `alkira_credential_gcp_vpc` (AK-65428)
- #548 — `alkira_credential_azure_vnet` (AK-65427)
- #549 — `alkira_credential_oci_vcn` (AK-65429)

## What changed
- Removed `WriteOnly: true` and `Sensitive: true` from credential fields
- Removed `GetRawConfigAt` helpers
- Restored `DefaultFunc: schema.EnvDefaultFunc(...)` for env var support
- Restored `d.Get()` calls in Create/Update
- Restored no-op Read functions (`return nil`)

## Test plan
- [x] `make build` passes
- [x] `golangci-lint` — 0 issues (against release base)
- [x] `go test ./alkira/...` — all unit tests pass
- [x] Live tested on dev branch (#631): greenfield CRUD + brownfield upgrade all pass