### PR TITLE
AK-69292: clarify NAT policy group-ID-only behavior in docs

### DIFF
--- a/alkira/resource_alkira_policy_nat.go
+++ b/alkira/resource_alkira_policy_nat.go
@@ -59,17 +59,21 @@ func resourceAlkiraPolicyNat() *schema.Resource {
 			},
 			"included_group_ids": {
 				Description: "Defines the scope for the policy. Connectors " +
-					"associated with groups defined here is where this policy " +
-					"would be applied.",
+					"associated with the groups defined here are where this " +
+					"policy is applied. This field accepts group IDs only " +
+					"(not connector IDs); for a connector that is not " +
+					"associated with any user-defined group, use the " +
+					"connector's implicit group ID.",
 				Type:     schema.TypeSet,
 				Elem:     &schema.Schema{Type: schema.TypeInt},
 				Required: true,
 			},
 			"excluded_group_ids": {
-				Description: "Excludes given associated connector from " +
-					"`included_groups`. Implicit group of a branch or on-premise " +
-					"connector for which a user defined group is used in " +
-					"`included_groups` can be used here.",
+				Description: "Excludes connectors from the scope defined by " +
+					"`included_group_ids`. This field accepts group IDs only " +
+					"(not connector IDs). The implicit group ID of a branch or " +
+					"on-premise connector whose user-defined group is listed in " +
+					"`included_group_ids` can be used here.",
 				Type:     schema.TypeSet,
 				Elem:     &schema.Schema{Type: schema.TypeInt},
 				Optional: true,

--- a/docs/resources/policy_nat.md
+++ b/docs/resources/policy_nat.md
@@ -51,7 +51,7 @@ resource "alkira_policy_nat" "example" {
 
 ### Required
 
-- `included_group_ids` (Set of Number) Defines the scope for the policy. Connectors associated with groups defined here is where this policy would be applied.
+- `included_group_ids` (Set of Number) Defines the scope for the policy. Connectors associated with the groups defined here are where this policy is applied. This field accepts group IDs only (not connector IDs); for a connector that is not associated with any user-defined group, use the connector's implicit group ID.
 - `name` (String) The name of the policy.
 - `nat_rule_ids` (List of Number) The list of NAT rules to be applied by the policy.
 - `segment_id` (String) IDs of the segment that will define the policyscope.
@@ -62,10 +62,9 @@ resource "alkira_policy_nat" "example" {
 - `allow_overlapping_translated_source_addresses` (Boolean) Allow overlapping translated source address. Default value is `false`. (**BETA**)
 - `category` (String) The category of NAT policy. The vaule could be `DEFAULT` or `INTERNET_CONNECTOR`. Default value is `DEFAULT`.
 - `description` (String) The description of the policy.
-- `excluded_group_ids` (Set of Number) Excludes given associated connector from `included_groups`. Implicit group of a branch or on-premise connector for which a user defined group is used in `included_groups` can be used here.
+- `excluded_group_ids` (Set of Number) Excludes connectors from the scope defined by `included_group_ids`. This field accepts group IDs only (not connector IDs). The implicit group ID of a branch or on-premise connector whose user-defined group is listed in `included_group_ids` can be used here.
 
 ### Read-Only
 
 - `id` (String) The ID of this resource.
-
-
+- `provision_state` (String) The provisioning state of the resource.


### PR DESCRIPTION
## Summary

- Clarify the schema descriptions for `included_group_ids` and `excluded_group_ids` on the `alkira_policy_nat` resource to state they accept **group IDs only** (not connector IDs).
- Regenerate `docs/resources/policy_nat.md` from the updated schema.

## Problem

The `alkira_policy_nat` resource exposes `included_group_ids` and `excluded_group_ids`, which accept group IDs only. Users have been confused and passed connector IDs, because the documentation did not make the group-ID-only requirement explicit — nor did it explain that a connector with no user-defined group must be referenced by its **implicit** group ID.

See AK-69292 and the linked Slack thread.

## Solution

Updated the `Description` strings for both fields in `alkira/resource_alkira_policy_nat.go`:

- `included_group_ids`: now states the field accepts group IDs only (not connector IDs) and that the connector's implicit group ID must be used for connectors not associated with any user-defined group.
- `excluded_group_ids`: tightened to make the group-ID-only requirement explicit and consistent.

Docs are auto-generated, so `docs/resources/policy_nat.md` was regenerated via `make doc` (never hand-edited).

## Changes

- `alkira/resource_alkira_policy_nat.go` — schema field descriptions for `included_group_ids` and `excluded_group_ids`.
- `docs/resources/policy_nat.md` — regenerated registry doc.

## Testing Performed

### Documentation-only change

This is a documentation/schema-description change with no runtime behavior change, so live-environment testing is not applicable.

### Code Quality

- `make lint` — 0 issues
- `make build` — clean
- `make doc` — regenerated, only `policy_nat.md` retained
- Unit tests (`go test ./alkira/... -run TestPolicyNat`) — all pass

## Jira

https://alkiranet.atlassian.net/browse/AK-69292