### PR TITLE
AK-67764: Add policy_fqdn_list_id and INTERNAL_DNS to internet applic…

### DIFF
--- a/alkira/resource_alkira_internet_applications.go
+++ b/alkira/resource_alkira_internet_applications.go
@@ -183,16 +183,16 @@ func resourceAlkiraInternetApplication() *schema.Resource {
 					Schema: map[string]*schema.Schema{
 						"type": {
 							Description: "The type of the target, one of " +
-								"`IP` or `ILB_NAME`.",
+								"`IP`, `ILB_NAME` or `INTERNAL_DNS`.",
 							Type:     schema.TypeString,
 							Required: true,
 							ValidateFunc: validation.StringInSlice(
-								[]string{"IP", "ILB_NAME"}, false),
+								[]string{"IP", "ILB_NAME", "INTERNAL_DNS"}, false),
 						},
 						"value": {
-							Description: "IFA ILB name or private IP.",
+							Description: "IFA ILB name or private IP. Not required when `type` is `INTERNAL_DNS`.",
 							Type:        schema.TypeString,
-							Required:    true,
+							Optional:    true,
 						},
 						"port_ranges": {
 							Description: "list of ports or port ranges. " +
@@ -202,6 +202,12 @@ func resourceAlkiraInternetApplication() *schema.Resource {
 							Type:     schema.TypeList,
 							Elem:     &schema.Schema{Type: schema.TypeString},
 							Required: true,
+						},
+						"policy_fqdn_list_id": {
+							Description: "The ID of the policy FQDN list. " +
+								"Only applicable when `type` is `INTERNAL_DNS`.",
+							Type:     schema.TypeInt,
+							Optional: true,
 						},
 					},
 				},
@@ -334,9 +340,10 @@ func resourceInternetApplicationRead(ctx context.Context, d *schema.ResourceData
 
 	for _, target := range app.Targets {
 		i := map[string]interface{}{
-			"type":        target.Type,
-			"value":       target.Value,
-			"port_ranges": target.PortRanges,
+			"type":                target.Type,
+			"value":               target.Value,
+			"port_ranges":         target.PortRanges,
+			"policy_fqdn_list_id": target.PolicyFqdnListId,
 		}
 		targets = append(targets, i)
 	}

--- a/alkira/resource_alkira_internet_applications.go
+++ b/alkira/resource_alkira_internet_applications.go
@@ -31,6 +31,59 @@ func resourceAlkiraInternetApplication() *schema.Resource {
 				d.SetNew("provision_state", "SUCCESS")
 			}
 
+			// Inspect raw config so we can tell which fields the user actually
+			// wrote vs. unknown references to other terraform-managed resources.
+			// Unknown fields are skipped; the API enforces them at apply time.
+			rawConfig := d.GetRawConfig()
+			if !rawConfig.IsKnown() || rawConfig.IsNull() {
+				return nil
+			}
+
+			targetRaw := rawConfig.GetAttr("target")
+			if targetRaw.IsNull() || !targetRaw.IsKnown() {
+				return nil
+			}
+
+			for it := targetRaw.ElementIterator(); it.Next(); {
+				_, elem := it.Element()
+
+				typeAttr := elem.GetAttr("type")
+				if !typeAttr.IsKnown() || typeAttr.IsNull() {
+					continue
+				}
+				tType := typeAttr.AsString()
+
+				valueAttr := elem.GetAttr("value")
+				fqdnAttr := elem.GetAttr("policy_fqdn_list_id")
+
+				valueKnown := valueAttr.IsKnown()
+				valueSet := valueKnown && !valueAttr.IsNull() && valueAttr.AsString() != ""
+
+				fqdnKnown := fqdnAttr.IsKnown()
+				fqdnSet := false
+				if fqdnKnown && !fqdnAttr.IsNull() {
+					n, _ := fqdnAttr.AsBigFloat().Int64()
+					fqdnSet = n != 0
+				}
+
+				switch tType {
+				case "IP", "ILB_NAME":
+					if valueKnown && !valueSet {
+						return fmt.Errorf("[ERROR] target.value is required when target.type is %q", tType)
+					}
+					if fqdnSet {
+						return fmt.Errorf("[ERROR] target.policy_fqdn_list_id must not be set when target.type is %q", tType)
+					}
+				case "INTERNAL_DNS":
+					if valueSet {
+						return fmt.Errorf("[ERROR] target.value must not be set when target.type is \"INTERNAL_DNS\"")
+					}
+					if fqdnKnown && !fqdnSet {
+						return fmt.Errorf("[ERROR] target.policy_fqdn_list_id is required when target.type is \"INTERNAL_DNS\"")
+					}
+				}
+			}
+
 			return nil
 		},
 		Importer: &schema.ResourceImporter{

--- a/alkira/resource_alkira_internet_applications_helper.go
+++ b/alkira/resource_alkira_internet_applications_helper.go
@@ -51,6 +51,9 @@ func expandInternetApplicationTargets(in *schema.Set) []alkira.InternetApplicati
 		if v, ok := content["port_ranges"].([]interface{}); ok {
 			r.PortRanges = convertTypeListToStringList(v)
 		}
+		if v, ok := content["policy_fqdn_list_id"].(int); ok {
+			r.PolicyFqdnListId = v
+		}
 		targets[i] = r
 	}
 

--- a/docs/resources/internet_application.md
+++ b/docs/resources/internet_application.md
@@ -27,7 +27,7 @@ This resource needs to work with one of the following connector resources so far
 
 ## Example Usage
 
-This example assumes that `alkira_connector_aws_vpc.test` was created separately.
+This example assumes that `alkira_connector_aws_vpc.test` and `alkira_connector_aws_vpc.test2` were created separately.
 
 ```terraform
 resource "alkira_internet_application" "test" {
@@ -42,6 +42,21 @@ resource "alkira_internet_application" "test" {
     type        = "IP"
     value       = "192.168.1.1"
     port_ranges = ["1200"]
+  }
+}
+
+resource "alkira_internet_application" "test_internal_dns" {
+  name           = "test-ifa-internal-dns"
+  connector_id   = alkira_connector_aws_vpc.test2.id
+  connector_type = "AWS_VPC"
+  fqdn_prefix    = "tfexample-dns"
+  segment_id     = alkira_segment.seg1.id
+  size           = "SMALL"
+
+  target {
+    type                = "INTERNAL_DNS"
+    policy_fqdn_list_id = alkira_list_policy_fqdn.test.id
+    port_ranges         = ["1200"]
   }
 }
 ```
@@ -83,8 +98,12 @@ resource "alkira_internet_application" "test" {
 Required:
 
 - `port_ranges` (List of String) list of ports or port ranges. Values can be mixed i.e. `["20", "100-200"]`. Value ["-1"] means any port.
-- `type` (String) The type of the target, one of `IP` or `ILB_NAME`.
-- `value` (String) IFA ILB name or private IP.
+- `type` (String) The type of the target, one of `IP`, `ILB_NAME` or `INTERNAL_DNS`.
+
+Optional:
+
+- `policy_fqdn_list_id` (Number) The ID of the policy FQDN list. Only applicable when `type` is `INTERNAL_DNS`.
+- `value` (String) IFA ILB name or private IP. Not required when `type` is `INTERNAL_DNS`.
 
 
 <a id="nestedblock--source_nat_ip_pool"></a>

--- a/examples/resources/alkira_internet_application/resource.tf
+++ b/examples/resources/alkira_internet_application/resource.tf
@@ -12,3 +12,18 @@ resource "alkira_internet_application" "test" {
     port_ranges = ["1200"]
   }
 }
+
+resource "alkira_internet_application" "test_internal_dns" {
+  name           = "test-ifa-internal-dns"
+  connector_id   = alkira_connector_aws_vpc.test2.id
+  connector_type = "AWS_VPC"
+  fqdn_prefix    = "tfexample-dns"
+  segment_id     = alkira_segment.seg1.id
+  size           = "SMALL"
+
+  target {
+    type                = "INTERNAL_DNS"
+    policy_fqdn_list_id = alkira_list_policy_fqdn.test.id
+    port_ranges         = ["1200"]
+  }
+}

--- a/templates/resources/internet_application.md.tmpl
+++ b/templates/resources/internet_application.md.tmpl
@@ -24,7 +24,7 @@ This resource needs to work with one of the following connector resources so far
 
 ## Example Usage
 
-This example assumes that `alkira_connector_aws_vpc.test` was created separately.
+This example assumes that `alkira_connector_aws_vpc.test` and `alkira_connector_aws_vpc.test2` were created separately.
 
 {{ tffile "examples/resources/alkira_internet_application/resource.tf" }}
 


### PR DESCRIPTION
…ation resource

Add `policy_fqdn_list_id` as an optional `TypeInt` attribute on the target block and accept `INTERNAL_DNS` as a valid target type. Field is plumbed through expand/flatten so create, read, and import round-trip correctly. Existing `IP`/`ILB_NAME` configurations are unaffected.