### PR TITLE
[AK-68256] include all prefixes in prefixDetails so UI renders NAT-ru…

### DIFF
--- a/alkira/resource_alkira_policy_prefix_list_helper.go
+++ b/alkira/resource_alkira_policy_prefix_list_helper.go
@@ -88,7 +88,7 @@ func buildPrefixDetailsMap(d *schema.ResourceData) map[string]*alkira.PolicyPref
 			prefixMap := p.(map[string]interface{})
 			prefix := prefixMap["cidr"].(string)
 
-			if desc, ok := prefixMap["description"].(string); ok && desc != "" {
+			if desc, ok := prefixMap["description"].(string); ok {
 				details[prefix] = &alkira.PolicyPrefixListDetails{Description: desc}
 			}
 		}

--- a/alkira/resource_alkira_policy_prefix_list_helper_test.go
+++ b/alkira/resource_alkira_policy_prefix_list_helper_test.go
@@ -231,7 +231,7 @@ func TestExpandPrefixListPrefixes(t *testing.T) {
 				map[string]interface{}{"cidr": "10.0.0.0/8"},
 			},
 			expectedPrefixes:   []string{"192.168.1.0/24", "10.0.0.0/8"},
-			expectedDetailsLen: 0,
+			expectedDetailsLen: 2,
 		},
 		{
 			name: "prefixes with descriptions",


### PR DESCRIPTION
…le prefix lists without descriptions

Summary

  In buildPrefixDetailsMap (resource_alkira_policy_prefix_list_helper.go:91), the && desc != "" filter caused prefixes with an empty description to be omitted from the prefixDetails map in the API write payload. The customer portal's NAT-rule prefix-list view renders entries by joining on prefixDetails, so prefixes managed via Terraform without a description silently disappeared from that view.

  UKG hit this in production on prefix list 10383 (referenced by 7 NAT rules) when adding 10.214.70.0/28 via Terraform; adding any description unblocked them. Reproduced in staging Bluesky on prefix list pl8.

  Fix

  - alkira/resource_alkira_policy_prefix_list_helper.go — drop the empty-description filter so every prefix in a prefix block gets a prefixDetails entry. The inner Description field still has omitempty, so empty-description prefixes serialize as "10.6.3.0/25": {} — same shape the UI sends, and enough for the UI to
  render the prefix in the NAT-rule view.
  - alkira/resource_alkira_policy_prefix_list_helper_test.go — update the TestExpandPrefixListPrefixes/prefixes_without_descriptions case to expect expectedDetailsLen: 2 (it previously asserted 0, codifying the bug).
