### PR TITLE
[CLONE-65] AK-67809: Filter backend-injected ALKIRA_MGMT_ZONE from segment_options

### DIFF
--- a/alkira/helper.go
+++ b/alkira/helper.go
@@ -74,11 +74,21 @@ func expandSegmentOptions(in *schema.Set, m interface{}) (alkira.SegmentNameToZo
 	return segmentOptions, nil
 }
 
+// alkiraManagementZoneName is the backend-injected management zone
+// that should be filtered from Terraform state to prevent perpetual
+// drift. The backend auto-creates this zone for all firewall services
+// but users never configure it in HCL.
+const alkiraManagementZoneName = "ALKIRA_MGMT_ZONE"
+
 func deflateSegmentOptions(c alkira.SegmentNameToZone) []map[string]interface{} {
 	var options []map[string]interface{}
 
 	for _, outerZoneToGroups := range c {
 		for zone, groups := range outerZoneToGroups.ZonesToGroups {
+			if zone == alkiraManagementZoneName {
+				log.Printf("[DEBUG] Filtering out backend-injected %s from segment_options", alkiraManagementZoneName)
+				continue
+			}
 			i := map[string]interface{}{
 				"segment_id": strconv.Itoa(outerZoneToGroups.SegmentId),
 				"zone_name":  zone,

--- a/alkira/helper_test.go
+++ b/alkira/helper_test.go
@@ -455,6 +455,56 @@ func TestDeflateSegmentOptionsCanBeSetInTerraformState(t *testing.T) {
 	assert.True(t, foundUntrustZone, "untrust-zone should be in segment_options")
 }
 
+func TestDeflateSegmentOptionsFiltersManagementZone(t *testing.T) {
+	zonesToGroups := make(alkira.ZoneToGroups)
+	zonesToGroups["trust-zone"] = []string{"group1"}
+	zonesToGroups["ALKIRA_MGMT_ZONE"] = []string{}
+
+	segmentOptions := make(alkira.SegmentNameToZone)
+	segmentOptions["segment1"] = alkira.OuterZoneToGroups{
+		SegmentId:     100,
+		ZonesToGroups: zonesToGroups,
+	}
+
+	result := deflateSegmentOptions(segmentOptions)
+
+	assert.Len(t, result, 1, "ALKIRA_MGMT_ZONE should be filtered out")
+	assert.Equal(t, "trust-zone", result[0]["zone_name"])
+	assert.Equal(t, "100", result[0]["segment_id"])
+}
+
+func TestDeflateSegmentOptionsFiltersManagementZoneMultipleSegments(t *testing.T) {
+	zones1 := make(alkira.ZoneToGroups)
+	zones1["trust-zone"] = []string{"group1"}
+	zones1["ALKIRA_MGMT_ZONE"] = []string{}
+
+	zones2 := make(alkira.ZoneToGroups)
+	zones2["untrust-zone"] = []string{"group2"}
+	zones2["ALKIRA_MGMT_ZONE"] = nil
+
+	segmentOptions := make(alkira.SegmentNameToZone)
+	segmentOptions["seg1"] = alkira.OuterZoneToGroups{
+		SegmentId:     100,
+		ZonesToGroups: zones1,
+	}
+	segmentOptions["seg2"] = alkira.OuterZoneToGroups{
+		SegmentId:     200,
+		ZonesToGroups: zones2,
+	}
+
+	result := deflateSegmentOptions(segmentOptions)
+
+	assert.Len(t, result, 2, "Only non-mgmt zones should remain")
+
+	zoneNames := make(map[string]bool)
+	for _, opt := range result {
+		zoneNames[opt["zone_name"].(string)] = true
+	}
+	assert.True(t, zoneNames["trust-zone"])
+	assert.True(t, zoneNames["untrust-zone"])
+	assert.False(t, zoneNames["ALKIRA_MGMT_ZONE"])
+}
+
 func TestConvertInputTimeToEpoch(t *testing.T) {
 	tests := []struct {
 		name        string


### PR DESCRIPTION
Cherry-pick of PR #656 for REL 65 release.

**Original Issue:** AK-67049
**Clone for REL 65:** AK-67809

## Summary

- Filter out backend-injected `ALKIRA_MGMT_ZONE` entries in `deflateSegmentOptions()` before writing to Terraform state
- Add constant `alkiraManagementZoneName` for the management zone name
- Add unit tests for single-segment and multi-segment filtering

## Problem

The backend auto-injects an `ALKIRA_MGMT_ZONE` zone into `segmentOptions` for all firewall services (PAN, Fortinet, Checkpoint, Cisco FTDv). Users never configure this zone in HCL — it is a backend-managed internal zone used for management traffic. The provider's `deflateSegmentOptions()` was faithfully storing it in Terraform state, causing perpetual drift on every `plan`/`apply` cycle: Terraform would always show a removal diff for `ALKIRA_MGMT_ZONE` since it wasn't declared in the user's config.

## Changes

- `alkira/helper.go` — Add `alkiraManagementZoneName` constant, skip matching zones in `deflateSegmentOptions()`
- `alkira/helper_test.go` — Add `TestDeflateSegmentOptionsFiltersManagementZone` and `TestDeflateSegmentOptionsFiltersManagementZoneMultipleSegments`

## Original PR
#656

## Cherry-picked Commit(s)
- 2f628ce2b49a307e36f7dac23e9262ba6d41dfef