### PR TITLE
AK-67727: [REL64] Add MaxItems=1 to Juniper SDWAN instance block

### DIFF
--- a/alkira/resource_alkira_connector_juniper_sdwan.go
+++ b/alkira/resource_alkira_connector_juniper_sdwan.go
@@ -102,9 +102,10 @@ func resourceAlkiraConnectorJuniperSdwan() *schema.Resource {
 				},
 			},
 			"instance": {
-				Description: "Juniper SSR Connector Instances",
+				Description: "Juniper SSR Connector Instance. Only one instance is supported per connector.",
 				Type:        schema.TypeList,
 				MinItems:    1,
+				MaxItems:    1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"registration_key": {


### PR DESCRIPTION
## Summary
- Cherry-pick of AK-67722 to REL64
- Add `MaxItems: 1` to Juniper SDWAN `instance` schema block
- Enforces single-instance constraint client-side to match API schema change

## Test plan
- [ ] Verify Terraform plan with 1 instance succeeds
- [ ] Verify Terraform plan with 2 instances fails validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)