### PR TITLE
[CLONE-64] Revert AWS VPC connector routing Read changes (#539, #606)

### DIFF
--- a/alkira/resource_alkira_connector_aws_vpc.go
+++ b/alkira/resource_alkira_connector_aws_vpc.go
@@ -163,7 +163,6 @@ func resourceAlkiraConnectorAwsVpc() *schema.Resource {
 					"`vpc_subnet` is not specified.",
 				Type:          schema.TypeList,
 				Optional:      true,
-				Computed:      true,
 				ConflictsWith: []string{"vpc_subnet"},
 				Elem:          &schema.Schema{Type: schema.TypeString},
 			},
@@ -173,7 +172,6 @@ func resourceAlkiraConnectorAwsVpc() *schema.Resource {
 					"is not specified.",
 				Type:          schema.TypeSet,
 				Optional:      true,
-				Computed:      true,
 				ConflictsWith: []string{"vpc_cidr"},
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
@@ -221,7 +219,6 @@ func resourceAlkiraConnectorAwsVpc() *schema.Resource {
 					},
 				},
 				Optional: true,
-				Computed: true,
 			},
 			"scale_group_id": {
 				Description: "The ID of the scale group associated with the connector.",
@@ -232,7 +229,6 @@ func resourceAlkiraConnectorAwsVpc() *schema.Resource {
 				Description: "Overlay subnet.",
 				Type:        schema.TypeList,
 				Optional:    true,
-				Computed:    true,
 				Elem:        &schema.Schema{Type: schema.TypeString},
 			},
 			"description": {
@@ -333,14 +329,6 @@ func resourceConnectorAwsVpcRead(ctx context.Context, d *schema.ResourceData, m 
 	d.Set("tgw_connect_enabled", connector.TgwConnectEnabled)
 	d.Set("scale_group_id", connector.ScaleGroupId)
 	d.Set("description", connector.Description)
-
-	// Set routing configuration from API response
-	setAwsVpcRoutingOptions(connector, d)
-
-	// Set TGW attachments (reusing existing function)
-	if connector.TgwAttachments != nil && len(connector.TgwAttachments) > 0 {
-		setTgwAttachment(d, connector.TgwAttachments)
-	}
 
 	// Get segment
 	numOfSegments := len(connector.Segments)

--- a/alkira/resource_alkira_connector_aws_vpc_helper.go
+++ b/alkira/resource_alkira_connector_aws_vpc_helper.go
@@ -1,124 +1,12 @@
 package alkira
 
 import (
-	"encoding/json"
 	"fmt"
 	"log"
 
 	"github.com/alkiranet/alkira-client-go/alkira"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
-
-// setAwsVpcRoutingOptions sets the routing configuration fields from the API response
-func setAwsVpcRoutingOptions(connector *alkira.ConnectorAwsVpc, d *schema.ResourceData) {
-	if connector.VpcRouting == nil {
-		log.Printf("[DEBUG] VpcRouting is nil, skipping routing options")
-		return
-	}
-
-	// Unmarshal the interface{} to concrete types
-	routingJSON, err := json.Marshal(connector.VpcRouting)
-	if err != nil {
-		log.Printf("[ERROR] Failed to marshal VpcRouting: %v", err)
-		return
-	}
-
-	var routing alkira.ConnectorAwsVpcRouting
-	if err := json.Unmarshal(routingJSON, &routing); err != nil {
-		log.Printf("[ERROR] Failed to unmarshal VpcRouting: %v", err)
-		return
-	}
-
-	// Set export-related fields (vpc_cidr, vpc_subnet, overlay_subnets)
-	setAwsVpcExportPrefixes(routing.Export, d)
-
-	// Set import-related fields (vpc_route_table)
-	setAwsVpcImportRouteTables(routing.Import, d)
-}
-
-// setAwsVpcExportPrefixes sets export-related fields from ExportOptions
-func setAwsVpcExportPrefixes(exportOptions interface{}, d *schema.ResourceData) {
-	if exportOptions == nil {
-		log.Printf("[DEBUG] Export options is nil, clearing export prefixes")
-		d.Set("vpc_cidr", []interface{}{})
-		d.Set("vpc_subnet", []interface{}{})
-		d.Set("overlay_subnets", []interface{}{})
-		return
-	}
-
-	// Unmarshal the interface{} to ExportOptions
-	exportJSON, err := json.Marshal(exportOptions)
-	if err != nil {
-		log.Printf("[ERROR] Failed to marshal ExportOptions: %v", err)
-		return
-	}
-
-	var export alkira.ExportOptions
-	if err := json.Unmarshal(exportJSON, &export); err != nil {
-		log.Printf("[ERROR] Failed to unmarshal ExportOptions: %v", err)
-		return
-	}
-
-	var cidrList []string
-	var subnetList []interface{}
-	var overlaySubnets []string
-
-	for _, prefix := range export.Prefixes {
-		switch prefix.Type {
-		case "CIDR":
-			cidrList = append(cidrList, prefix.Value)
-		case "SUBNET":
-			subnet := map[string]interface{}{
-				"id":   prefix.Id,
-				"cidr": prefix.Value,
-			}
-			subnetList = append(subnetList, subnet)
-		case "OVERLAY_SUBNETS":
-			overlaySubnets = append(overlaySubnets, prefix.Value)
-		default:
-			log.Printf("[DEBUG] Unknown prefix type: %s", prefix.Type)
-		}
-	}
-
-	// Always set all export fields because they are Computed
-	// Backend returns userInputPrefixes with type entries; empty set if none specified
-	d.Set("vpc_cidr", cidrList)
-	d.Set("vpc_subnet", subnetList)
-	d.Set("overlay_subnets", overlaySubnets)
-}
-
-// setAwsVpcImportRouteTables sets vpc_route_table from ImportOptions
-func setAwsVpcImportRouteTables(importOptions interface{}, d *schema.ResourceData) {
-	if importOptions == nil {
-		log.Printf("[DEBUG] Import options is nil, skipping route tables")
-		return
-	}
-
-	// Unmarshal the interface{} to ImportOptions
-	importJSON, err := json.Marshal(importOptions)
-	if err != nil {
-		log.Printf("[ERROR] Failed to marshal ImportOptions: %v", err)
-		return
-	}
-
-	var importOpts alkira.ImportOptions
-	if err := json.Unmarshal(importJSON, &importOpts); err != nil {
-		log.Printf("[ERROR] Failed to unmarshal ImportOptions: %v", err)
-		return
-	}
-
-	routeTables := make([]interface{}, len(importOpts.RouteTables))
-	for i, rt := range importOpts.RouteTables {
-		routeTable := map[string]interface{}{
-			"id":              rt.Id,
-			"options":         rt.Mode,
-			"prefix_list_ids": rt.PrefixListIds,
-		}
-		routeTables[i] = routeTable
-	}
-
-	d.Set("vpc_route_table", routeTables)
-}
 
 // setTgwAttachment set tgw_attachment blocks
 func setTgwAttachment(d *schema.ResourceData, tgwAttachments []alkira.TgwAttachment) {
@@ -163,6 +51,7 @@ func setTgwAttachment(d *schema.ResourceData, tgwAttachments []alkira.TgwAttachm
 			}
 
 			attachments = append(attachments, attachment)
+			break
 		}
 	}
 


### PR DESCRIPTION
## Summary

Restores the AWS VPC connector resource to its pre-January-2026 behavior by reverting:
- **#539** (AK-65432): Read to populate routing and TGW fields
- **#606** (AK-66765): `Computed: true` + unconditional-set drift fix (clone of #588)

## What changes

- Removes `Computed: true` from `vpc_cidr`, `vpc_subnet`, `vpc_route_table`, `overlay_subnets`
- Removes `setAwsVpcRoutingOptions` / `setAwsVpcExportPrefixes` / `setAwsVpcImportRouteTables` helper functions
- Read function no longer sets routing fields from the API response

Unrelated improvements (import error handling, delete error messages) are preserved.