### PR TITLE
AK-66965: Add scale_group_id to alkira_connector_azure_vnet_third_party

### DIFF
--- a/alkira/resource_alkira_connector_azure_vnet_third_party.go
+++ b/alkira/resource_alkira_connector_azure_vnet_third_party.go
@@ -69,6 +69,17 @@ func resourceAlkiraConnectorAzureVnetThirdParty() *schema.Resource {
 				Type:        schema.TypeString,
 				Required:    true,
 			},
+			"scale_group_id": {
+				Description: "The ID of a scale group to place this " +
+					"connector on. A scale group is a set of " +
+					"dedicated CXP nodes used to isolate a connector " +
+					"or distribute many connectors for performance. " +
+					"Typically available only on high-capacity CXPs " +
+					"(10Gb and above). Can only be set at create " +
+					"time and cannot be changed after provisioning.",
+				Type:     schema.TypeString,
+				Optional: true,
+			},
 			"azure_vnet_third_party_connector_attachment_id": {
 				Description: "The ID of the Azure VNET Third Party Connector Attachment.",
 				Type:        schema.TypeInt,
@@ -173,6 +184,7 @@ func resourceConnectorAzureVnetThirdPartyRead(ctx context.Context, d *schema.Res
 	d.Set("enabled", connector.Enabled)
 	d.Set("group", connector.Group)
 	d.Set("size", connector.Size)
+	d.Set("scale_group_id", connector.ScaleGroupId)
 	d.Set("azure_vnet_third_party_connector_attachment_id", connector.AzureVnetThirdPartyConnectorAttachmentId)
 	d.Set("implicit_group_id", connector.ImplicitGroupId)
 
@@ -301,6 +313,7 @@ func generateConnectorAzureVnetThirdPartyRequest(d *schema.ResourceData, m inter
 		Group:                                    d.Get("group").(string),
 		Segments:                                 []string{segmentName},
 		Size:                                     d.Get("size").(string),
+		ScaleGroupId:                             d.Get("scale_group_id").(string),
 		AzureVnetThirdPartyConnectorAttachmentId: d.Get("azure_vnet_third_party_connector_attachment_id").(int),
 		BillingTags:                              billingTags,
 		StaticRoutes:                             staticRoutes,

--- a/alkira/resource_alkira_connector_azure_vnet_third_party_test.go
+++ b/alkira/resource_alkira_connector_azure_vnet_third_party_test.go
@@ -1,0 +1,89 @@
+package alkira
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/alkiranet/alkira-client-go/alkira"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConnectorAzureVnetThirdPartyScaleGroupId(t *testing.T) {
+	t.Run("omitted when empty", func(t *testing.T) {
+		connector := alkira.AzureVnetThirdPartyConnector{
+			Name: "test-connector",
+			CXP:  "US-EAST-2",
+		}
+
+		data, err := json.Marshal(connector)
+		require.NoError(t, err)
+
+		var m map[string]interface{}
+		require.NoError(t, json.Unmarshal(data, &m))
+		require.NotContains(t, m, "scaleGroupId", "scaleGroupId should be omitted when empty")
+	})
+
+	t.Run("included when set", func(t *testing.T) {
+		connector := alkira.AzureVnetThirdPartyConnector{
+			Name:         "test-connector",
+			CXP:          "US-EAST-2",
+			ScaleGroupId: "sg-abc123",
+		}
+
+		data, err := json.Marshal(connector)
+		require.NoError(t, err)
+
+		var m map[string]interface{}
+		require.NoError(t, json.Unmarshal(data, &m))
+		require.Contains(t, m, "scaleGroupId", "scaleGroupId should be present when set")
+		require.Equal(t, "sg-abc123", m["scaleGroupId"])
+	})
+
+	t.Run("round-trip marshal/unmarshal", func(t *testing.T) {
+		original := alkira.AzureVnetThirdPartyConnector{
+			Name:         "test-connector",
+			CXP:          "US-WEST-1",
+			ScaleGroupId: "sg-xyz789",
+		}
+
+		data, err := json.Marshal(original)
+		require.NoError(t, err)
+
+		var decoded alkira.AzureVnetThirdPartyConnector
+		require.NoError(t, json.Unmarshal(data, &decoded))
+		require.Equal(t, original.ScaleGroupId, decoded.ScaleGroupId)
+	})
+}
+
+func TestAzureVnetThirdPartyScaleGroupIdSchema(t *testing.T) {
+	resourceSchema := resourceAlkiraConnectorAzureVnetThirdParty().Schema
+
+	t.Run("field exists in schema", func(t *testing.T) {
+		_, ok := resourceSchema["scale_group_id"]
+		assert.True(t, ok, "scale_group_id must be present in schema")
+	})
+
+	t.Run("field is Optional TypeString", func(t *testing.T) {
+		field := resourceSchema["scale_group_id"]
+		assert.Equal(t, schema.TypeString, field.Type)
+		assert.True(t, field.Optional)
+		assert.False(t, field.Required)
+		assert.False(t, field.Computed)
+	})
+}
+
+func TestAzureVnetThirdPartyScaleGroupIdRequest(t *testing.T) {
+	t.Run("ScaleGroupId populated when set", func(t *testing.T) {
+		connector := alkira.AzureVnetThirdPartyConnector{
+			ScaleGroupId: "sg-123",
+		}
+		assert.Equal(t, "sg-123", connector.ScaleGroupId)
+	})
+
+	t.Run("ScaleGroupId empty when not set", func(t *testing.T) {
+		connector := alkira.AzureVnetThirdPartyConnector{}
+		assert.Empty(t, connector.ScaleGroupId)
+	})
+}

--- a/docs/resources/connector_azure_vnet_third_party.md
+++ b/docs/resources/connector_azure_vnet_third_party.md
@@ -54,6 +54,7 @@ resource "alkira_connector_azure_vnet_third_party" "example" {
 - `description` (String) The description of the connector.
 - `enabled` (Boolean) Is the connector enabled. Default is `true`.
 - `group` (String) The group of the connector.
+- `scale_group_id` (String) The ID of a scale group to place this connector on. A scale group is a set of dedicated CXP nodes used to isolate a connector or distribute many connectors for performance. Typically available only on high-capacity CXPs (10Gb and above). Can only be set at create time and cannot be changed after provisioning.
 
 ### Read-Only
 


### PR DESCRIPTION
 ## Summary
  - Add `scale_group_id` (Optional, String) to the `alkira_connector_azure_vnet_third_party` schema
  - Wire it through the Read path and the request generator so users can attach the connector to a scale group
  - Bump vendored `alkira-client-go` to a version that exposes `ScaleGroupId` on `AzureVnetThirdPartyConnector`
  - Add unit tests covering JSON marshal omission when unset, inclusion when set, round-trip, and schema shape (Optional/TypeString)

  ## Notable decisions
  - Field is `Optional` (not `Required` or `Computed`) — matches `scale_group_id` conventions on other connectors (e.g. AWS DX, GCP Interconnect)
  - SDK struct uses `json:"scaleGroupId,omitempty"` so existing tfstates without a scale group don't start sending an empty value to the backend
  - Tests assert `scaleGroupId` is *omitted* from the JSON body when empty, to guard against future struct-tag regressions

  ## Test plan
  - [ ] `make lint` clean
  - [ ] `go test ./alkira/ -run TestConnectorAzureVnetThirdPartyScaleGroupId -run TestAzureVnetThirdPartyScaleGroupIdSchema -run TestAzureVnetThirdPartyScaleGroupIdRequest`
  - [ ] Apply a tf config that sets `scale_group_id` and confirm it is sent in the create request and round-trips on refresh
  - [ ] Apply a tf config without `scale_group_id` and confirm no `scaleGroupId` is sent