### PR TITLE
AK-67049: filter system-generated zones from segment_options using configOrigin

### DIFF
--- a/alkira/helper.go
+++ b/alkira/helper.go
@@ -79,6 +79,10 @@ func deflateSegmentOptions(c alkira.SegmentNameToZone) []map[string]interface{} 
 
 	for _, outerZoneToGroups := range c {
 		for zone, groups := range outerZoneToGroups.ZonesToGroups {
+			if outerZoneToGroups.ZoneConfigOrigins[zone] == "SYSTEM" {
+				log.Printf("[DEBUG] Filtering system-generated zone %s from segment_options", zone)
+				continue
+			}
 			i := map[string]interface{}{
 				"segment_id": strconv.Itoa(outerZoneToGroups.SegmentId),
 				"zone_name":  zone,

--- a/alkira/helper_test.go
+++ b/alkira/helper_test.go
@@ -455,6 +455,111 @@ func TestDeflateSegmentOptionsCanBeSetInTerraformState(t *testing.T) {
 	assert.True(t, foundUntrustZone, "untrust-zone should be in segment_options")
 }
 
+func TestDeflateSegmentOptionsFiltersManagementZone(t *testing.T) {
+	zonesToGroups := make(alkira.ZoneToGroups)
+	zonesToGroups["trust-zone"] = []string{"group1"}
+	zonesToGroups["ALKIRA_MGMT_ZONE"] = []string{}
+
+	segmentOptions := make(alkira.SegmentNameToZone)
+	segmentOptions["segment1"] = alkira.OuterZoneToGroups{
+		SegmentId:     100,
+		ZonesToGroups: zonesToGroups,
+		ZoneConfigOrigins: map[string]string{
+			"ALKIRA_MGMT_ZONE": "SYSTEM",
+			"trust-zone":       "USER",
+		},
+	}
+
+	result := deflateSegmentOptions(segmentOptions)
+
+	assert.Len(t, result, 1, "ALKIRA_MGMT_ZONE should be filtered out")
+	assert.Equal(t, "trust-zone", result[0]["zone_name"])
+	assert.Equal(t, "100", result[0]["segment_id"])
+}
+
+func TestDeflateSegmentOptionsFiltersManagementZoneMultipleSegments(t *testing.T) {
+	zones1 := make(alkira.ZoneToGroups)
+	zones1["trust-zone"] = []string{"group1"}
+	zones1["ALKIRA_MGMT_ZONE"] = []string{}
+
+	zones2 := make(alkira.ZoneToGroups)
+	zones2["untrust-zone"] = []string{"group2"}
+	zones2["ALKIRA_MGMT_ZONE"] = nil
+
+	segmentOptions := make(alkira.SegmentNameToZone)
+	segmentOptions["seg1"] = alkira.OuterZoneToGroups{
+		SegmentId:     100,
+		ZonesToGroups: zones1,
+		ZoneConfigOrigins: map[string]string{
+			"ALKIRA_MGMT_ZONE": "SYSTEM",
+			"trust-zone":       "USER",
+		},
+	}
+	segmentOptions["seg2"] = alkira.OuterZoneToGroups{
+		SegmentId:     200,
+		ZonesToGroups: zones2,
+		ZoneConfigOrigins: map[string]string{
+			"ALKIRA_MGMT_ZONE": "SYSTEM",
+			"untrust-zone":     "USER",
+		},
+	}
+
+	result := deflateSegmentOptions(segmentOptions)
+
+	assert.Len(t, result, 2, "Only non-mgmt zones should remain")
+
+	zoneNames := make(map[string]bool)
+	for _, opt := range result {
+		zoneNames[opt["zone_name"].(string)] = true
+	}
+	assert.True(t, zoneNames["trust-zone"])
+	assert.True(t, zoneNames["untrust-zone"])
+	assert.False(t, zoneNames["ALKIRA_MGMT_ZONE"])
+}
+
+func TestDeflateSegmentOptionsKeepsUserZoneNamedAlkiraMgmtZone(t *testing.T) {
+	zonesToGroups := make(alkira.ZoneToGroups)
+	zonesToGroups["ALKIRA_MGMT_ZONE"] = []string{"group1"}
+
+	segmentOptions := make(alkira.SegmentNameToZone)
+	segmentOptions["segment1"] = alkira.OuterZoneToGroups{
+		SegmentId:     100,
+		ZonesToGroups: zonesToGroups,
+		ZoneConfigOrigins: map[string]string{
+			"ALKIRA_MGMT_ZONE": "USER",
+		},
+	}
+
+	result := deflateSegmentOptions(segmentOptions)
+
+	assert.Len(t, result, 1, "USER-origin zone named ALKIRA_MGMT_ZONE should not be filtered")
+	assert.Equal(t, "ALKIRA_MGMT_ZONE", result[0]["zone_name"])
+}
+
+func TestDeflateSegmentOptionsNoFilterWhenConfigOriginsNil(t *testing.T) {
+	zonesToGroups := make(alkira.ZoneToGroups)
+	zonesToGroups["trust-zone"] = []string{"group1"}
+	zonesToGroups["ALKIRA_MGMT_ZONE"] = []string{}
+
+	segmentOptions := make(alkira.SegmentNameToZone)
+	segmentOptions["segment1"] = alkira.OuterZoneToGroups{
+		SegmentId:         100,
+		ZonesToGroups:     zonesToGroups,
+		ZoneConfigOrigins: nil,
+	}
+
+	result := deflateSegmentOptions(segmentOptions)
+
+	assert.Len(t, result, 2, "all zones should be kept when ZoneConfigOrigins is nil (old API)")
+
+	zoneNames := make(map[string]bool)
+	for _, opt := range result {
+		zoneNames[opt["zone_name"].(string)] = true
+	}
+	assert.True(t, zoneNames["trust-zone"])
+	assert.True(t, zoneNames["ALKIRA_MGMT_ZONE"])
+}
+
 func TestConvertInputTimeToEpoch(t *testing.T) {
 	tests := []struct {
 		name        string

--- a/vendor/github.com/alkiranet/alkira-client-go/alkira/helper.go
+++ b/vendor/github.com/alkiranet/alkira-client-go/alkira/helper.go
@@ -21,8 +21,9 @@ type ZoneToGroups map[string][]string
 // OuterZoneToGroups is an object that includes a segment ID as an
 // identifier and a map of zone names to Groups
 type OuterZoneToGroups struct {
-	SegmentId     int          `json:"segmentId"`
-	ZonesToGroups ZoneToGroups `json:"zonesToGroups"`
+	SegmentId         int               `json:"segmentId"`
+	ZonesToGroups     ZoneToGroups      `json:"zonesToGroups"`
+	ZoneConfigOrigins map[string]string `json:"zoneConfigOrigins"`
 }
 
 // logf a simple log wrapper to log based on ENV var


### PR DESCRIPTION
## Summary

- `deflateSegmentOptions()` now skips zones where `ZoneConfigOrigins[zone] == "SYSTEM"`, preventing backend-injected zones (e.g. `ALKIRA_MGMT_ZONE`) from appearing in Terraform state and causing perpetual drift
- Backward-compatible: when `ZoneConfigOrigins` is `nil` (older API versions), the map lookup returns `""` which does not match `"SYSTEM"`, so no zones are filtered
- `ZoneConfigOrigins map[string]string` added to `OuterZoneToGroups` in the vendored `alkira-client-go` helper — manual update pending upstream TPS PR #5184; will be replaced by a proper `make vendor` once that lands

## Test plan

- [x] `TestDeflateSegmentOptionsFiltersManagementZone` — SYSTEM zone is filtered out
- [x] `TestDeflateSegmentOptionsFiltersManagementZoneMultipleSegments` — SYSTEM zones filtered across multiple segments
- [x] `TestDeflateSegmentOptionsKeepsUserZoneNamedAlkiraMgmtZone` — zone named `ALKIRA_MGMT_ZONE` with origin `USER` is kept
- [x] `TestDeflateSegmentOptionsNoFilterWhenConfigOriginsNil` — nil `ZoneConfigOrigins` (old API) keeps all zones
- [x] `go test ./alkira/...` passes
- [x] `make build` passes