### PR TITLE
AK-67730: Fix Checkpoint/FTDv management server perpetual diff

### DIFF
--- a/alkira/resource_alkira_service_checkpoint.go
+++ b/alkira/resource_alkira_service_checkpoint.go
@@ -122,7 +122,8 @@ func resourceAlkiraCheckpoint() *schema.Resource {
 				ValidateFunc: validation.StringInSlice([]string{"BRING_YOUR_OWN", "PAY_AS_YOU_GO"}, false),
 			},
 			"management_server": {
-				Type:        schema.TypeSet,
+				Type:        schema.TypeList,
+				MaxItems:    1,
 				Required:    true,
 				Description: "",
 				Elem: &schema.Resource{
@@ -381,7 +382,7 @@ func resourceCheckpointRead(ctx context.Context, d *schema.ResourceData, m inter
 	d.Set("instance", setCheckpointInstances(d, checkpoint.Instances))
 	d.Set("license_type", checkpoint.LicenseType)
 	if checkpoint.ManagementServer != nil {
-		d.Set("management_server", deflateCheckpointManagementServer(*checkpoint.ManagementServer, m))
+		d.Set("management_server", deflateCheckpointManagementServer(d, *checkpoint.ManagementServer, m))
 	}
 	d.Set("max_instance_count", checkpoint.MaxInstanceCount)
 	d.Set("min_instance_count", checkpoint.MinInstanceCount)

--- a/alkira/resource_alkira_service_checkpoint_helper.go
+++ b/alkira/resource_alkira_service_checkpoint_helper.go
@@ -35,23 +35,23 @@ func updateCheckpointCredential(d *schema.ResourceData, c *alkira.AlkiraClient) 
 	return nil
 }
 
-func expandCheckpointManagementServer(name string, in *schema.Set, m interface{}) (*alkira.CheckpointManagementServer, error) {
+func expandCheckpointManagementServer(name string, in []interface{}, m interface{}) (*alkira.CheckpointManagementServer, error) {
 
 	client := m.(*alkira.AlkiraClient)
 
-	if in == nil || in.Len() > 1 {
+	if in == nil || len(in) > 1 {
 		log.Printf("[DEBUG] Invalid Checkpoint Firewall Management Server input")
 		return nil, errors.New("ERROR: Invalid checkpoint firewall management server input")
 	}
 
-	if in.Len() < 1 {
+	if len(in) < 1 {
 		return nil, nil
 	}
 
 	mg := &alkira.CheckpointManagementServer{}
 	var manServerPass string
 
-	for _, option := range in.List() {
+	for _, option := range in {
 		cfg := option.(map[string]interface{})
 		if v, ok := cfg["configuration_mode"].(string); ok {
 			mg.ConfigurationMode = v
@@ -186,7 +186,7 @@ func expandCheckpointSegmentOptions(segmentName string, in *schema.Set, m interf
 
 }
 
-func deflateCheckpointManagementServer(mg alkira.CheckpointManagementServer, m interface{}) []map[string]interface{} {
+func deflateCheckpointManagementServer(d *schema.ResourceData, mg alkira.CheckpointManagementServer, m interface{}) []map[string]interface{} {
 	result := make(map[string]interface{})
 	result["configuration_mode"] = mg.ConfigurationMode
 	result["credential_id"] = mg.CredentialId
@@ -202,6 +202,17 @@ func deflateCheckpointManagementServer(mg alkira.CheckpointManagementServer, m i
 		segmentId, err := getSegmentIdByName(mg.Segment, m)
 		if err == nil {
 			result["segment_id"] = segmentId
+		}
+	}
+
+	// API doesn't return password. Carry forward from prior state.
+	if d != nil {
+		if existing, ok := d.GetOk("management_server"); ok {
+			prior := existing.([]interface{})
+			if len(prior) > 0 {
+				p := prior[0].(map[string]interface{})
+				result["password"] = p["password"]
+			}
 		}
 	}
 
@@ -263,7 +274,7 @@ func setCheckpointInstances(d *schema.ResourceData, c []alkira.CheckpointInstanc
 func generateCheckpointRequest(d *schema.ResourceData, m interface{}) (*alkira.ServiceCheckpoint, error) {
 
 	// Management Server block
-	managementServer, err := expandCheckpointManagementServer(d.Get("name").(string), d.Get("management_server").(*schema.Set), m)
+	managementServer, err := expandCheckpointManagementServer(d.Get("name").(string), d.Get("management_server").([]interface{}), m)
 
 	if err != nil {
 		return nil, err

--- a/alkira/resource_alkira_service_checkpoint_helper_test.go
+++ b/alkira/resource_alkira_service_checkpoint_helper_test.go
@@ -39,8 +39,8 @@ func TestCheckpointInstanceInvalid(t *testing.T) {
 func TestCheckpointDeflateManagementServerValid(t *testing.T) {
 	expected := initCheckpointTestManagementServer()
 
-	// Pass nil for meta since we're not testing segment conversion
-	m := deflateCheckpointManagementServer(expected, nil)
+	// Pass nil for d and meta since we're not testing state carry-forward or segment conversion
+	m := deflateCheckpointManagementServer(nil, expected, nil)
 
 	require.Equal(t, m[0]["configuration_mode"].(string), expected.ConfigurationMode)
 	require.Equal(t, m[0]["credential_id"].(string), expected.CredentialId)

--- a/alkira/resource_alkira_service_cisco_ftdv.go
+++ b/alkira/resource_alkira_service_cisco_ftdv.go
@@ -110,7 +110,8 @@ func resourceAlkiraServiceCiscoFTDv() *schema.Resource {
 			},
 			"firepower_management_center": {
 				Description: "The Firepower Management Center options.",
-				Type:        schema.TypeSet,
+				Type:        schema.TypeList,
+				MaxItems:    1,
 				Required:    true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
@@ -325,7 +326,7 @@ func resourceServiceCiscoFTDvRead(ctx context.Context, d *schema.ResourceData, m
 	d.Set("billing_tag_ids", service.BillingTags)
 	d.Set("credential_id", service.CredentialId)
 	d.Set("cxp", service.Cxp)
-	d.Set("firepower_management_center", deflateCiscoFTDvManagementServer(service, m))
+	d.Set("firepower_management_center", deflateCiscoFTDvManagementServer(d, service, m))
 	d.Set("global_cidr_list_id", service.GlobalCidrListId)
 	d.Set("instance", setCiscoFTDvInstances(d, service.Instances))
 	d.Set("max_instance_count", service.MaxInstanceCount)
@@ -463,7 +464,7 @@ func generateServiceCiscoFTDvRequest(d *schema.ResourceData, m interface{}) (*al
 	// credential_id and ip_allow_list is on top level of the service,
 	// but those fields should be part of the management_center.
 	//
-	credentialId, ipAllowList, managementServer, err := expandCiscoFtdvManagementServer(d.Get("firepower_management_center").(*schema.Set), m)
+	credentialId, ipAllowList, managementServer, err := expandCiscoFtdvManagementServer(d.Get("firepower_management_center").([]interface{}), m)
 
 	if err != nil {
 		return nil, err

--- a/alkira/resource_alkira_service_cisco_ftdv_helper.go
+++ b/alkira/resource_alkira_service_cisco_ftdv_helper.go
@@ -82,19 +82,19 @@ func expandCiscoFTDvInstances(in []interface{}, m interface{}) ([]alkira.CiscoFT
 	return instances, nil
 }
 
-func expandCiscoFtdvManagementServer(in *schema.Set, m interface{}) (string, []string, alkira.CiscoFTDvManagementServer, error) {
+func expandCiscoFtdvManagementServer(in []interface{}, m interface{}) (string, []string, alkira.CiscoFTDvManagementServer, error) {
 	client := m.(*alkira.AlkiraClient)
 
 	var credentialId string
 	var ipAllowList = []string{}
 	var managementServer = alkira.CiscoFTDvManagementServer{}
 
-	if in == nil || in.Len() != 1 {
+	if in == nil || len(in) != 1 {
 		log.Printf("[DEBUG] Invalid Cisco FTDv Management Server input.")
 		return credentialId, ipAllowList, managementServer, errors.New("ERROR: Invalid Cisco FTDv Management Server input")
 	}
 
-	for _, option := range in.List() {
+	for _, option := range in {
 		cfg := option.(map[string]interface{})
 
 		var username string
@@ -179,7 +179,7 @@ func expandCiscoFtdvSegmentOptions(in *schema.Set, m interface{}) (alkira.Segmen
 	return segmentOptions, nil
 }
 
-func deflateCiscoFTDvManagementServer(service *alkira.ServiceCiscoFTDv, m interface{}) []map[string]interface{} {
+func deflateCiscoFTDvManagementServer(d *schema.ResourceData, service *alkira.ServiceCiscoFTDv, m interface{}) []map[string]interface{} {
 
 	result := make(map[string]interface{})
 
@@ -192,6 +192,18 @@ func deflateCiscoFTDvManagementServer(service *alkira.ServiceCiscoFTDv, m interf
 		segmentId, err := getSegmentIdByName(service.ManagementServer.Segment, m)
 		if err == nil {
 			result["segment_id"] = segmentId
+		}
+	}
+
+	// API doesn't return username or password. Carry forward from prior state.
+	if d != nil {
+		if existing, ok := d.GetOk("firepower_management_center"); ok {
+			prior := existing.([]interface{})
+			if len(prior) > 0 {
+				p := prior[0].(map[string]interface{})
+				result["username"] = p["username"]
+				result["password"] = p["password"]
+			}
 		}
 	}
 


### PR DESCRIPTION
Problem:
Commit 9a131d9a (AK-63243) corrected the deflate field names for Checkpoint management_server and Cisco FTDv firepower_management_center ("segment" -> "segment_id", "user_name" -> "username"). Since both blocks use TypeSet, the corrected field names change the hash on the first Read after upgrade from v1.4.4. Terraform sees different hashes as "old block removed, new block added" (remove+add). The "add" side is built from HCL config which has no credential_id (it's Computed), so the expand function creates a new credential on every apply. This cycle never stabilizes — perpetual diff with orphaned credentials.

Additionally, the API doesn't return sensitive fields (password for Checkpoint, username/password for FTDv). Without carrying these from prior state, every Read writes empty values causing a perpetual diff on those fields.

Fix:
1. Change management_server (Checkpoint) and firepower_management_center (Cisco FTDv) from TypeSet to TypeList with MaxItems=1. TypeList compares fields directly instead of hashing, so the corrected field names don't trigger remove+add, and credential_id is preserved from state during in-place updates.

2. Add d.GetOk pattern to both deflate functions to carry forward password (Checkpoint) and username/password (FTDv) from prior state, since the API doesn't return these sensitive fields.

Changes per resource:
- Schema: TypeSet -> TypeList + MaxItems: 1
- Expand call site: .(*schema.Set) -> .([]interface{})
- Expand function: *schema.Set -> []interface{}
- Deflate function: accepts *schema.ResourceData, carries sensitive fields from prior state via d.GetOk

Verified:
- Created Checkpoint + FTDv with v1.4.4, upgraded to this fix
- management_server perpetual diff: FIXED
- firepower_management_center perpetual diff: FIXED
- credential_id cycling: FIXED (no orphaned credentials)
- password/username perpetual diff: FIXED (carried from state)
- Edited Checkpoint management_server.ips: apply succeeds, plan clean
- Edited FTDv firepower_management_center.server_ip: apply succeeds, plan clean
- Multiple apply cycles: no perpetual diff on either resource
- Only remaining diff: Checkpoint segment_options DEFAULT zone (pre-existing in v1.4.4)
- Tested on sneha.grassroots.dev.alkira2.net (CXP: US-WEST)