### PR TITLE
AK-67860: Expose alkira_admin_password on Fortinet FW credential Terraform resource

### DIFF
--- a/alkira/resource_alkira_service_fortinet.go
+++ b/alkira/resource_alkira_service_fortinet.go
@@ -62,6 +62,18 @@ func resourceAlkiraServiceFortinet() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"alkira_admin_password": {
+				Description: "Customer-supplied alkira-admin password. " +
+					"Used to authenticate against the FortiGate during first-time provisioning. " +
+					"Once provisioned, this field is for record-keeping only — Alkira does not " +
+					"rotate the password on deployed FortiGate instances. To change the password " +
+					"after provisioning, update the FortiGate side independently, then update " +
+					"this field to match. " +
+					"Gated behind feature flag RELEASE-SERVICE-FTNTFW-ALKIRA-ADMIN-PASSWORD.",
+				Type:      schema.TypeString,
+				Optional:  true,
+				Sensitive: true,
+			},
 			"cxp": {
 				Description: "The CXP where the service should be provisioned.",
 				Type:        schema.TypeString,

--- a/alkira/resource_alkira_service_fortinet.go
+++ b/alkira/resource_alkira_service_fortinet.go
@@ -68,8 +68,7 @@ func resourceAlkiraServiceFortinet() *schema.Resource {
 					"Once provisioned, this field is for record-keeping only — Alkira does not " +
 					"rotate the password on deployed FortiGate instances. To change the password " +
 					"after provisioning, update the FortiGate side independently, then update " +
-					"this field to match. " +
-					"Gated behind feature flag RELEASE-SERVICE-FTNTFW-ALKIRA-ADMIN-PASSWORD.",
+					"this field to match.",
 				Type:      schema.TypeString,
 				Optional:  true,
 				Sensitive: true,

--- a/alkira/resource_alkira_service_fortinet_helper.go
+++ b/alkira/resource_alkira_service_fortinet_helper.go
@@ -165,8 +165,9 @@ func createFortinetCredential(d *schema.ResourceData, c *alkira.AlkiraClient) (s
 	d.Set("credential_name", credentialName)
 
 	credential := alkira.CredentialFortinet{
-		UserName: d.Get("username").(string),
-		Password: d.Get("password").(string),
+		UserName:            d.Get("username").(string),
+		Password:            d.Get("password").(string),
+		AlkiraAdminPassword: d.Get("alkira_admin_password").(string),
 	}
 
 	return c.CreateCredential(credentialName, alkira.CredentialTypeFortinet, credential, 0)
@@ -174,7 +175,7 @@ func createFortinetCredential(d *schema.ResourceData, c *alkira.AlkiraClient) (s
 
 // updateFortinetCredential update credential when username or password has changes
 func updateFortinetCredential(d *schema.ResourceData, c *alkira.AlkiraClient) error {
-	if d.HasChanges("username", "password") {
+	if d.HasChanges("username", "password", "alkira_admin_password") {
 		log.Printf("[INFO] Fortinet credential has changed")
 
 		if d.Get("credential_id") == nil {
@@ -188,8 +189,9 @@ func updateFortinetCredential(d *schema.ResourceData, c *alkira.AlkiraClient) er
 			credentialId := d.Get("credential_id").(string)
 
 			credential := alkira.CredentialFortinet{
-				UserName: d.Get("username").(string),
-				Password: d.Get("password").(string),
+				UserName:            d.Get("username").(string),
+				Password:            d.Get("password").(string),
+				AlkiraAdminPassword: d.Get("alkira_admin_password").(string),
 			}
 
 			return c.UpdateCredential(credentialId, credentialName, alkira.CredentialTypeFortinet, credential, 0)

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/alkiranet/terraform-provider-alkira
 go 1.26
 
 require (
-	github.com/alkiranet/alkira-client-go v1.59.1-0.20260416002820-3d69db9f22ea
+	github.com/alkiranet/alkira-client-go v1.59.1-0.20260504220508-2f02043c0bb3
 	github.com/hashicorp/go-cty v1.5.0
 	github.com/hashicorp/go-retryablehttp v0.7.7
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.37.0

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/alkiranet/terraform-provider-alkira
 go 1.26
 
 require (
-	github.com/alkiranet/alkira-client-go v1.59.1-0.20260504220508-2f02043c0bb3
+	github.com/alkiranet/alkira-client-go v1.59.1-0.20260504224438-015a2b0ee62d
 	github.com/hashicorp/go-cty v1.5.0
 	github.com/hashicorp/go-retryablehttp v0.7.7
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.37.0

--- a/go.sum
+++ b/go.sum
@@ -5,8 +5,8 @@ github.com/PuerkitoBio/purell v1.1.1/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbt
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
 github.com/agext/levenshtein v1.2.2 h1:0S/Yg6LYmFJ5stwQeRp6EeOcCbj7xiqQSdNelsXvaqE=
 github.com/agext/levenshtein v1.2.2/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
-github.com/alkiranet/alkira-client-go v1.59.1-0.20260416002820-3d69db9f22ea h1:8Th3zqnf81LyFGgCrDau+cR2sxtwpnSE/KSPexyT6Zs=
-github.com/alkiranet/alkira-client-go v1.59.1-0.20260416002820-3d69db9f22ea/go.mod h1:ms9LjOc4O1Zrr7/VQOva+xwv3sJuBUqS9JsI+MbE2go=
+github.com/alkiranet/alkira-client-go v1.59.1-0.20260504220508-2f02043c0bb3 h1:qQnJTPegvribKau5ILM9IGoGrVMiKux716UEOcxUW/o=
+github.com/alkiranet/alkira-client-go v1.59.1-0.20260504220508-2f02043c0bb3/go.mod h1:ms9LjOc4O1Zrr7/VQOva+xwv3sJuBUqS9JsI+MbE2go=
 github.com/apparentlymart/go-textseg/v12 v12.0.0/go.mod h1:S/4uRK2UtaQttw1GenVJEynmyUenKwP++x/+DdGV/Ec=
 github.com/apparentlymart/go-textseg/v15 v15.0.0 h1:uYvfpb3DyLSCGWnctWKGj857c6ew1u1fNQOlOtuGxQY=
 github.com/apparentlymart/go-textseg/v15 v15.0.0/go.mod h1:K8XmNZdhEBkdlyDdvbmmsvpAG721bKi0joRfFdHIWJ4=

--- a/go.sum
+++ b/go.sum
@@ -5,8 +5,8 @@ github.com/PuerkitoBio/purell v1.1.1/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbt
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
 github.com/agext/levenshtein v1.2.2 h1:0S/Yg6LYmFJ5stwQeRp6EeOcCbj7xiqQSdNelsXvaqE=
 github.com/agext/levenshtein v1.2.2/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
-github.com/alkiranet/alkira-client-go v1.59.1-0.20260504220508-2f02043c0bb3 h1:qQnJTPegvribKau5ILM9IGoGrVMiKux716UEOcxUW/o=
-github.com/alkiranet/alkira-client-go v1.59.1-0.20260504220508-2f02043c0bb3/go.mod h1:ms9LjOc4O1Zrr7/VQOva+xwv3sJuBUqS9JsI+MbE2go=
+github.com/alkiranet/alkira-client-go v1.59.1-0.20260504224438-015a2b0ee62d h1:1PkwPxKghfy21/cTlRWMPhWqwl4nmQaoaYoGbKZc94U=
+github.com/alkiranet/alkira-client-go v1.59.1-0.20260504224438-015a2b0ee62d/go.mod h1:ms9LjOc4O1Zrr7/VQOva+xwv3sJuBUqS9JsI+MbE2go=
 github.com/apparentlymart/go-textseg/v12 v12.0.0/go.mod h1:S/4uRK2UtaQttw1GenVJEynmyUenKwP++x/+DdGV/Ec=
 github.com/apparentlymart/go-textseg/v15 v15.0.0 h1:uYvfpb3DyLSCGWnctWKGj857c6ew1u1fNQOlOtuGxQY=
 github.com/apparentlymart/go-textseg/v15 v15.0.0/go.mod h1:K8XmNZdhEBkdlyDdvbmmsvpAG721bKi0joRfFdHIWJ4=

--- a/vendor/github.com/alkiranet/alkira-client-go/alkira/credentials.go
+++ b/vendor/github.com/alkiranet/alkira-client-go/alkira/credentials.go
@@ -112,9 +112,8 @@ type CredentialGcpVpc struct {
 }
 
 type CredentialFortinet struct {
-	UserName            string `json:"userName"`
-	Password            string `json:"password"`
-	AlkiraAdminPassword string `json:"alkiraAdminPassword,omitempty"`
+	UserName string `json:"userName"`
+	Password string `json:"password"`
 }
 
 type CredentialFortinetInstance struct {

--- a/vendor/github.com/alkiranet/alkira-client-go/alkira/credentials.go
+++ b/vendor/github.com/alkiranet/alkira-client-go/alkira/credentials.go
@@ -112,8 +112,9 @@ type CredentialGcpVpc struct {
 }
 
 type CredentialFortinet struct {
-	UserName string `json:"userName"`
-	Password string `json:"password"`
+	UserName            string `json:"userName"`
+	Password            string `json:"password"`
+	AlkiraAdminPassword string `json:"alkiraAdminPassword,omitempty"`
 }
 
 type CredentialFortinetInstance struct {

--- a/vendor/github.com/alkiranet/alkira-client-go/alkira/credentials.go
+++ b/vendor/github.com/alkiranet/alkira-client-go/alkira/credentials.go
@@ -120,7 +120,6 @@ type CredentialFortinet struct {
 	// rotate the password on deployed FortiGate instances. To change the password
 	// after provisioning, customers must update the FortiGate side independently
 	// and then update this field in Alkira to match.
-	// Gated behind feature flag RELEASE-SERVICE-FTNTFW-ALKIRA-ADMIN-PASSWORD.
 	AlkiraAdminPassword string `json:"alkiraAdminPassword,omitempty"`
 }
 

--- a/vendor/github.com/alkiranet/alkira-client-go/alkira/credentials.go
+++ b/vendor/github.com/alkiranet/alkira-client-go/alkira/credentials.go
@@ -114,6 +114,14 @@ type CredentialGcpVpc struct {
 type CredentialFortinet struct {
 	UserName string `json:"userName"`
 	Password string `json:"password"`
+	// AlkiraAdminPassword is the customer-supplied alkira-admin password.
+	// Used to authenticate against the FortiGate during first-time provisioning.
+	// Once provisioned, this field is for record-keeping only — Alkira does not
+	// rotate the password on deployed FortiGate instances. To change the password
+	// after provisioning, customers must update the FortiGate side independently
+	// and then update this field in Alkira to match.
+	// Gated behind feature flag RELEASE-SERVICE-FTNTFW-ALKIRA-ADMIN-PASSWORD.
+	AlkiraAdminPassword string `json:"alkiraAdminPassword,omitempty"`
 }
 
 type CredentialFortinetInstance struct {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,7 +1,7 @@
 # github.com/agext/levenshtein v1.2.2
 ## explicit
 github.com/agext/levenshtein
-# github.com/alkiranet/alkira-client-go v1.59.1-0.20260416002820-3d69db9f22ea
+# github.com/alkiranet/alkira-client-go v1.59.1-0.20260504220508-2f02043c0bb3
 ## explicit; go 1.26
 github.com/alkiranet/alkira-client-go/alkira
 # github.com/apparentlymart/go-textseg/v15 v15.0.0

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,7 +1,7 @@
 # github.com/agext/levenshtein v1.2.2
 ## explicit
 github.com/agext/levenshtein
-# github.com/alkiranet/alkira-client-go v1.59.1-0.20260504220508-2f02043c0bb3
+# github.com/alkiranet/alkira-client-go v1.59.1-0.20260504224438-015a2b0ee62d
 ## explicit; go 1.26
 github.com/alkiranet/alkira-client-go/alkira
 # github.com/apparentlymart/go-textseg/v15 v15.0.0


### PR DESCRIPTION
## Summary
- Adds `alkira_admin_password` as an Optional, Sensitive attribute to the `alkira_service_fortinet` resource schema
- Wires the field through create and update credential flows (`CredentialFortinet` struct)
- Updates vendored `alkira-client-go` `CredentialFortinet` struct with `AlkiraAdminPassword` field (`omitempty`)

## Dependencies
- **AK-67859** (alkira-client-go): Backend client must expose `alkiraAdminPassword` on the Fortinet credential API. The vendored copy is updated here; once AK-67859 merges, run `go mod vendor` to pick up the official change.

## Test plan
- [ ] `go build ./...` passes (verified locally)
- [ ] Create a Fortinet FW service with `alkira_admin_password` set — verify credential payload includes `alkiraAdminPassword`
- [ ] Create without `alkira_admin_password` — verify `alkiraAdminPassword` is omitted from JSON (omitempty)
- [ ] Update `alkira_admin_password` on existing service — verify credential update is triggered
- [ ] Verify `alkira_admin_password` is masked in plan output (Sensitive flag)

🤖 Generated with [Claude Code](https://claude.com/claude-code)