### PR TITLE
Revert AWS VPC connector routing Read changes (#539, #588, #610)

### DIFF
--- a/alkira/resource_alkira_connector_aws_vpc.go
+++ b/alkira/resource_alkira_connector_aws_vpc.go
@@ -219,7 +219,6 @@ func resourceAlkiraConnectorAwsVpc() *schema.Resource {
 					},
 				},
 				Optional: true,
-				Computed: true,
 			},
 			"scale_group_id": {
 				Description: "The ID of the scale group associated with the connector.",
@@ -230,7 +229,6 @@ func resourceAlkiraConnectorAwsVpc() *schema.Resource {
 				Description: "Overlay subnet.",
 				Type:        schema.TypeList,
 				Optional:    true,
-				Computed:    true,
 				Elem:        &schema.Schema{Type: schema.TypeString},
 			},
 			"description": {
@@ -331,15 +329,6 @@ func resourceConnectorAwsVpcRead(ctx context.Context, d *schema.ResourceData, m 
 	d.Set("tgw_connect_enabled", connector.TgwConnectEnabled)
 	d.Set("scale_group_id", connector.ScaleGroupId)
 	d.Set("description", connector.Description)
-
-	// Set routing configuration from API response
-	setAwsVpcRoutingOptions(connector, d)
-
-	// Set TGW attachments (reusing existing function)
-	if connector.TgwAttachments != nil && len(connector.TgwAttachments) > 0 {
-		setTgwAttachment(d, connector.TgwAttachments)
-	}
-
 	// Get segment
 	numOfSegments := len(connector.Segments)
 

--- a/alkira/resource_alkira_connector_aws_vpc_helper.go
+++ b/alkira/resource_alkira_connector_aws_vpc_helper.go
@@ -1,124 +1,12 @@
 package alkira
 
 import (
-	"encoding/json"
 	"fmt"
 	"log"
 
 	"github.com/alkiranet/alkira-client-go/alkira"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
-
-// setAwsVpcRoutingOptions sets the routing configuration fields from the API response
-func setAwsVpcRoutingOptions(connector *alkira.ConnectorAwsVpc, d *schema.ResourceData) {
-	if connector.VpcRouting == nil {
-		log.Printf("[DEBUG] VpcRouting is nil, skipping routing options")
-		return
-	}
-
-	// Unmarshal the interface{} to concrete types
-	routingJSON, err := json.Marshal(connector.VpcRouting)
-	if err != nil {
-		log.Printf("[ERROR] Failed to marshal VpcRouting: %v", err)
-		return
-	}
-
-	var routing alkira.ConnectorAwsVpcRouting
-	if err := json.Unmarshal(routingJSON, &routing); err != nil {
-		log.Printf("[ERROR] Failed to unmarshal VpcRouting: %v", err)
-		return
-	}
-
-	// Set export-related fields (vpc_cidr, vpc_subnet, overlay_subnets)
-	setAwsVpcExportPrefixes(routing.Export, d)
-
-	// Set import-related fields (vpc_route_table)
-	setAwsVpcImportRouteTables(routing.Import, d)
-}
-
-// setAwsVpcExportPrefixes sets export-related fields from ExportOptions
-func setAwsVpcExportPrefixes(exportOptions interface{}, d *schema.ResourceData) {
-	if exportOptions == nil {
-		log.Printf("[DEBUG] Export options is nil, clearing export prefixes")
-		d.Set("vpc_cidr", []interface{}{})
-		d.Set("vpc_subnet", []interface{}{})
-		d.Set("overlay_subnets", []interface{}{})
-		return
-	}
-
-	// Unmarshal the interface{} to ExportOptions
-	exportJSON, err := json.Marshal(exportOptions)
-	if err != nil {
-		log.Printf("[ERROR] Failed to marshal ExportOptions: %v", err)
-		return
-	}
-
-	var export alkira.ExportOptions
-	if err := json.Unmarshal(exportJSON, &export); err != nil {
-		log.Printf("[ERROR] Failed to unmarshal ExportOptions: %v", err)
-		return
-	}
-
-	var cidrList []string
-	var subnetList []interface{}
-	var overlaySubnets []string
-
-	for _, prefix := range export.Prefixes {
-		switch prefix.Type {
-		case "CIDR":
-			cidrList = append(cidrList, prefix.Value)
-		case "SUBNET":
-			subnet := map[string]interface{}{
-				"id":   prefix.Id,
-				"cidr": prefix.Value,
-			}
-			subnetList = append(subnetList, subnet)
-		case "OVERLAY_SUBNETS":
-			overlaySubnets = append(overlaySubnets, prefix.Value)
-		default:
-			log.Printf("[DEBUG] Unknown prefix type: %s", prefix.Type)
-		}
-	}
-
-	// Always set all export fields because they are Computed
-	// Backend returns userInputPrefixes with type entries; empty set if none specified
-	d.Set("vpc_cidr", cidrList)
-	d.Set("vpc_subnet", subnetList)
-	d.Set("overlay_subnets", overlaySubnets)
-}
-
-// setAwsVpcImportRouteTables sets vpc_route_table from ImportOptions
-func setAwsVpcImportRouteTables(importOptions interface{}, d *schema.ResourceData) {
-	if importOptions == nil {
-		log.Printf("[DEBUG] Import options is nil, skipping route tables")
-		return
-	}
-
-	// Unmarshal the interface{} to ImportOptions
-	importJSON, err := json.Marshal(importOptions)
-	if err != nil {
-		log.Printf("[ERROR] Failed to marshal ImportOptions: %v", err)
-		return
-	}
-
-	var importOpts alkira.ImportOptions
-	if err := json.Unmarshal(importJSON, &importOpts); err != nil {
-		log.Printf("[ERROR] Failed to unmarshal ImportOptions: %v", err)
-		return
-	}
-
-	routeTables := make([]interface{}, len(importOpts.RouteTables))
-	for i, rt := range importOpts.RouteTables {
-		routeTable := map[string]interface{}{
-			"id":              rt.Id,
-			"options":         rt.Mode,
-			"prefix_list_ids": rt.PrefixListIds,
-		}
-		routeTables[i] = routeTable
-	}
-
-	d.Set("vpc_route_table", routeTables)
-}
 
 // setTgwAttachment set tgw_attachment blocks
 func setTgwAttachment(d *schema.ResourceData, tgwAttachments []alkira.TgwAttachment) {
@@ -163,6 +51,7 @@ func setTgwAttachment(d *schema.ResourceData, tgwAttachments []alkira.TgwAttachm
 			}
 
 			attachments = append(attachments, attachment)
+			break
 		}
 	}
 
@@ -198,23 +87,23 @@ func expandAwsVpcRouteTables(in *schema.Set) []alkira.RouteTables {
 // expandUserInputPrefixes generate UserInputPrefixes used in AWS-VPC connector
 func expandUserInputPrefixes(cidr []interface{}, subnets *schema.Set, overlaySubnets []interface{}) ([]alkira.InputPrefixes, error) {
 
-	hasCidr := len(cidr) > 0
-	hasSubnets := subnets != nil && subnets.Len() > 0
+	if len(cidr) == 0 && subnets == nil {
+		return nil, fmt.Errorf("ERROR: either \"vpc_subnet\" or \"vpc_cidr\" must be specified")
+	}
 
 	// Processing overlay_subnets
 	log.Printf("[DEBUG] Processing overlay_subnets %v", overlaySubnets)
 	overlaySubnetList := make([]alkira.InputPrefixes, len(overlaySubnets))
 
-	for i, value := range overlaySubnets {
-		overlaySubnetList[i].Value = value.(string)
-		overlaySubnetList[i].Type = "OVERLAY_SUBNETS"
+	if len(overlaySubnets) > 0 {
+		for i, value := range overlaySubnets {
+			overlaySubnetList[i].Value = value.(string)
+			overlaySubnetList[i].Type = "OVERLAY_SUBNETS"
+		}
 	}
 
-	switch {
-	case hasCidr && hasSubnets:
-		return nil, fmt.Errorf("ERROR: \"vpc_cidr\" and \"vpc_subnet\" cannot both be specified")
-
-	case hasCidr:
+	// Processing vpc_cidr
+	if len(cidr) > 0 {
 		log.Printf("[DEBUG] Processing vpc_cidr %v", cidr)
 		cidrList := make([]alkira.InputPrefixes, len(cidr))
 
@@ -223,31 +112,34 @@ func expandUserInputPrefixes(cidr []interface{}, subnets *schema.Set, overlaySub
 			cidrList[i].Type = "CIDR"
 		}
 
-		return append(cidrList, overlaySubnetList...), nil
+		cidrList = append(cidrList, overlaySubnetList...)
+		return cidrList, nil
+	}
 
-	case hasSubnets:
-		log.Printf("[DEBUG] Processing vpc_subnet")
-		prefixes := make([]alkira.InputPrefixes, subnets.Len())
+	// Processing vpc_subnet
+	log.Printf("[DEBUG] Processing vpc_subnet")
+	if subnets == nil || subnets.Len() == 0 {
+		log.Printf("[DEBUG] Empty vpc_subnet")
+		return nil, fmt.Errorf("ERROR: Invalid vpc_subnet")
+	}
 
-		for i, subnet := range subnets.List() {
-			r := alkira.InputPrefixes{}
-			t := subnet.(map[string]interface{})
-			if v, ok := t["id"].(string); ok {
-				r.Id = v
-			}
-			if v, ok := t["cidr"].(string); ok {
-				r.Value = v
-			}
-
-			r.Type = "SUBNET"
-			prefixes[i] = r
+	prefixes := make([]alkira.InputPrefixes, subnets.Len())
+	for i, subnet := range subnets.List() {
+		r := alkira.InputPrefixes{}
+		t := subnet.(map[string]interface{})
+		if v, ok := t["id"].(string); ok {
+			r.Id = v
+		}
+		if v, ok := t["cidr"].(string); ok {
+			r.Value = v
 		}
 
-		return append(prefixes, overlaySubnetList...), nil
-
-	default:
-		return nil, fmt.Errorf("ERROR: either \"vpc_subnet\" or \"vpc_cidr\" must be specified")
+		r.Type = "SUBNET"
+		prefixes[i] = r
 	}
+
+	prefixes = append(prefixes, overlaySubnetList...)
+	return prefixes, nil
 }
 
 // expandAwsVpcTgwAttachments expand tgw_attachment of connector_aws_vpc

--- a/alkira/resource_alkira_connector_aws_vpc_helper_test.go
+++ b/alkira/resource_alkira_connector_aws_vpc_helper_test.go
@@ -204,7 +204,7 @@ func TestExpandUserInputPrefixes(t *testing.T) {
 			expectError: false,
 		},
 		{
-			name: "mixed subnets and CIDR - should error",
+			name: "mixed subnets and CIDR",
 			cidr: []interface{}{"10.0.0.0/16"},
 			subnets: schema.NewSet(
 				func(i interface{}) int {
@@ -219,125 +219,8 @@ func TestExpandUserInputPrefixes(t *testing.T) {
 				},
 			),
 			overlaySubnets: []interface{}{"172.16.0.0/24"},
-			expected:       nil,
-			expectError:    true,
-			errorMsg:       "cannot both be specified",
-		},
-		{
-			name:           "empty cidr with valid subnets - subnet mode",
-			cidr:           []interface{}{},
-			subnets: schema.NewSet(
-				func(i interface{}) int {
-					m := i.(map[string]interface{})
-					return schema.HashString(m["id"].(string))
-				},
-				[]interface{}{
-					map[string]interface{}{
-						"id":   "subnet-123",
-						"cidr": "10.0.1.0/24",
-					},
-				},
-			),
-			overlaySubnets: []interface{}{},
-			expected: []alkira.InputPrefixes{
-				{Id: "subnet-123", Type: "SUBNET", Value: "10.0.1.0/24"},
-			},
-			expectError: false,
-		},
-		{
-			name:           "nil subnets with valid cidr - cidr mode",
-			cidr:           []interface{}{"10.0.0.0/16"},
-			subnets:        nil,
-			overlaySubnets: []interface{}{},
 			expected: []alkira.InputPrefixes{
 				{Type: "CIDR", Value: "10.0.0.0/16"},
-			},
-			expectError: false,
-		},
-		{
-			name: "empty cidr with multiple subnets",
-			cidr: []interface{}{},
-			subnets: schema.NewSet(
-				func(i interface{}) int {
-					m := i.(map[string]interface{})
-					return schema.HashString(m["id"].(string))
-				},
-				[]interface{}{
-					map[string]interface{}{
-						"id":   "subnet-123",
-						"cidr": "10.0.1.0/24",
-					},
-					map[string]interface{}{
-						"id":   "subnet-456",
-						"cidr": "10.0.2.0/24",
-					},
-				},
-			),
-			overlaySubnets: []interface{}{},
-			expected: []alkira.InputPrefixes{
-				{Id: "subnet-123", Type: "SUBNET", Value: "10.0.1.0/24"},
-				{Id: "subnet-456", Type: "SUBNET", Value: "10.0.2.0/24"},
-			},
-			expectError: false,
-		},
-		{
-			name: "empty subnets set with valid cidr - cidr mode",
-			cidr: []interface{}{"192.168.0.0/16"},
-			subnets: schema.NewSet(
-				func(i interface{}) int {
-					m := i.(map[string]interface{})
-					return schema.HashString(m["id"].(string))
-				},
-				[]interface{}{},
-			),
-			overlaySubnets: []interface{}{},
-			expected: []alkira.InputPrefixes{
-				{Type: "CIDR", Value: "192.168.0.0/16"},
-			},
-			expectError: false,
-		},
-		{
-			name:           "empty cidr and empty subnets - should error",
-			cidr:           []interface{}{},
-			subnets: schema.NewSet(
-				func(i interface{}) int {
-					m := i.(map[string]interface{})
-					return schema.HashString(m["id"].(string))
-				},
-				[]interface{}{},
-			),
-			overlaySubnets: []interface{}{},
-			expected:       nil,
-			expectError:    true,
-			errorMsg:       "either",
-		},
-		{
-			name:           "nil cidr and nil subnets - should error",
-			cidr:           nil,
-			subnets:        nil,
-			overlaySubnets: []interface{}{},
-			expected:       nil,
-			expectError:    true,
-			errorMsg:       "either",
-		},
-		{
-			name:           "subnets with overlay - combined payload",
-			cidr:           []interface{}{},
-			subnets: schema.NewSet(
-				func(i interface{}) int {
-					m := i.(map[string]interface{})
-					return schema.HashString(m["id"].(string))
-				},
-				[]interface{}{
-					map[string]interface{}{
-						"id":   "subnet-789",
-						"cidr": "10.0.3.0/24",
-					},
-				},
-			),
-			overlaySubnets: []interface{}{"172.16.0.0/24"},
-			expected: []alkira.InputPrefixes{
-				{Id: "subnet-789", Type: "SUBNET", Value: "10.0.3.0/24"},
 				{Type: "OVERLAY_SUBNETS", Value: "172.16.0.0/24"},
 			},
 			expectError: false,


### PR DESCRIPTION
## Summary

Restores the AWS VPC connector resource to its pre-January-2026 behavior by reverting:
- **#539** (AK-65432): Read to populate routing and TGW fields
- **#588** (AK-66346): `Computed: true` + unconditional-set drift fix
- **#610** (AK-66870): `vpc_cidr` to `vpc_subnet` mode switch fix

## What changes

- Removes `Computed: true` from `vpc_cidr`, `vpc_subnet`, `vpc_route_table`, `overlay_subnets`
- Removes `setAwsVpcRoutingOptions` / `setAwsVpcExportPrefixes` / `setAwsVpcImportRouteTables` helper functions
- Read function no longer sets routing fields from the API response
- Restores original `expandUserInputPrefixes` logic
