### PR TITLE
AK-69343: omit empty firstIpAssignedTo in IP reservation payload

### DIFF
--- a/alkira/resource_alkira_ip_reservation.go
+++ b/alkira/resource_alkira_ip_reservation.go
@@ -74,9 +74,13 @@ func resourceAlkiraIpReservation() *schema.Resource {
 					"`prefix` is a `/30`. This field determines which IP from " +
 					"the given or the computed `/30` prefix is assigned to the " +
 					"customer end of the tunnel and which IP is assigned to the " +
-					"CXP end of the tunnel.",
+					"CXP end of the tunnel. The backend retains this value once " +
+					"set, so it cannot be cleared by removing it from the " +
+					"configuration; omitting it defers to the value stored by " +
+					"the backend.",
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 				ValidateFunc: validation.StringInSlice([]string{
 					"CUSTOMER", "CXP"}, false),
 			},

--- a/docs/resources/ip_reservation.md
+++ b/docs/resources/ip_reservation.md
@@ -13,7 +13,8 @@ Provide IP Reservation resource.
 ## Example Usage
 
 ```terraform
-# With an explicit prefix
+# A /30 reservation with an explicit prefix.
+# For a /30, both first_ip_assignment and node_id are required.
 resource "alkira_ip_reservation" "explicit_prefix" {
   name                = "test"
   type                = "OVERLAY"
@@ -26,12 +27,28 @@ resource "alkira_ip_reservation" "explicit_prefix" {
   cxp                 = "US-WEST"
 }
 
-# Without a prefix — the backend assigns it based on prefix_type and prefix_len
+# A /30 reservation without an explicit prefix — the backend assigns it based
+# on prefix_type and prefix_len. A /30 still requires first_ip_assignment and
+# node_id even when the backend assigns the prefix.
 resource "alkira_ip_reservation" "backend_assigned_prefix" {
-  name           = "test-backend"
+  name                = "test-backend"
+  type                = "OVERLAY"
+  prefix_type         = "APIPA"
+  prefix_len          = 30
+  first_ip_assignment = "CUSTOMER"
+  node_id             = "d70503d2-1a99-4084-8aae-8268e2764365"
+  scale_group_id      = "99a6f3db-02d5-4189-8b0a-352eaeda2e10"
+  segment_id          = alkira_segment.test.id
+  cxp                 = "US-WEST"
+}
+
+# A single-IP (/32) reservation. first_ip_assignment only governs which IP of a
+# /30 pair is assigned, so it is omitted here.
+resource "alkira_ip_reservation" "single_ip" {
+  name           = "test-single-ip"
   type           = "OVERLAY"
-  prefix_type    = "APIPA"
-  prefix_len     = 30
+  prefix         = "10.1.0.10/32"
+  prefix_type    = "SEGMENT"
   scale_group_id = "99a6f3db-02d5-4189-8b0a-352eaeda2e10"
   segment_id     = alkira_segment.test.id
   cxp            = "US-WEST"
@@ -52,7 +69,7 @@ resource "alkira_ip_reservation" "backend_assigned_prefix" {
 
 ### Optional
 
-- `first_ip_assignment` (String) The value could be either `CUSTOMER` or `CXP`. This is required when `prefix_len` is `30` or the `prefix` is a `/30`. This field determines which IP from the given or the computed `/30` prefix is assigned to the customer end of the tunnel and which IP is assigned to the CXP end of the tunnel.
+- `first_ip_assignment` (String) The value could be either `CUSTOMER` or `CXP`. This is required when `prefix_len` is `30` or the `prefix` is a `/30`. This field determines which IP from the given or the computed `/30` prefix is assigned to the customer end of the tunnel and which IP is assigned to the CXP end of the tunnel. The backend retains this value once set, so it cannot be cleared by removing it from the configuration; omitting it defers to the value stored by the backend.
 - `node_id` (String) The ID of the node that the IP Reservation is assigned to. This must be provided when the given or computed `prefix` is `/30`. When the `prefix` is `/32`then this field determines whether the IP address will be assigned to the customer end or the CXP end.
 - `prefix` (String) The IP Prefix of the IP Reservation. If this is specified, both `prefix_type` and `prefix_len` will be ignored.
 - `prefix_len` (Number) The IP Prefix length of the IP Reservation.

--- a/examples/resources/alkira_ip_reservation/resource.tf
+++ b/examples/resources/alkira_ip_reservation/resource.tf
@@ -1,4 +1,5 @@
-# With an explicit prefix
+# A /30 reservation with an explicit prefix.
+# For a /30, both first_ip_assignment and node_id are required.
 resource "alkira_ip_reservation" "explicit_prefix" {
   name                = "test"
   type                = "OVERLAY"
@@ -11,12 +12,28 @@ resource "alkira_ip_reservation" "explicit_prefix" {
   cxp                 = "US-WEST"
 }
 
-# Without a prefix — the backend assigns it based on prefix_type and prefix_len
+# A /30 reservation without an explicit prefix — the backend assigns it based
+# on prefix_type and prefix_len. A /30 still requires first_ip_assignment and
+# node_id even when the backend assigns the prefix.
 resource "alkira_ip_reservation" "backend_assigned_prefix" {
-  name           = "test-backend"
+  name                = "test-backend"
+  type                = "OVERLAY"
+  prefix_type         = "APIPA"
+  prefix_len          = 30
+  first_ip_assignment = "CUSTOMER"
+  node_id             = "d70503d2-1a99-4084-8aae-8268e2764365"
+  scale_group_id      = "99a6f3db-02d5-4189-8b0a-352eaeda2e10"
+  segment_id          = alkira_segment.test.id
+  cxp                 = "US-WEST"
+}
+
+# A single-IP (/32) reservation. first_ip_assignment only governs which IP of a
+# /30 pair is assigned, so it is omitted here.
+resource "alkira_ip_reservation" "single_ip" {
+  name           = "test-single-ip"
   type           = "OVERLAY"
-  prefix_type    = "APIPA"
-  prefix_len     = 30
+  prefix         = "10.1.0.10/32"
+  prefix_type    = "SEGMENT"
   scale_group_id = "99a6f3db-02d5-4189-8b0a-352eaeda2e10"
   segment_id     = alkira_segment.test.id
   cxp            = "US-WEST"

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/alkiranet/terraform-provider-alkira
 go 1.26
 
 require (
-	github.com/alkiranet/alkira-client-go v1.59.1-0.20260527042706-75b739d6eddd
+	github.com/alkiranet/alkira-client-go v1.59.1-0.20260604163303-8a74a1d62aef
 	github.com/hashicorp/go-cty v1.5.0
 	github.com/hashicorp/go-retryablehttp v0.7.7
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.37.0

--- a/go.sum
+++ b/go.sum
@@ -5,8 +5,8 @@ github.com/PuerkitoBio/purell v1.1.1/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbt
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
 github.com/agext/levenshtein v1.2.2 h1:0S/Yg6LYmFJ5stwQeRp6EeOcCbj7xiqQSdNelsXvaqE=
 github.com/agext/levenshtein v1.2.2/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
-github.com/alkiranet/alkira-client-go v1.59.1-0.20260527042706-75b739d6eddd h1:wC6cQp6cA2h2cXYGOFUYcuc+NVQn5IxhgQdh7bzGGJQ=
-github.com/alkiranet/alkira-client-go v1.59.1-0.20260527042706-75b739d6eddd/go.mod h1:ms9LjOc4O1Zrr7/VQOva+xwv3sJuBUqS9JsI+MbE2go=
+github.com/alkiranet/alkira-client-go v1.59.1-0.20260604163303-8a74a1d62aef h1:iHiloVRC7zRNmXSLYlIF6aZOEjJ96J+sVdE0Fgs51ds=
+github.com/alkiranet/alkira-client-go v1.59.1-0.20260604163303-8a74a1d62aef/go.mod h1:ms9LjOc4O1Zrr7/VQOva+xwv3sJuBUqS9JsI+MbE2go=
 github.com/apparentlymart/go-textseg/v12 v12.0.0/go.mod h1:S/4uRK2UtaQttw1GenVJEynmyUenKwP++x/+DdGV/Ec=
 github.com/apparentlymart/go-textseg/v15 v15.0.0 h1:uYvfpb3DyLSCGWnctWKGj857c6ew1u1fNQOlOtuGxQY=
 github.com/apparentlymart/go-textseg/v15 v15.0.0/go.mod h1:K8XmNZdhEBkdlyDdvbmmsvpAG721bKi0joRfFdHIWJ4=

--- a/vendor/github.com/alkiranet/alkira-client-go/alkira/ip_reservations.go
+++ b/vendor/github.com/alkiranet/alkira-client-go/alkira/ip_reservations.go
@@ -13,7 +13,7 @@ type IPReservation struct {
 	Prefix            string `json:"prefix"`
 	PrefixLen         int    `json:"prefixLen"`
 	PrefixType        string `json:"prefixType"`
-	FirstIpAssignedTo string `json:"firstIpAssignedTo"`
+	FirstIpAssignedTo string `json:"firstIpAssignedTo,omitempty"`
 	NodeId            string `json:"nodeId"`
 	Cxp               string `json:"cxp"`
 	ScaleGroupId      string `json:"scaleGroupId"`

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,7 +1,7 @@
 # github.com/agext/levenshtein v1.2.2
 ## explicit
 github.com/agext/levenshtein
-# github.com/alkiranet/alkira-client-go v1.59.1-0.20260527042706-75b739d6eddd
+# github.com/alkiranet/alkira-client-go v1.59.1-0.20260604163303-8a74a1d62aef
 ## explicit; go 1.26
 github.com/alkiranet/alkira-client-go/alkira
 # github.com/apparentlymart/go-textseg/v15 v15.0.0


### PR DESCRIPTION
https://alkiranet.atlassian.net/browse/AK-69343

## Problem

1. Creating an `alkira_ip_reservation` without `first_ip_assignment` failed at apply with `400 {"code":"AK000001", ... "message":"Failed to parse request"}`. `terraform plan` was clean; the failure only surfaced at apply when the request body is built.
2. Surfaced during live testing: `first_ip_assignment` is retained by the backend once set and cannot be cleared. As a plain `Optional` field, removing it from config produced a perpetual diff (`"CUSTOMER" -> null`) — the PUT omits the field, the backend keeps the value, and Read re-surfaces it.

## Root cause

The provider serialized `firstIpAssignedTo` even when unset, so the body contained `"firstIpAssignedTo":""`. That field maps to a backend enum (`CUSTOMER`/`CXP`); an empty string cannot be deserialized, so the request was rejected at parse time (`AK000001`). The field is optional on the backend DTO — the correct representation of "unset" is to omit the key.

## Fix

- Bump `alkira-client-go` to [#251](https://github.com/alkiranet/alkira-client-go/pull/251), which adds `omitempty` to `firstIpAssignedTo` so the field is dropped when unset (`v1.59.1-0.20260527042706-75b739d6eddd` → `v1.59.1-0.20260604163303-8a74a1d62aef`).
- Mark `first_ip_assignment` `Optional+Computed` so an omitted value defers to the backend-stored value instead of proposing `null` (fixes the perpetual diff); document the retain-once-set behavior.
- Correct the resource examples: the backend-assigned `/30` block now includes the required `first_ip_assignment` + `node_id`; add a `/32` example that legitimately omits `first_ip_assignment`.

## Changes

- `alkira/resource_alkira_ip_reservation.go` — `first_ip_assignment` → Optional+Computed
- `examples/resources/alkira_ip_reservation/resource.tf`, `docs/resources/ip_reservation.md` — example/doc fixes
- `go.mod` / `go.sum` / `vendor/` — client bump

## Testing

### Live testing (`provision=false`)

- **KEY TEST:** Create with no `first_ip_assignment` — request omits `firstIpAssignedTo`, no `AK000001`, apply succeeds, post-apply plan clean.
- Update (rename) and import of a no-`first_ip_assignment` reservation — plan clean, no drift.
- Set value (`CUSTOMER`) — serialized correctly in the request.
- **KEY TEST:** Set → unset transition — plan now shows **No changes** (was a perpetual `"CUSTOMER" -> null` diff before the `Optional+Computed` fix).
- `/30` without `first_ip_assignment` — no longer `AK000001`; backend returns the expected "required for /30" validation.

### Code quality

- `make build` — clean
- `go test ./alkira/... -run TestAlkiraIpReservation` — passes
- Vendored struct carries `firstIpAssignedTo,omitempty`
