### PR TITLE
AK-68104 apply spurious PROVISION (DELETE) FAILED fix to remaining re…

### DIFF
--- a/alkira/resource_alkira_byoip_prefix.go
+++ b/alkira/resource_alkira_byoip_prefix.go
@@ -189,7 +189,7 @@ func resourceByoipPrefixDelete(ctx context.Context, d *schema.ResourceData, m in
 	api := alkira.NewByoip(client)
 
 	// Delete resource
-	provState, err, valErr, provErr := api.Delete(d.Id())
+	_, err, valErr, provErr := api.Delete(d.Id())
 
 	if err != nil {
 		// Terraform may not print "with <resource address>" for destroys of objects
@@ -213,7 +213,7 @@ func resourceByoipPrefixDelete(ctx context.Context, d *schema.ResourceData, m in
 	}
 
 	// Check provision state
-	if client.Provision && provState != "SUCCESS" {
+	if client.Provision && provErr != nil {
 		return diag.Diagnostics{{
 			Severity: diag.Warning,
 			Summary:  "PROVISION (DELETE) FAILED",

--- a/alkira/resource_alkira_connector_akamai_prolexic.go
+++ b/alkira/resource_alkira_connector_akamai_prolexic.go
@@ -369,7 +369,7 @@ func resourceConnectorAkamaiProlexicDelete(ctx context.Context, d *schema.Resour
 	// clean up the implicit credential afterwards.
 	credentialId := d.Get("credential_id").(string)
 
-	provState, err, valErr, provErr := api.Delete(d.Id())
+	_, err, valErr, provErr := api.Delete(d.Id())
 
 	if err != nil {
 		// Terraform may not print "with <resource address>" for destroys of objects
@@ -400,7 +400,7 @@ func resourceConnectorAkamaiProlexicDelete(ctx context.Context, d *schema.Resour
 		}}
 	}
 
-	if client.Provision && provState != "SUCCESS" {
+	if client.Provision && provErr != nil {
 		return diag.Diagnostics{{
 			Severity: diag.Warning,
 			Summary:  "PROVISION (DELETE) FAILED",

--- a/alkira/resource_alkira_connector_aruba_edge.go
+++ b/alkira/resource_alkira_connector_aruba_edge.go
@@ -371,7 +371,7 @@ func resourceConnectorArubaEdgeDelete(ctx context.Context, d *schema.ResourceDat
 	api := alkira.NewConnectorArubaEdge(m.(*alkira.AlkiraClient))
 
 	// DELETE
-	provState, err, valErr, provErr := api.Delete(d.Id())
+	_, err, valErr, provErr := api.Delete(d.Id())
 
 	if err != nil {
 		// Terraform may not print "with <resource address>" for destroys of objects
@@ -394,7 +394,7 @@ func resourceConnectorArubaEdgeDelete(ctx context.Context, d *schema.ResourceDat
 		}}
 	}
 
-	if client.Provision && provState != "SUCCESS" {
+	if client.Provision && provErr != nil {
 		return diag.Diagnostics{{
 			Severity: diag.Warning,
 			Summary:  "PROVISION (DELETE) FAILED",

--- a/alkira/resource_alkira_connector_aws_dx.go
+++ b/alkira/resource_alkira_connector_aws_dx.go
@@ -449,7 +449,7 @@ func resourceConnectorAwsDxDelete(ctx context.Context, d *schema.ResourceData, m
 	api := alkira.NewConnectorAwsDirectConnect(m.(*alkira.AlkiraClient))
 
 	// DELETE
-	provState, err, valErr, provErr := api.Delete(d.Id())
+	_, err, valErr, provErr := api.Delete(d.Id())
 
 	if err != nil {
 		// Terraform may not print "with <resource address>" for destroys of objects
@@ -472,7 +472,7 @@ func resourceConnectorAwsDxDelete(ctx context.Context, d *schema.ResourceData, m
 		}}
 	}
 
-	if client.Provision && provState != "SUCCESS" {
+	if client.Provision && provErr != nil {
 		return diag.Diagnostics{{
 			Severity: diag.Warning,
 			Summary:  "PROVISION (DELETE) FAILED",

--- a/alkira/resource_alkira_connector_aws_tgw.go
+++ b/alkira/resource_alkira_connector_aws_tgw.go
@@ -272,7 +272,7 @@ func resourceConnectorAwsTgwDelete(ctx context.Context, d *schema.ResourceData, 
 	api := alkira.NewConnectorAwsTgw(m.(*alkira.AlkiraClient))
 
 	// DELETE
-	provState, err, valErr, provErr := api.Delete(d.Id())
+	_, err, valErr, provErr := api.Delete(d.Id())
 
 	if err != nil {
 		// Terraform may not print "with <resource address>" for destroys of objects
@@ -295,7 +295,7 @@ func resourceConnectorAwsTgwDelete(ctx context.Context, d *schema.ResourceData, 
 		}}
 	}
 
-	if client.Provision && provState != "SUCCESS" {
+	if client.Provision && provErr != nil {
 		return diag.Diagnostics{{
 			Severity: diag.Warning,
 			Summary:  "PROVISION (DELETE) FAILED",

--- a/alkira/resource_alkira_connector_aws_vpc.go
+++ b/alkira/resource_alkira_connector_aws_vpc.go
@@ -411,7 +411,7 @@ func resourceConnectorAwsVpcDelete(ctx context.Context, d *schema.ResourceData, 
 	api := alkira.NewConnectorAwsVpc(client)
 
 	// DELETE
-	provState, err, valErr, provErr := api.Delete(d.Id())
+	_, err, valErr, provErr := api.Delete(d.Id())
 
 	if err != nil {
 		// Terraform may not print "with <resource address>" for destroys of objects
@@ -434,7 +434,7 @@ func resourceConnectorAwsVpcDelete(ctx context.Context, d *schema.ResourceData, 
 		}}
 	}
 
-	if client.Provision && provState != "SUCCESS" {
+	if client.Provision && provErr != nil {
 		return diag.Diagnostics{{
 			Severity: diag.Warning,
 			Summary:  "PROVISION (DELETE) FAILED",

--- a/alkira/resource_alkira_connector_azure_expressroute.go
+++ b/alkira/resource_alkira_connector_azure_expressroute.go
@@ -471,7 +471,7 @@ func resourceConnectorAzureExpressRouteDelete(ctx context.Context, d *schema.Res
 	api := alkira.NewConnectorAzureExpressRoute(m.(*alkira.AlkiraClient))
 
 	// DELETE
-	provState, err, valErr, provErr := api.Delete((d.Id()))
+	_, err, valErr, provErr := api.Delete((d.Id()))
 
 	if err != nil {
 		// Terraform may not print "with <resource address>" for destroys of objects
@@ -494,7 +494,7 @@ func resourceConnectorAzureExpressRouteDelete(ctx context.Context, d *schema.Res
 		}}
 	}
 
-	if client.Provision && provState != "SUCCESS" {
+	if client.Provision && provErr != nil {
 		return diag.Diagnostics{{
 			Severity: diag.Warning,
 			Summary:  "PROVISION (DELETE) FAILED",

--- a/alkira/resource_alkira_connector_azure_vhub.go
+++ b/alkira/resource_alkira_connector_azure_vhub.go
@@ -338,7 +338,7 @@ func resourceConnectorAzureVhubDelete(ctx context.Context, d *schema.ResourceDat
 	api := alkira.NewConnectorAzureVhub(m.(*alkira.AlkiraClient))
 
 	// DELETE
-	provState, err, valErr, provErr := api.Delete(d.Id())
+	_, err, valErr, provErr := api.Delete(d.Id())
 
 	if err != nil {
 		name, _ := d.GetOk("name")
@@ -359,7 +359,7 @@ func resourceConnectorAzureVhubDelete(ctx context.Context, d *schema.ResourceDat
 		}}
 	}
 
-	if client.Provision && provState != "SUCCESS" {
+	if client.Provision && provErr != nil {
 		return diag.Diagnostics{{
 			Severity: diag.Warning,
 			Summary:  "PROVISION (DELETE) FAILED",

--- a/alkira/resource_alkira_connector_azure_vnet.go
+++ b/alkira/resource_alkira_connector_azure_vnet.go
@@ -465,7 +465,7 @@ func resourceConnectorAzureVnetDelete(ctx context.Context, d *schema.ResourceDat
 	api := alkira.NewConnectorAzureVnet(m.(*alkira.AlkiraClient))
 
 	// DELETE
-	provState, err, valErr, provErr := api.Delete(d.Id())
+	_, err, valErr, provErr := api.Delete(d.Id())
 
 	if err != nil {
 		// Terraform may not print "with <resource address>" for destroys of objects
@@ -488,7 +488,7 @@ func resourceConnectorAzureVnetDelete(ctx context.Context, d *schema.ResourceDat
 		}}
 	}
 
-	if client.Provision && provState != "SUCCESS" {
+	if client.Provision && provErr != nil {
 		return diag.Diagnostics{{
 			Severity: diag.Warning,
 			Summary:  "PROVISION (DELETE) FAILED",

--- a/alkira/resource_alkira_connector_azure_vnet_third_party.go
+++ b/alkira/resource_alkira_connector_azure_vnet_third_party.go
@@ -250,7 +250,7 @@ func resourceConnectorAzureVnetThirdPartyDelete(ctx context.Context, d *schema.R
 	client := m.(*alkira.AlkiraClient)
 	api := alkira.NewAzureVnetThirdPartyConnector(client)
 
-	provState, err, valErr, provErr := api.Delete(d.Id())
+	_, err, valErr, provErr := api.Delete(d.Id())
 
 	if err != nil {
 		// Terraform may not print "with <resource address>" for destroys of objects
@@ -273,7 +273,7 @@ func resourceConnectorAzureVnetThirdPartyDelete(ctx context.Context, d *schema.R
 		}}
 	}
 
-	if client.Provision && provState != "SUCCESS" {
+	if client.Provision && provErr != nil {
 		return diag.Diagnostics{{
 			Severity: diag.Warning,
 			Summary:  "PROVISION (DELETE) FAILED",

--- a/alkira/resource_alkira_connector_cisco_sdwan.go
+++ b/alkira/resource_alkira_connector_cisco_sdwan.go
@@ -374,7 +374,7 @@ func resourceConnectorCiscoSdwanDelete(ctx context.Context, d *schema.ResourceDa
 	api := alkira.NewConnectorCiscoSdwan(m.(*alkira.AlkiraClient))
 
 	// DELETE
-	provState, err, valErr, provErr := api.Delete(d.Id())
+	_, err, valErr, provErr := api.Delete(d.Id())
 
 	if err != nil {
 		// Terraform may not print "with <resource address>" for destroys of objects
@@ -395,7 +395,7 @@ func resourceConnectorCiscoSdwanDelete(ctx context.Context, d *schema.ResourceDa
 	}
 
 	// Check provision state
-	if client.Provision && provState != "SUCCESS" {
+	if client.Provision && provErr != nil {
 		return diag.Diagnostics{{
 			Severity: diag.Warning,
 			Summary:  "PROVISION (DELETE) FAILED",

--- a/alkira/resource_alkira_connector_fortinet_sdwan.go
+++ b/alkira/resource_alkira_connector_fortinet_sdwan.go
@@ -377,7 +377,7 @@ func resourceConnectorFortinetSdwanDelete(ctx context.Context, d *schema.Resourc
 	api := alkira.NewConnectorFortinetSdwan(m.(*alkira.AlkiraClient))
 
 	// DELETE
-	provState, err, valErr, provErr := api.Delete(d.Id())
+	_, err, valErr, provErr := api.Delete(d.Id())
 
 	if err != nil {
 		// Terraform may not print "with <resource address>" for destroys of objects
@@ -400,7 +400,7 @@ func resourceConnectorFortinetSdwanDelete(ctx context.Context, d *schema.Resourc
 	}
 
 	// Check provision state
-	if client.Provision && provState != "SUCCESS" {
+	if client.Provision && provErr != nil {
 		return diag.Diagnostics{{
 			Severity: diag.Warning,
 			Summary:  "PROVISION (DELETE) FAILED",

--- a/alkira/resource_alkira_connector_gcp_interconnect.go
+++ b/alkira/resource_alkira_connector_gcp_interconnect.go
@@ -373,7 +373,7 @@ func resourceConnectorGcpInterconnectDelete(ctx context.Context, d *schema.Resou
 	api := alkira.NewConnectorGcpInterconnect(m.(*alkira.AlkiraClient))
 
 	// DELETE
-	provState, err, valErr, provErr := api.Delete(d.Id())
+	_, err, valErr, provErr := api.Delete(d.Id())
 
 	if err != nil {
 		// Terraform may not print "with <resource address>" for destroys of objects
@@ -396,7 +396,7 @@ func resourceConnectorGcpInterconnectDelete(ctx context.Context, d *schema.Resou
 		}}
 	}
 
-	if client.Provision && provState != "SUCCESS" {
+	if client.Provision && provErr != nil {
 		return diag.Diagnostics{{
 			Severity: diag.Warning,
 			Summary:  "PROVISION (DELETE) FAILED",

--- a/alkira/resource_alkira_connector_gcp_vpc.go
+++ b/alkira/resource_alkira_connector_gcp_vpc.go
@@ -385,7 +385,7 @@ func resourceConnectorGcpVpcDelete(ctx context.Context, d *schema.ResourceData, 
 	api := alkira.NewConnectorGcpVpc(m.(*alkira.AlkiraClient))
 
 	// DELETE
-	provState, err, valErr, provErr := api.Delete(d.Id())
+	_, err, valErr, provErr := api.Delete(d.Id())
 
 	if err != nil {
 		// Terraform may not print "with <resource address>" for destroys of objects
@@ -408,7 +408,7 @@ func resourceConnectorGcpVpcDelete(ctx context.Context, d *schema.ResourceData, 
 	}
 
 	// Check provision state
-	if client.Provision && provState != "SUCCESS" {
+	if client.Provision && provErr != nil {
 		return diag.Diagnostics{{
 			Severity: diag.Warning,
 			Summary:  "PROVISION (DELETE) FAILED",

--- a/alkira/resource_alkira_connector_internet_exit.go
+++ b/alkira/resource_alkira_connector_internet_exit.go
@@ -304,7 +304,7 @@ func resourceConnectorInternetExitDelete(ctx context.Context, d *schema.Resource
 	api := alkira.NewConnectorInternet(m.(*alkira.AlkiraClient))
 
 	// DELETE
-	provState, err, valErr, provErr := api.Delete(d.Id())
+	_, err, valErr, provErr := api.Delete(d.Id())
 
 	if err != nil {
 		// Terraform may not print "with <resource address>" for destroys of objects
@@ -327,7 +327,7 @@ func resourceConnectorInternetExitDelete(ctx context.Context, d *schema.Resource
 		}}
 	}
 
-	if client.Provision && provState != "SUCCESS" {
+	if client.Provision && provErr != nil {
 		return diag.Diagnostics{{
 			Severity: diag.Warning,
 			Summary:  "PROVISION (DELETE) FAILED",

--- a/alkira/resource_alkira_connector_ipsec.go
+++ b/alkira/resource_alkira_connector_ipsec.go
@@ -625,7 +625,7 @@ func resourceConnectorIPSecDelete(ctx context.Context, d *schema.ResourceData, m
 	api := alkira.NewConnectorIPSec(m.(*alkira.AlkiraClient))
 
 	// DELETE
-	provState, err, valErr, provErr := api.Delete(d.Id())
+	_, err, valErr, provErr := api.Delete(d.Id())
 
 	if err != nil {
 		// Terraform may not print "with <resource address>" for destroys of objects
@@ -648,7 +648,7 @@ func resourceConnectorIPSecDelete(ctx context.Context, d *schema.ResourceData, m
 		}}
 	}
 
-	if client.Provision && provState != "SUCCESS" {
+	if client.Provision && provErr != nil {
 		return diag.Diagnostics{{
 			Severity: diag.Warning,
 			Summary:  "PROVISION (DELETE) FAILED",

--- a/alkira/resource_alkira_connector_ipsec_adv.go
+++ b/alkira/resource_alkira_connector_ipsec_adv.go
@@ -499,7 +499,7 @@ func resourceConnectorIPSecAdvDelete(ctx context.Context, d *schema.ResourceData
 	api := alkira.NewConnectorAdvIPSec(m.(*alkira.AlkiraClient))
 
 	// DELETE
-	provState, err, valErr, provErr := api.Delete(d.Id())
+	_, err, valErr, provErr := api.Delete(d.Id())
 
 	if err != nil {
 		// Terraform may not print "with <resource address>" for destroys of objects
@@ -522,7 +522,7 @@ func resourceConnectorIPSecAdvDelete(ctx context.Context, d *schema.ResourceData
 		}}
 	}
 
-	if client.Provision && provState != "SUCCESS" {
+	if client.Provision && provErr != nil {
 		return diag.Diagnostics{{
 			Severity: diag.Warning,
 			Summary:  "PROVISION (DELETE) FAILED",

--- a/alkira/resource_alkira_connector_ipsec_tunnel_profile.go
+++ b/alkira/resource_alkira_connector_ipsec_tunnel_profile.go
@@ -243,7 +243,7 @@ func resourceConnectorIpsecTunnelProfileDelete(ctx context.Context, d *schema.Re
 	api := alkira.NewConnectorIPSecTunnelProfile(client)
 
 	// Delete
-	provState, err, valErr, provErr := api.Delete(d.Id())
+	_, err, valErr, provErr := api.Delete(d.Id())
 
 	if err != nil {
 		// Terraform may not print "with <resource address>" for destroys of objects
@@ -267,7 +267,7 @@ func resourceConnectorIpsecTunnelProfileDelete(ctx context.Context, d *schema.Re
 	}
 
 	// Check provisions state
-	if client.Provision && provState != "SUCCESS" {
+	if client.Provision && provErr != nil {
 		return diag.Diagnostics{{
 			Severity: diag.Warning,
 			Summary:  "PROVISION (DELETE) FAILED",

--- a/alkira/resource_alkira_connector_juniper_sdwan.go
+++ b/alkira/resource_alkira_connector_juniper_sdwan.go
@@ -371,7 +371,7 @@ func resourceConnectorJuniperSdwanDelete(ctx context.Context, d *schema.Resource
 	api := alkira.NewConnectorJuniperSdwan(m.(*alkira.AlkiraClient))
 
 	// DELETE
-	provState, err, valErr, provErr := api.Delete(d.Id())
+	_, err, valErr, provErr := api.Delete(d.Id())
 
 	if err != nil {
 		// Terraform may not print "with <resource address>" for destroys of objects
@@ -393,7 +393,7 @@ func resourceConnectorJuniperSdwanDelete(ctx context.Context, d *schema.Resource
 			Detail:   fmt.Sprintf("%s", valErr),
 		}}
 	}
-	if client.Provision && provState != "SUCCESS" {
+	if client.Provision && provErr != nil {
 		return diag.Diagnostics{{
 			Severity: diag.Warning,
 			Summary:  "PROVISION (DELETE) FAILED",

--- a/alkira/resource_alkira_connector_oci_vcn.go
+++ b/alkira/resource_alkira_connector_oci_vcn.go
@@ -346,7 +346,7 @@ func resourceConnectorOciVcnDelete(ctx context.Context, d *schema.ResourceData, 
 	api := alkira.NewConnectorOciVcn(m.(*alkira.AlkiraClient))
 
 	// DELETE
-	provState, err, valErr, provErr := api.Delete(d.Id())
+	_, err, valErr, provErr := api.Delete(d.Id())
 
 	if err != nil {
 		// Terraform may not print "with <resource address>" for destroys of objects
@@ -369,7 +369,7 @@ func resourceConnectorOciVcnDelete(ctx context.Context, d *schema.ResourceData, 
 		}}
 	}
 
-	if client.Provision && provState != "SUCCESS" {
+	if client.Provision && provErr != nil {
 		return diag.Diagnostics{{
 			Severity: diag.Warning,
 			Summary:  "PROVISION (DELETE) FAILED",

--- a/alkira/resource_alkira_connector_remote_access.go
+++ b/alkira/resource_alkira_connector_remote_access.go
@@ -334,7 +334,7 @@ func resourceConnectorRemoteAccessDelete(ctx context.Context, d *schema.Resource
 	client := m.(*alkira.AlkiraClient)
 	api := alkira.NewConnectorRemoteAccessTemplate(m.(*alkira.AlkiraClient))
 
-	provState, err, valErr, provErr := api.Delete(d.Id())
+	_, err, valErr, provErr := api.Delete(d.Id())
 
 	if err != nil {
 		// Terraform may not print "with <resource address>" for destroys of objects
@@ -357,7 +357,7 @@ func resourceConnectorRemoteAccessDelete(ctx context.Context, d *schema.Resource
 		}}
 	}
 
-	if client.Provision && provState != "SUCCESS" {
+	if client.Provision && provErr != nil {
 		return diag.Diagnostics{{
 			Severity: diag.Warning,
 			Summary:  "PROVISION (DELETE) FAILED",

--- a/alkira/resource_alkira_connector_versa_sdwan.go
+++ b/alkira/resource_alkira_connector_versa_sdwan.go
@@ -373,7 +373,7 @@ func resourceConnectorVersaSdwanDelete(ctx context.Context, d *schema.ResourceDa
 	api := alkira.NewConnectorVersaSdwan(m.(*alkira.AlkiraClient))
 
 	// DELETE
-	provState, err, valErr, provErr := api.Delete(d.Id())
+	_, err, valErr, provErr := api.Delete(d.Id())
 
 	if err != nil {
 		// Terraform may not print "with <resource address>" for destroys of objects
@@ -394,7 +394,7 @@ func resourceConnectorVersaSdwanDelete(ctx context.Context, d *schema.ResourceDa
 		}}
 	}
 
-	if client.Provision && provState != "SUCCESS" {
+	if client.Provision && provErr != nil {
 		return diag.Diagnostics{{
 			Severity: diag.Warning,
 			Summary:  "PROVISION (DELETE) FAILED",

--- a/alkira/resource_alkira_connector_vmware_sdwan.go
+++ b/alkira/resource_alkira_connector_vmware_sdwan.go
@@ -350,7 +350,7 @@ func resourceConnectorVmwareSdwanDelete(ctx context.Context, d *schema.ResourceD
 	api := alkira.NewConnectorVmwareSdwan(m.(*alkira.AlkiraClient))
 
 	// DELETE
-	provState, err, valErr, provErr := api.Delete(d.Id())
+	_, err, valErr, provErr := api.Delete(d.Id())
 
 	if err != nil {
 		// Terraform may not print "with <resource address>" for destroys of objects
@@ -373,7 +373,7 @@ func resourceConnectorVmwareSdwanDelete(ctx context.Context, d *schema.ResourceD
 		}}
 	}
 
-	if client.Provision && provState != "SUCCESS" {
+	if client.Provision && provErr != nil {
 		return diag.Diagnostics{{
 			Severity: diag.Warning,
 			Summary:  "PROVISION (DELETE) FAILED",

--- a/alkira/resource_alkira_flow_collector.go
+++ b/alkira/resource_alkira_flow_collector.go
@@ -281,7 +281,7 @@ func resourceFlowCollectorDelete(ctx context.Context, d *schema.ResourceData, m 
 	client := m.(*alkira.AlkiraClient)
 	api := alkira.NewFlowCollector(m.(*alkira.AlkiraClient))
 
-	provState, err, valErr, provErr := api.Delete(d.Id())
+	_, err, valErr, provErr := api.Delete(d.Id())
 
 	if err != nil {
 		// Terraform may not print "with <resource address>" for destroys of objects
@@ -304,7 +304,7 @@ func resourceFlowCollectorDelete(ctx context.Context, d *schema.ResourceData, m 
 		}}
 	}
 
-	if client.Provision && provState != "SUCCESS" {
+	if client.Provision && provErr != nil {
 		return diag.Diagnostics{{
 			Severity: diag.Warning,
 			Summary:  "PROVISION (DELETE) FAILED",

--- a/alkira/resource_alkira_group.go
+++ b/alkira/resource_alkira_group.go
@@ -193,7 +193,7 @@ func resourceGroupDelete(ctx context.Context, d *schema.ResourceData, m interfac
 	client := m.(*alkira.AlkiraClient)
 	api := alkira.NewGroup(m.(*alkira.AlkiraClient))
 
-	provState, err, valErr, provErr := api.Delete(d.Id())
+	_, err, valErr, provErr := api.Delete(d.Id())
 
 	if err != nil {
 		// Terraform may not print "with <resource address>" for destroys of objects
@@ -216,7 +216,7 @@ func resourceGroupDelete(ctx context.Context, d *schema.ResourceData, m interfac
 		}}
 	}
 
-	if client.Provision && provState != "SUCCESS" {
+	if client.Provision && provErr != nil {
 		return diag.Diagnostics{{
 			Severity: diag.Warning,
 			Summary:  "PROVISION (DELETE) FAILED",

--- a/alkira/resource_alkira_group_direct_inter_connector.go
+++ b/alkira/resource_alkira_group_direct_inter_connector.go
@@ -234,7 +234,7 @@ func resourceDirectInterConnectorGroupDelete(ctx context.Context, d *schema.Reso
 	client := m.(*alkira.AlkiraClient)
 	api := alkira.NewInterConnectorCommunicationGroup(m.(*alkira.AlkiraClient))
 
-	provState, err, valErr, provErr := api.Delete(d.Id())
+	_, err, valErr, provErr := api.Delete(d.Id())
 
 	if err != nil {
 		// Terraform may not print "with <resource address>" for destroys of objects
@@ -257,7 +257,7 @@ func resourceDirectInterConnectorGroupDelete(ctx context.Context, d *schema.Reso
 		}}
 	}
 
-	if client.Provision && provState != "SUCCESS" {
+	if client.Provision && provErr != nil {
 		return diag.Diagnostics{{
 			Severity: diag.Warning,
 			Summary:  "PROVISION (DELETE) FAILED",

--- a/alkira/resource_alkira_internet_applications.go
+++ b/alkira/resource_alkira_internet_applications.go
@@ -410,7 +410,7 @@ func resourceInternetApplicationDelete(ctx context.Context, d *schema.ResourceDa
 	client := m.(*alkira.AlkiraClient)
 	api := alkira.NewInternetApplication(m.(*alkira.AlkiraClient))
 
-	provState, err, valErr, provErr := api.Delete(d.Id())
+	_, err, valErr, provErr := api.Delete(d.Id())
 
 	if err != nil {
 		// Terraform may not print "with <resource address>" for destroys of objects
@@ -433,7 +433,7 @@ func resourceInternetApplicationDelete(ctx context.Context, d *schema.ResourceDa
 
 	d.SetId("")
 
-	if client.Provision && provState != "SUCCESS" {
+	if client.Provision && provErr != nil {
 		return diag.Diagnostics{{
 			Severity: diag.Warning,
 			Summary:  "PROVISION (DELETE) FAILED",

--- a/alkira/resource_alkira_ip_reservation.go
+++ b/alkira/resource_alkira_ip_reservation.go
@@ -300,7 +300,7 @@ func resourceIpReservationDelete(ctx context.Context, d *schema.ResourceData, m 
 	client := m.(*alkira.AlkiraClient)
 	api := alkira.NewIPReservation(m.(*alkira.AlkiraClient))
 
-	provState, err, valErr, provErr := api.Delete(d.Id())
+	_, err, valErr, provErr := api.Delete(d.Id())
 
 	if err != nil {
 		// Terraform may not print "with <resource address>" for destroys of objects
@@ -323,7 +323,7 @@ func resourceIpReservationDelete(ctx context.Context, d *schema.ResourceData, m 
 
 	d.SetId("")
 
-	if client.Provision && provState != "SUCCESS" {
+	if client.Provision && provErr != nil {
 		return diag.Diagnostics{{
 			Severity: diag.Warning,
 			Summary:  "PROVISION (DELETE) FAILED",

--- a/alkira/resource_alkira_list_as_path.go
+++ b/alkira/resource_alkira_list_as_path.go
@@ -201,7 +201,7 @@ func resourceListAsPathDelete(ctx context.Context, d *schema.ResourceData, m int
 	client := m.(*alkira.AlkiraClient)
 	api := alkira.NewListAsPath(m.(*alkira.AlkiraClient))
 
-	provState, err, valErr, provErr := api.Delete(d.Id())
+	_, err, valErr, provErr := api.Delete(d.Id())
 
 	if err != nil {
 		// Terraform may not print "with <resource address>" for destroys of objects
@@ -224,7 +224,7 @@ func resourceListAsPathDelete(ctx context.Context, d *schema.ResourceData, m int
 
 	d.SetId("")
 
-	if client.Provision && provState != "SUCCESS" {
+	if client.Provision && provErr != nil {
 		return diag.Diagnostics{{
 			Severity: diag.Warning,
 			Summary:  "PROVISION (DELETE) FAILED",

--- a/alkira/resource_alkira_list_community.go
+++ b/alkira/resource_alkira_list_community.go
@@ -194,7 +194,7 @@ func resourceListCommunityDelete(ctx context.Context, d *schema.ResourceData, m 
 	client := m.(*alkira.AlkiraClient)
 	api := alkira.NewListCommunity(m.(*alkira.AlkiraClient))
 
-	provState, err, valErr, provErr := api.Delete(d.Id())
+	_, err, valErr, provErr := api.Delete(d.Id())
 
 	if err != nil {
 		// Terraform may not print "with <resource address>" for destroys of objects
@@ -217,7 +217,7 @@ func resourceListCommunityDelete(ctx context.Context, d *schema.ResourceData, m 
 
 	d.SetId("")
 
-	if client.Provision && provState != "SUCCESS" {
+	if client.Provision && provErr != nil {
 		return diag.Diagnostics{{
 			Severity: diag.Warning,
 			Summary:  "PROVISION (DELETE) FAILED",

--- a/alkira/resource_alkira_list_dns_server.go
+++ b/alkira/resource_alkira_list_dns_server.go
@@ -217,7 +217,7 @@ func resourceListDnsServerDelete(ctx context.Context, d *schema.ResourceData, m 
 	client := m.(*alkira.AlkiraClient)
 	api := alkira.NewDnsServerList(m.(*alkira.AlkiraClient))
 
-	provState, err, valErr, provErr := api.Delete(d.Id())
+	_, err, valErr, provErr := api.Delete(d.Id())
 
 	if err != nil {
 		// Terraform may not print "with <resource address>" for destroys of objects
@@ -240,7 +240,7 @@ func resourceListDnsServerDelete(ctx context.Context, d *schema.ResourceData, m 
 
 	d.SetId("")
 
-	if client.Provision && provState != "SUCCESS" {
+	if client.Provision && provErr != nil {
 		return diag.Diagnostics{{
 			Severity: diag.Warning,
 			Summary:  "PROVISION (DELETE) FAILED",

--- a/alkira/resource_alkira_list_extended_community.go
+++ b/alkira/resource_alkira_list_extended_community.go
@@ -198,7 +198,7 @@ func resourceListExtendedCommunityDelete(ctx context.Context, d *schema.Resource
 	client := m.(*alkira.AlkiraClient)
 	api := alkira.NewListExtendedCommunity(m.(*alkira.AlkiraClient))
 
-	provState, err, valErr, provErr := api.Delete(d.Id())
+	_, err, valErr, provErr := api.Delete(d.Id())
 
 	if err != nil {
 		// Terraform may not print "with <resource address>" for destroys of objects
@@ -221,7 +221,7 @@ func resourceListExtendedCommunityDelete(ctx context.Context, d *schema.Resource
 
 	d.SetId("")
 
-	if client.Provision && provState != "SUCCESS" {
+	if client.Provision && provErr != nil {
 		return diag.Diagnostics{{
 			Severity: diag.Warning,
 			Summary:  "PROVISION (DELETE) FAILED",

--- a/alkira/resource_alkira_list_global_cidr.go
+++ b/alkira/resource_alkira_list_global_cidr.go
@@ -208,7 +208,7 @@ func resourceListGlobalCidrDelete(ctx context.Context, d *schema.ResourceData, m
 	client := m.(*alkira.AlkiraClient)
 	api := alkira.NewGlobalCidrList(m.(*alkira.AlkiraClient))
 
-	provState, err, valErr, provErr := api.Delete(d.Id())
+	_, err, valErr, provErr := api.Delete(d.Id())
 
 	if err != nil {
 		// Terraform may not print "with <resource address>" for destroys of objects
@@ -231,7 +231,7 @@ func resourceListGlobalCidrDelete(ctx context.Context, d *schema.ResourceData, m
 
 	d.SetId("")
 
-	if client.Provision && provState != "SUCCESS" {
+	if client.Provision && provErr != nil {
 		return diag.Diagnostics{{
 			Severity: diag.Warning,
 			Summary:  "PROVISION (DELETE) FAILED",

--- a/alkira/resource_alkira_list_policy_fqdn.go
+++ b/alkira/resource_alkira_list_policy_fqdn.go
@@ -196,7 +196,7 @@ func resourceListPolicyFqdnDelete(ctx context.Context, d *schema.ResourceData, m
 	client := m.(*alkira.AlkiraClient)
 	api := alkira.NewPolicyFqdnList(m.(*alkira.AlkiraClient))
 
-	provState, err, valErr, provErr := api.Delete(d.Id())
+	_, err, valErr, provErr := api.Delete(d.Id())
 
 	if err != nil {
 		// Terraform may not print "with <resource address>" for destroys of objects
@@ -219,7 +219,7 @@ func resourceListPolicyFqdnDelete(ctx context.Context, d *schema.ResourceData, m
 
 	d.SetId("")
 
-	if client.Provision && provState != "SUCCESS" {
+	if client.Provision && provErr != nil {
 		return diag.Diagnostics{{
 			Severity: diag.Warning,
 			Summary:  "PROVISION (DELETE) FAILED",

--- a/alkira/resource_alkira_list_udr.go
+++ b/alkira/resource_alkira_list_udr.go
@@ -230,7 +230,7 @@ func resourceListUdrDelete(ctx context.Context, d *schema.ResourceData, m interf
 	client := m.(*alkira.AlkiraClient)
 	api := alkira.NewUdrList(m.(*alkira.AlkiraClient))
 
-	provState, err, valErr, provErr := api.Delete(d.Id())
+	_, err, valErr, provErr := api.Delete(d.Id())
 
 	if err != nil {
 		// Terraform may not print "with <resource address>" for destroys of objects
@@ -253,7 +253,7 @@ func resourceListUdrDelete(ctx context.Context, d *schema.ResourceData, m interf
 
 	d.SetId("")
 
-	if client.Provision && provState != "SUCCESS" {
+	if client.Provision && provErr != nil {
 		return diag.Diagnostics{{
 			Severity: diag.Warning,
 			Summary:  "PROVISION (DELETE) FAILED",

--- a/alkira/resource_alkira_network_entity_scale_options.go
+++ b/alkira/resource_alkira_network_entity_scale_options.go
@@ -295,7 +295,7 @@ func resourceNetworkEntityScaleOptionsDelete(ctx context.Context, d *schema.Reso
 	client := m.(*alkira.AlkiraClient)
 	api := alkira.NewNetworkEntityScaleOptions(client)
 
-	provState, err, valErr, provErr := api.Delete(d.Id())
+	_, err, valErr, provErr := api.Delete(d.Id())
 	if err != nil {
 		// Terraform may not print "with <resource address>" for destroys of objects
 		// that are no longer in configuration, so include identifying context here.
@@ -317,7 +317,7 @@ func resourceNetworkEntityScaleOptionsDelete(ctx context.Context, d *schema.Reso
 		}}
 	}
 
-	if client.Provision && provState != "SUCCESS" {
+	if client.Provision && provErr != nil {
 		return diag.Diagnostics{{
 			Severity: diag.Warning,
 			Summary:  "PROVISION (DELETE) FAILED",

--- a/alkira/resource_alkira_policy_inter_cxp_routing.go
+++ b/alkira/resource_alkira_policy_inter_cxp_routing.go
@@ -344,7 +344,7 @@ func resourcePolicyInterCxpRoutingDelete(ctx context.Context, d *schema.Resource
 	client := m.(*alkira.AlkiraClient)
 	api := alkira.NewInterCxpRoutePolicy(m.(*alkira.AlkiraClient))
 
-	provState, err, valErr, provErr := api.Delete(d.Id())
+	_, err, valErr, provErr := api.Delete(d.Id())
 
 	if err != nil {
 		name, _ := d.GetOk("name")
@@ -362,7 +362,7 @@ func resourcePolicyInterCxpRoutingDelete(ctx context.Context, d *schema.Resource
 		}}
 	}
 
-	if client.Provision && provState != "SUCCESS" {
+	if client.Provision && provErr != nil {
 		return diag.Diagnostics{{
 			Severity: diag.Warning,
 			Summary:  "PROVISION (DELETE) FAILED",

--- a/alkira/resource_alkira_policy_nat_rule.go
+++ b/alkira/resource_alkira_policy_nat_rule.go
@@ -398,7 +398,7 @@ func resourcePolicyNatRuleDelete(ctx context.Context, d *schema.ResourceData, m 
 	client := m.(*alkira.AlkiraClient)
 	api := alkira.NewNatRule(m.(*alkira.AlkiraClient))
 
-	provState, err, valErr, provErr := api.Delete(d.Id())
+	_, err, valErr, provErr := api.Delete(d.Id())
 
 	if err != nil {
 		// Terraform may not print "with <resource address>" for destroys of objects
@@ -421,7 +421,7 @@ func resourcePolicyNatRuleDelete(ctx context.Context, d *schema.ResourceData, m 
 
 	d.SetId("")
 
-	if client.Provision && provState != "SUCCESS" {
+	if client.Provision && provErr != nil {
 		return diag.Diagnostics{{
 			Severity: diag.Warning,
 			Summary:  "PROVISION (DELETE) FAILED",

--- a/alkira/resource_alkira_policy_prefix_list.go
+++ b/alkira/resource_alkira_policy_prefix_list.go
@@ -344,7 +344,7 @@ func resourcePolicyPrefixListDelete(ctx context.Context, d *schema.ResourceData,
 	client := m.(*alkira.AlkiraClient)
 	api := alkira.NewPolicyPrefixList(m.(*alkira.AlkiraClient))
 
-	provState, err, valErr, provErr := api.Delete(d.Id())
+	_, err, valErr, provErr := api.Delete(d.Id())
 
 	if err != nil {
 		// Terraform may not print "with <resource address>" for destroys of objects
@@ -367,7 +367,7 @@ func resourcePolicyPrefixListDelete(ctx context.Context, d *schema.ResourceData,
 
 	d.SetId("")
 
-	if client.Provision && provState != "SUCCESS" {
+	if client.Provision && provErr != nil {
 		return diag.Diagnostics{{
 			Severity: diag.Warning,
 			Summary:  "PROVISION (DELETE) FAILED",

--- a/alkira/resource_alkira_policy_routing.go
+++ b/alkira/resource_alkira_policy_routing.go
@@ -461,7 +461,7 @@ func resourcePolicyRoutingDelete(ctx context.Context, d *schema.ResourceData, m 
 	client := m.(*alkira.AlkiraClient)
 	api := alkira.NewRoutePolicy(m.(*alkira.AlkiraClient))
 
-	provState, err, valErr, provErr := api.Delete(d.Id())
+	_, err, valErr, provErr := api.Delete(d.Id())
 
 	if err != nil {
 		// Terraform may not print "with <resource address>" for destroys of objects
@@ -482,7 +482,7 @@ func resourcePolicyRoutingDelete(ctx context.Context, d *schema.ResourceData, m 
 		}}
 	}
 
-	if client.Provision && provState != "SUCCESS" {
+	if client.Provision && provErr != nil {
 		return diag.Diagnostics{{
 			Severity: diag.Warning,
 			Summary:  "PROVISION (DELETE) FAILED",

--- a/alkira/resource_alkira_segment.go
+++ b/alkira/resource_alkira_segment.go
@@ -278,7 +278,7 @@ func resourceSegmentDelete(ctx context.Context, d *schema.ResourceData, m interf
 	api := alkira.NewSegment(client)
 
 	// Delete
-	provState, err, valErr, provErr := api.Delete(d.Id())
+	_, err, valErr, provErr := api.Delete(d.Id())
 
 	if err != nil {
 		// Terraform may not print "with <resource address>" for destroys of objects
@@ -302,7 +302,7 @@ func resourceSegmentDelete(ctx context.Context, d *schema.ResourceData, m interf
 	}
 
 	// Check provisions state
-	if client.Provision && provState != "SUCCESS" {
+	if client.Provision && provErr != nil {
 		return diag.Diagnostics{{
 			Severity: diag.Warning,
 			Summary:  "PROVISION (DELETE) FAILED",

--- a/alkira/resource_alkira_segment_resource.go
+++ b/alkira/resource_alkira_segment_resource.go
@@ -252,7 +252,7 @@ func resourceSegmentResourceDelete(ctx context.Context, d *schema.ResourceData, 
 	client := m.(*alkira.AlkiraClient)
 	api := alkira.NewSegmentResource(m.(*alkira.AlkiraClient))
 
-	provState, err, valErr, provErr := api.Delete(d.Id())
+	_, err, valErr, provErr := api.Delete(d.Id())
 
 	if err != nil {
 		// Terraform may not print "with <resource address>" for destroys of objects
@@ -275,7 +275,7 @@ func resourceSegmentResourceDelete(ctx context.Context, d *schema.ResourceData, 
 		}}
 	}
 
-	if client.Provision && provState != "SUCCESS" {
+	if client.Provision && provErr != nil {
 		return diag.Diagnostics{{
 			Severity: diag.Warning,
 			Summary:  "PROVISION (DELETE) FAILED",

--- a/alkira/resource_alkira_segment_resource_share.go
+++ b/alkira/resource_alkira_segment_resource_share.go
@@ -276,7 +276,7 @@ func resourceSegmentResourceShareDelete(ctx context.Context, d *schema.ResourceD
 	client := m.(*alkira.AlkiraClient)
 	api := alkira.NewSegmentResourceShare(m.(*alkira.AlkiraClient))
 
-	provState, err, valErr, provErr := api.Delete(d.Id())
+	_, err, valErr, provErr := api.Delete(d.Id())
 
 	if err != nil {
 		// Terraform may not print "with <resource address>" for destroys of objects
@@ -299,7 +299,7 @@ func resourceSegmentResourceShareDelete(ctx context.Context, d *schema.ResourceD
 		}}
 	}
 
-	if client.Provision && provState != "SUCCESS" {
+	if client.Provision && provErr != nil {
 		return diag.Diagnostics{{
 			Severity: diag.Warning,
 			Summary:  "PROVISION (DELETE) FAILED",

--- a/alkira/resource_alkira_service_bluecat.go
+++ b/alkira/resource_alkira_service_bluecat.go
@@ -413,7 +413,7 @@ func resourceBluecatDelete(ctx context.Context, d *schema.ResourceData, m interf
 	client := m.(*alkira.AlkiraClient)
 	api := alkira.NewServiceBluecat(m.(*alkira.AlkiraClient))
 
-	provState, err, valErr, provErr := api.Delete(d.Id())
+	_, err, valErr, provErr := api.Delete(d.Id())
 
 	if err != nil {
 		return diag.FromErr(err)
@@ -430,7 +430,7 @@ func resourceBluecatDelete(ctx context.Context, d *schema.ResourceData, m interf
 		}}
 	}
 
-	if client.Provision && provState != "SUCCESS" {
+	if client.Provision && provErr != nil {
 		return diag.Diagnostics{{
 			Severity: diag.Warning,
 			Summary:  "PROVISION (DELETE) FAILED",

--- a/alkira/resource_alkira_service_checkpoint.go
+++ b/alkira/resource_alkira_service_checkpoint.go
@@ -463,7 +463,7 @@ func resourceCheckpointDelete(ctx context.Context, d *schema.ResourceData, m int
 	client := m.(*alkira.AlkiraClient)
 	api := alkira.NewServiceCheckpoint(m.(*alkira.AlkiraClient))
 
-	provState, err, valErr, provErr := api.Delete(d.Id())
+	_, err, valErr, provErr := api.Delete(d.Id())
 
 	if err != nil {
 		// Terraform may not print "with <resource address>" for destroys of objects
@@ -486,7 +486,7 @@ func resourceCheckpointDelete(ctx context.Context, d *schema.ResourceData, m int
 	}
 
 	// Check provision state
-	if client.Provision && provState != "SUCCESS" {
+	if client.Provision && provErr != nil {
 		return diag.Diagnostics{{
 			Severity: diag.Warning,
 			Summary:  "PROVISION (DELETE) FAILED",

--- a/alkira/resource_alkira_service_cisco_ftdv.go
+++ b/alkira/resource_alkira_service_cisco_ftdv.go
@@ -406,7 +406,7 @@ func resourceServiceCiscoFTDvDelete(ctx context.Context, d *schema.ResourceData,
 	client := m.(*alkira.AlkiraClient)
 	api := alkira.NewServiceCiscoFTDv(m.(*alkira.AlkiraClient))
 
-	provState, err, valErr, provErr := api.Delete((d.Id()))
+	_, err, valErr, provErr := api.Delete((d.Id()))
 
 	if err != nil {
 		// Terraform may not print "with <resource address>" for destroys of objects
@@ -429,7 +429,7 @@ func resourceServiceCiscoFTDvDelete(ctx context.Context, d *schema.ResourceData,
 		}}
 	}
 
-	if client.Provision && provState != "SUCCESS" {
+	if client.Provision && provErr != nil {
 		return diag.Diagnostics{{
 			Severity: diag.Warning,
 			Summary:  "PROVISION (DELETE) FAILED",

--- a/alkira/resource_alkira_service_f5_lb.go
+++ b/alkira/resource_alkira_service_f5_lb.go
@@ -474,7 +474,7 @@ func resourceF5LoadBalancerDelete(ctx context.Context, d *schema.ResourceData, m
 	client := m.(*alkira.AlkiraClient)
 	api := alkira.NewServiceF5Lb(m.(*alkira.AlkiraClient))
 
-	provState, err, valErr, provErr := api.Delete(d.Id())
+	_, err, valErr, provErr := api.Delete(d.Id())
 
 	if err != nil {
 		// Terraform may not print "with <resource address>" for destroys of objects
@@ -497,7 +497,7 @@ func resourceF5LoadBalancerDelete(ctx context.Context, d *schema.ResourceData, m
 	}
 
 	// Check provision state
-	if client.Provision && provState != "SUCCESS" {
+	if client.Provision && provErr != nil {
 		return diag.Diagnostics{{
 			Severity: diag.Warning,
 			Summary:  "PROVISION (DELETE) FAILED",

--- a/alkira/resource_alkira_service_f5_vserver_endpoint.go
+++ b/alkira/resource_alkira_service_f5_vserver_endpoint.go
@@ -345,7 +345,7 @@ func resourceF5vServerEndpointDelete(ctx context.Context, d *schema.ResourceData
 	client := m.(*alkira.AlkiraClient)
 	api := alkira.NewF5vServerEndpoint(m.(*alkira.AlkiraClient))
 
-	provState, err, valErr, provErr := api.Delete(d.Id())
+	_, err, valErr, provErr := api.Delete(d.Id())
 
 	if err != nil {
 		// Terraform may not print "with <resource address>" for destroys of objects
@@ -368,7 +368,7 @@ func resourceF5vServerEndpointDelete(ctx context.Context, d *schema.ResourceData
 	}
 
 	// Check provision state
-	if client.Provision && provState != "SUCCESS" {
+	if client.Provision && provErr != nil {
 		return diag.Diagnostics{{
 			Severity: diag.Warning,
 			Summary:  "PROVISION (DELETE) FAILED",

--- a/alkira/resource_alkira_service_fortinet.go
+++ b/alkira/resource_alkira_service_fortinet.go
@@ -458,7 +458,7 @@ func resourceFortinetDelete(ctx context.Context, d *schema.ResourceData, m inter
 	client := m.(*alkira.AlkiraClient)
 	api := alkira.NewServiceFortinet(m.(*alkira.AlkiraClient))
 
-	provState, err, valErr, provErr := api.Delete(d.Id())
+	_, err, valErr, provErr := api.Delete(d.Id())
 
 	if err != nil {
 		// Terraform may not print "with <resource address>" for destroys of objects
@@ -481,7 +481,7 @@ func resourceFortinetDelete(ctx context.Context, d *schema.ResourceData, m inter
 	}
 
 	// Check provision state
-	if client.Provision && provState != "SUCCESS" {
+	if client.Provision && provErr != nil {
 		return diag.Diagnostics{{
 			Severity: diag.Warning,
 			Summary:  "PROVISION (DELETE) FAILED",

--- a/alkira/resource_alkira_service_infoblox.go
+++ b/alkira/resource_alkira_service_infoblox.go
@@ -405,7 +405,7 @@ func resourceInfobloxDelete(ctx context.Context, d *schema.ResourceData, m inter
 	client := m.(*alkira.AlkiraClient)
 	api := alkira.NewServiceInfoblox(m.(*alkira.AlkiraClient))
 
-	provState, err, valErr, provErr := api.Delete(d.Id())
+	_, err, valErr, provErr := api.Delete(d.Id())
 
 	if err != nil {
 		// Terraform may not print "with <resource address>" for destroys of objects
@@ -428,7 +428,7 @@ func resourceInfobloxDelete(ctx context.Context, d *schema.ResourceData, m inter
 		}}
 	}
 
-	if client.Provision && provState != "SUCCESS" {
+	if client.Provision && provErr != nil {
 		return diag.Diagnostics{{
 			Severity: diag.Warning,
 			Summary:  "PROVISION (DELETE) FAILED",

--- a/alkira/resource_alkira_service_pan.go
+++ b/alkira/resource_alkira_service_pan.go
@@ -626,7 +626,7 @@ func resourceServicePanDelete(ctx context.Context, d *schema.ResourceData, m int
 	api := alkira.NewServicePan(client)
 
 	// DELETE
-	provState, err, valErr, provErr := api.Delete(d.Id())
+	_, err, valErr, provErr := api.Delete(d.Id())
 
 	if err != nil {
 		// Terraform may not print "with <resource address>" for destroys of objects
@@ -648,7 +648,7 @@ func resourceServicePanDelete(ctx context.Context, d *schema.ResourceData, m int
 		}}
 	}
 	// Check provision state
-	if client.Provision && provState != "SUCCESS" {
+	if client.Provision && provErr != nil {
 		return diag.Diagnostics{{
 			Severity: diag.Warning,
 			Summary:  "PROVISION (DELETE) FAILED",

--- a/alkira/resource_alkira_service_zscaler.go
+++ b/alkira/resource_alkira_service_zscaler.go
@@ -374,7 +374,7 @@ func resourceZscalerDelete(ctx context.Context, d *schema.ResourceData, m interf
 	client := m.(*alkira.AlkiraClient)
 	api := alkira.NewServiceZscaler(m.(*alkira.AlkiraClient))
 
-	provState, err, valErr, provErr := api.Delete(d.Id())
+	_, err, valErr, provErr := api.Delete(d.Id())
 
 	if err != nil {
 		// Terraform may not print "with <resource address>" for destroys of objects
@@ -397,7 +397,7 @@ func resourceZscalerDelete(ctx context.Context, d *schema.ResourceData, m interf
 		}}
 	}
 
-	if client.Provision && provState != "SUCCESS" {
+	if client.Provision && provErr != nil {
 		return diag.Diagnostics{{
 			Severity: diag.Warning,
 			Summary:  "PROVISION (DELETE) FAILED",


### PR DESCRIPTION
…sources

Follow-up to #627 (AK-67216): roll out the same fix to the remaining 52 resources. Gate the DELETE diagnostic on provErr != nil (matching CREATE/UPDATE) instead of provState != "SUCCESS"; the SDK's delete() legitimately returns provState="" with nil err/valErr/provErr on 202 async-validation, 404 already-deleted, and provision-disabled paths, all of which the old guard misread as failure and printed with Detail=%!s(<nil>), which ATF's stdout matcher treats as a test failure.

alkira_policy_nat already gates on provErr != nil (different shape, already bug-free) so is unchanged.