### PR TITLE
AK-67626: Add MaxItems=1 to Juniper SDWAN instance block

### DIFF
--- a/alkira/resource_alkira_connector_juniper_sdwan.go
+++ b/alkira/resource_alkira_connector_juniper_sdwan.go
@@ -102,9 +102,10 @@ func resourceAlkiraConnectorJuniperSdwan() *schema.Resource {
 				},
 			},
 			"instance": {
-				Description: "Juniper SSR Connector Instances",
+				Description: "Juniper SSR Connector Instances. Only one instance is supported per connector (HA is not supported on cloud).",
 				Type:        schema.TypeList,
 				MinItems:    1,
+				MaxItems:    1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"registration_key": {


### PR DESCRIPTION
## Summary
- Adds `MaxItems: 1` to the Juniper SDWAN connector `instance` schema block, enforcing a single-instance constraint client-side
- Juniper confirmed HA is not recommended on cloud; no production deployments exist with multiple instances
- Matches the corresponding API schema change (AK-67626)

## Context
Hotfix to REL64. Part of [AK-67626](https://alkiranet.atlassian.net/browse/AK-67626).

## Test plan
- [ ] Verify `terraform plan` rejects configs with more than one instance in the `instance` block
- [ ] Verify existing single-instance configs continue to work without changes
- [ ] Run provider acceptance tests for `alkira_connector_juniper_sdwan`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[AK-67626]: https://alkiranet.atlassian.net/browse/AK-67626?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ