### PR TITLE
AK-67534 Bump fortinet acceptance test version to 7.4.3

### DIFF
--- a/acceptance/service_fortinet.tf
+++ b/acceptance/service_fortinet.tf
@@ -10,7 +10,7 @@ resource "alkira_service_fortinet" "test1" {
   segment_ids                  = [alkira_segment.test1.id, alkira_segment.test2.id]
   size                         = "SMALL"
   tunnel_protocol              = "IPSEC"
-  version                      = "7.0.3"
+  version                      = "7.4.3"
 
   instances {
     name                  = "a-ins1"


### PR DESCRIPTION
- version 7.0.3 is now deprecated for fortigate-byol/payg on US-WEST-1 in `alkiranet/inventory-data/data/common/products/overrides/us-west-1.yaml`, causing the `acceptance-test-preprod` check to fail with:
      `Fortinet firewall version '7.0.3' is not supported on cxp 'US-WEST-1'`
- 7.4.11 is non-deprecated on us-west-1 (preprod) but not yet present in the prod inventory for the US-WEST CXP. 
- 7.4.3 is older and present in both environments' fortigate-byol/payg catalogs.