### PR TITLE
AK-67722: Add MaxItems=1 to Juniper SDWAN instance block

### DIFF
--- a/alkira/resource_alkira_connector_juniper_sdwan.go
+++ b/alkira/resource_alkira_connector_juniper_sdwan.go
@@ -102,9 +102,10 @@ func resourceAlkiraConnectorJuniperSdwan() *schema.Resource {
 				},
 			},
 			"instance": {
-				Description: "Juniper SSR Connector Instances",
+				Description: "Juniper SSR Connector Instance. Only one instance is supported per connector.",
 				Type:        schema.TypeList,
 				MinItems:    1,
+				MaxItems:    1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"registration_key": {


### PR DESCRIPTION
## Summary
- Add `MaxItems: 1` to Juniper SDWAN `instance` schema block
- Enforces single-instance constraint client-side to match API schema change

## Context
Parent: AK-67626. Hotfix to REL64. No production deployments exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)