### PR TITLE
[AK-68129] Adds Computed to customer_asn schema for Azure VNet connec…

### DIFF
--- a/alkira/resource_alkira_connector_azure_vnet.go
+++ b/alkira/resource_alkira_connector_azure_vnet.go
@@ -261,9 +261,12 @@ func resourceAlkiraConnectorAzureVnet() *schema.Resource {
 					"when `connection_mode` is `VNET_PEERING`. This field cannot be updated " +
 					"once the connector has been provisioned. The ASN cannot be value that " +
 					"is [restricted by Azure]" +
-					"(https://learn.microsoft.com/en-us/azure/vpn-gateway/vpn-gateway-vpn-faq#bgp).",
+					"(https://learn.microsoft.com/en-us/azure/vpn-gateway/vpn-gateway-vpn-faq#bgp). " +
+					"If omitted, the backend assigns one (the existing Azure VGW's ASN if " +
+					"present, otherwise a default), which the provider reads back into state.",
 				Type:     schema.TypeInt,
 				Optional: true,
+				Computed: true,
 			},
 			"scale_group_id": {
 				Description: "The ID of the scale group associated with the connector.",

--- a/alkira/resource_alkira_connector_azure_vnet_helper_test.go
+++ b/alkira/resource_alkira_connector_azure_vnet_helper_test.go
@@ -453,3 +453,29 @@ func TestAzureVnetCidrFieldNameMatch(t *testing.T) {
 		assert.NotNil(t, vnetCidrField, "vnet_cidr field must not be nil")
 	})
 }
+
+
+// The backend auto-populates `customerAsn` when the user omits it in VGW mode
+// (either to the existing Azure VGW's ASN, or to a DEFAULT_ASN constant for a
+// fresh VNet). If the provider schema declares this field as Optional only,
+// the backend-supplied value lands in TF state and reads as drift versus the
+// empty user config, producing a perpetual "remove customer_asn" plan diff
+// that apply cannot resolve.
+//
+// Marking the field Optional + Computed tells Terraform that a backend-supplied
+// value is a valid settled outcome — no drift. This test pins that contract so
+// the regression cannot be reintroduced silently.
+func TestCustomerAsnSchemaIsOptionalAndComputed(t *testing.T) {
+	resourceSchema := resourceAlkiraConnectorAzureVnet().Schema
+
+	customerAsn, exists := resourceSchema["customer_asn"]
+	assert.True(t, exists, "Schema must have 'customer_asn' field")
+	assert.NotNil(t, customerAsn, "customer_asn field must not be nil")
+
+	assert.Equal(t, schema.TypeInt, customerAsn.Type, "customer_asn must be TypeInt")
+	assert.True(t, customerAsn.Optional, "customer_asn must be Optional so users can set it explicitly")
+	assert.True(t, customerAsn.Computed,
+		"customer_asn must be Computed because the backend auto-populates it "+
+			"in VGW mode when the user omits it (AK-68129). "+
+			"Without Computed, Terraform treats the backend-supplied value as drift.")
+}


### PR DESCRIPTION
…tor to stop perpetual plan diff in VGW mode

## Root cause

  The provider declares `customer_asn` as `Optional` only, but the backend auto-populates the field when the user omits it in VGW mode — either to the existing Azure VGW's ASN
  (`AzureVNETConnectorServiceImpl.java:504`) or, when no VGW pre-exists, to `DEFAULT_ASN = 64521` (`AzureVNETConnectorServiceImpl.java:151,1421,1669`). The Read function writes that
  backend-supplied value into Terraform state, and because the schema treats the field as user-owned, the populated state reads as drift versus the empty config — producing a perpetual
  "remove `customer_asn`" diff.

  Apply doesn't resolve it because every leg of the cycle treats "field absent" as "don't touch": the provider builds the update payload from `d.Get("customer_asn").(int) = 0`, the Go
  client's `omitempty` drops `0` from the JSON, the backend update path leaves the stored value alone when the field is absent, and Read writes the persisted value back into state.

  ## Fix

  Mark `customer_asn` as `Optional + Computed` in the schema. This tells Terraform that the field can be set by the user *or* by the backend, and a backend-supplied value is a valid
  settled outcome — no drift.

  ```go
  "customer_asn": {
      Type:     schema.TypeInt,
      Optional: true,
      Computed: true,   // <-- added
  },

  Users who explicitly set customer_asn are unaffected: the backend already rejects any user-supplied ASN that doesn't match the VGW (AzureVNETConnectorServiceImpl.java:501-502), so the
  read-back value matches the config.

  Backend changes are not needed — the auto-set behavior is correct (BGP requires a customer ASN; either the VGW's existing ASN or DEFAULT_ASN is the right product choice). The bug was
  only that the provider schema didn't reflect that the field is co-owned.