### PR TITLE
AK-68322: omit empty loopback_prefixes in AWS DX connector payload

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/alkiranet/terraform-provider-alkira
 go 1.26
 
 require (
-	github.com/alkiranet/alkira-client-go v1.59.1-0.20260526170339-1a024f7afb64
+	github.com/alkiranet/alkira-client-go v1.59.1-0.20260527042706-75b739d6eddd
 	github.com/hashicorp/go-cty v1.5.0
 	github.com/hashicorp/go-retryablehttp v0.7.7
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.37.0

--- a/go.sum
+++ b/go.sum
@@ -5,8 +5,8 @@ github.com/PuerkitoBio/purell v1.1.1/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbt
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
 github.com/agext/levenshtein v1.2.2 h1:0S/Yg6LYmFJ5stwQeRp6EeOcCbj7xiqQSdNelsXvaqE=
 github.com/agext/levenshtein v1.2.2/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
-github.com/alkiranet/alkira-client-go v1.59.1-0.20260526170339-1a024f7afb64 h1:WBDWPyRFHQsQ9Z7GrAynqxUn0ROyKMF5B4wB2XdGulQ=
-github.com/alkiranet/alkira-client-go v1.59.1-0.20260526170339-1a024f7afb64/go.mod h1:ms9LjOc4O1Zrr7/VQOva+xwv3sJuBUqS9JsI+MbE2go=
+github.com/alkiranet/alkira-client-go v1.59.1-0.20260527042706-75b739d6eddd h1:wC6cQp6cA2h2cXYGOFUYcuc+NVQn5IxhgQdh7bzGGJQ=
+github.com/alkiranet/alkira-client-go v1.59.1-0.20260527042706-75b739d6eddd/go.mod h1:ms9LjOc4O1Zrr7/VQOva+xwv3sJuBUqS9JsI+MbE2go=
 github.com/apparentlymart/go-textseg/v12 v12.0.0/go.mod h1:S/4uRK2UtaQttw1GenVJEynmyUenKwP++x/+DdGV/Ec=
 github.com/apparentlymart/go-textseg/v15 v15.0.0 h1:uYvfpb3DyLSCGWnctWKGj857c6ew1u1fNQOlOtuGxQY=
 github.com/apparentlymart/go-textseg/v15 v15.0.0/go.mod h1:K8XmNZdhEBkdlyDdvbmmsvpAG721bKi0joRfFdHIWJ4=

--- a/vendor/github.com/alkiranet/alkira-client-go/alkira/connector_aws_direct_connect.go
+++ b/vendor/github.com/alkiranet/alkira-client-go/alkira/connector_aws_direct_connect.go
@@ -51,7 +51,7 @@ type ConnectorAwsDirectConnect struct {
 	Size             string                              `json:"size"`
 	ScaleGroupId     string                              `json:"scaleGroupId,omitempty"`
 	TunnelProtocol   string                              `json:"tunnelProtocol"`
-	LoopbackPrefixes []string                            `json:"loopbackPrefixes"`
+	LoopbackPrefixes []string                            `json:"loopbackPrefixes,omitempty"`
 	Instances        []ConnectorAwsDirectConnectInstance `json:"instances"`
 }
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,7 +1,7 @@
 # github.com/agext/levenshtein v1.2.2
 ## explicit
 github.com/agext/levenshtein
-# github.com/alkiranet/alkira-client-go v1.59.1-0.20260526170339-1a024f7afb64
+# github.com/alkiranet/alkira-client-go v1.59.1-0.20260527042706-75b739d6eddd
 ## explicit; go 1.26
 github.com/alkiranet/alkira-client-go/alkira
 # github.com/apparentlymart/go-textseg/v15 v15.0.0


### PR DESCRIPTION
 ## Summary
  - Bump `alkira-client-go` to `v1.59.1-0.20260527042706-75b739d6eddd` so the `ConnectorAwsDirectConnect.LoopbackPrefixes` field is tagged `omitempty`.
  - Follow-up to AK-68322 (#676), which added `loopback_prefixes` support to `alkira_connector_aws_dx`. Without `omitempty`, the field was always serialized — sending an empty array to
  the API when the user didn't configure loopback prefixes.