### PR TITLE
AK-69786: document scale_group_id cannot be updated after provisioning

### DIFF
--- a/alkira/resource_alkira_connector_aruba_edge.go
+++ b/alkira/resource_alkira_connector_aruba_edge.go
@@ -202,9 +202,15 @@ func resourceAlkiraConnectorArubaEdge() *schema.Resource {
 				Default:  true,
 			},
 			"scale_group_id": {
-				Description: "The ID of the scale group associated with the connector.",
-				Type:        schema.TypeString,
-				Optional:    true,
+				Description: "The ID of a scale group to place this " +
+					"connector on. A scale group is a set of " +
+					"dedicated CXP nodes used to isolate a connector " +
+					"or distribute many connectors for performance. " +
+					"Typically available only on high-capacity CXPs " +
+					"(10Gb and above). Can only be set at create " +
+					"time and cannot be changed after provisioning.",
+				Type:     schema.TypeString,
+				Optional: true,
 			},
 		},
 	}

--- a/alkira/resource_alkira_connector_aruba_edge.go
+++ b/alkira/resource_alkira_connector_aruba_edge.go
@@ -202,13 +202,9 @@ func resourceAlkiraConnectorArubaEdge() *schema.Resource {
 				Default:  true,
 			},
 			"scale_group_id": {
-				Description: "The ID of a scale group to place this " +
-					"connector on. A scale group is a set of " +
-					"dedicated CXP nodes used to isolate a connector " +
-					"or distribute many connectors for performance. " +
-					"Typically available only on high-capacity CXPs " +
-					"(10Gb and above). Can only be set at create " +
-					"time and cannot be changed after provisioning.",
+				Description: "The ID of the scale group associated with " +
+					"the connector. Can only be set at create time and " +
+					"cannot be changed after provisioning.",
 				Type:     schema.TypeString,
 				Optional: true,
 			},

--- a/alkira/resource_alkira_connector_aws_dx.go
+++ b/alkira/resource_alkira_connector_aws_dx.go
@@ -91,13 +91,9 @@ func resourceAlkiraConnectorAwsDx() *schema.Resource {
 				Required: true,
 			},
 			"scale_group_id": {
-				Description: "The ID of a scale group to place this " +
-					"connector on. A scale group is a set of " +
-					"dedicated CXP nodes used to isolate a connector " +
-					"or distribute many connectors for performance. " +
-					"Typically available only on high-capacity CXPs " +
-					"(10Gb and above). Can only be set at create " +
-					"time and cannot be changed after provisioning.",
+				Description: "The ID of the scale group associated with " +
+					"the connector. Can only be set at create time and " +
+					"cannot be changed after provisioning.",
 				Type:     schema.TypeString,
 				Optional: true,
 			},

--- a/alkira/resource_alkira_connector_aws_dx.go
+++ b/alkira/resource_alkira_connector_aws_dx.go
@@ -91,8 +91,13 @@ func resourceAlkiraConnectorAwsDx() *schema.Resource {
 				Required: true,
 			},
 			"scale_group_id": {
-				Description: "The ID of the scale group associated with " +
-					"the connector.",
+				Description: "The ID of a scale group to place this " +
+					"connector on. A scale group is a set of " +
+					"dedicated CXP nodes used to isolate a connector " +
+					"or distribute many connectors for performance. " +
+					"Typically available only on high-capacity CXPs " +
+					"(10Gb and above). Can only be set at create " +
+					"time and cannot be changed after provisioning.",
 				Type:     schema.TypeString,
 				Optional: true,
 			},

--- a/alkira/resource_alkira_connector_aws_tgw.go
+++ b/alkira/resource_alkira_connector_aws_tgw.go
@@ -100,9 +100,15 @@ func resourceAlkiraConnectorAwsTgw() *schema.Resource {
 				Elem:     &schema.Schema{Type: schema.TypeInt},
 			},
 			"scale_group_id": {
-				Description: "The ID of the scale group associated with the connector.",
-				Type:        schema.TypeString,
-				Optional:    true,
+				Description: "The ID of a scale group to place this " +
+					"connector on. A scale group is a set of " +
+					"dedicated CXP nodes used to isolate a connector " +
+					"or distribute many connectors for performance. " +
+					"Typically available only on high-capacity CXPs " +
+					"(10Gb and above). Can only be set at create " +
+					"time and cannot be changed after provisioning.",
+				Type:     schema.TypeString,
+				Optional: true,
 			},
 		},
 	}

--- a/alkira/resource_alkira_connector_aws_tgw.go
+++ b/alkira/resource_alkira_connector_aws_tgw.go
@@ -100,13 +100,9 @@ func resourceAlkiraConnectorAwsTgw() *schema.Resource {
 				Elem:     &schema.Schema{Type: schema.TypeInt},
 			},
 			"scale_group_id": {
-				Description: "The ID of a scale group to place this " +
-					"connector on. A scale group is a set of " +
-					"dedicated CXP nodes used to isolate a connector " +
-					"or distribute many connectors for performance. " +
-					"Typically available only on high-capacity CXPs " +
-					"(10Gb and above). Can only be set at create " +
-					"time and cannot be changed after provisioning.",
+				Description: "The ID of the scale group associated with " +
+					"the connector. Can only be set at create time and " +
+					"cannot be changed after provisioning.",
 				Type:     schema.TypeString,
 				Optional: true,
 			},

--- a/alkira/resource_alkira_connector_aws_vpc.go
+++ b/alkira/resource_alkira_connector_aws_vpc.go
@@ -221,9 +221,15 @@ func resourceAlkiraConnectorAwsVpc() *schema.Resource {
 				Optional: true,
 			},
 			"scale_group_id": {
-				Description: "The ID of the scale group associated with the connector.",
-				Type:        schema.TypeString,
-				Optional:    true,
+				Description: "The ID of a scale group to place this " +
+					"connector on. A scale group is a set of " +
+					"dedicated CXP nodes used to isolate a connector " +
+					"or distribute many connectors for performance. " +
+					"Typically available only on high-capacity CXPs " +
+					"(10Gb and above). Can only be set at create " +
+					"time and cannot be changed after provisioning.",
+				Type:     schema.TypeString,
+				Optional: true,
 			},
 			"overlay_subnets": {
 				Description: "Overlay subnet.",

--- a/alkira/resource_alkira_connector_aws_vpc.go
+++ b/alkira/resource_alkira_connector_aws_vpc.go
@@ -221,13 +221,9 @@ func resourceAlkiraConnectorAwsVpc() *schema.Resource {
 				Optional: true,
 			},
 			"scale_group_id": {
-				Description: "The ID of a scale group to place this " +
-					"connector on. A scale group is a set of " +
-					"dedicated CXP nodes used to isolate a connector " +
-					"or distribute many connectors for performance. " +
-					"Typically available only on high-capacity CXPs " +
-					"(10Gb and above). Can only be set at create " +
-					"time and cannot be changed after provisioning.",
+				Description: "The ID of the scale group associated with " +
+					"the connector. Can only be set at create time and " +
+					"cannot be changed after provisioning.",
 				Type:     schema.TypeString,
 				Optional: true,
 			},

--- a/alkira/resource_alkira_connector_azure_vhub.go
+++ b/alkira/resource_alkira_connector_azure_vhub.go
@@ -93,9 +93,15 @@ func resourceAlkiraConnectorAzureVhub() *schema.Resource {
 				Computed:    true,
 			},
 			"scale_group_id": {
-				Description: "The ID of the scale group associated with the connector.",
-				Type:        schema.TypeString,
-				Optional:    true,
+				Description: "The ID of a scale group to place this " +
+					"connector on. A scale group is a set of " +
+					"dedicated CXP nodes used to isolate a connector " +
+					"or distribute many connectors for performance. " +
+					"Typically available only on high-capacity CXPs " +
+					"(10Gb and above). Can only be set at create " +
+					"time and cannot be changed after provisioning.",
+				Type:     schema.TypeString,
+				Optional: true,
 			},
 			"segment_id": {
 				Description: "The ID of the segment associated with the connector.",

--- a/alkira/resource_alkira_connector_azure_vhub.go
+++ b/alkira/resource_alkira_connector_azure_vhub.go
@@ -93,13 +93,9 @@ func resourceAlkiraConnectorAzureVhub() *schema.Resource {
 				Computed:    true,
 			},
 			"scale_group_id": {
-				Description: "The ID of a scale group to place this " +
-					"connector on. A scale group is a set of " +
-					"dedicated CXP nodes used to isolate a connector " +
-					"or distribute many connectors for performance. " +
-					"Typically available only on high-capacity CXPs " +
-					"(10Gb and above). Can only be set at create " +
-					"time and cannot be changed after provisioning.",
+				Description: "The ID of the scale group associated with " +
+					"the connector. Can only be set at create time and " +
+					"cannot be changed after provisioning.",
 				Type:     schema.TypeString,
 				Optional: true,
 			},

--- a/alkira/resource_alkira_connector_azure_vnet.go
+++ b/alkira/resource_alkira_connector_azure_vnet.go
@@ -269,13 +269,9 @@ func resourceAlkiraConnectorAzureVnet() *schema.Resource {
 				Computed: true,
 			},
 			"scale_group_id": {
-				Description: "The ID of a scale group to place this " +
-					"connector on. A scale group is a set of " +
-					"dedicated CXP nodes used to isolate a connector " +
-					"or distribute many connectors for performance. " +
-					"Typically available only on high-capacity CXPs " +
-					"(10Gb and above). Can only be set at create " +
-					"time and cannot be changed after provisioning.",
+				Description: "The ID of the scale group associated with " +
+					"the connector. Can only be set at create time and " +
+					"cannot be changed after provisioning.",
 				Type:     schema.TypeString,
 				Optional: true,
 			},

--- a/alkira/resource_alkira_connector_azure_vnet.go
+++ b/alkira/resource_alkira_connector_azure_vnet.go
@@ -269,9 +269,15 @@ func resourceAlkiraConnectorAzureVnet() *schema.Resource {
 				Computed: true,
 			},
 			"scale_group_id": {
-				Description: "The ID of the scale group associated with the connector.",
-				Type:        schema.TypeString,
-				Optional:    true,
+				Description: "The ID of a scale group to place this " +
+					"connector on. A scale group is a set of " +
+					"dedicated CXP nodes used to isolate a connector " +
+					"or distribute many connectors for performance. " +
+					"Typically available only on high-capacity CXPs " +
+					"(10Gb and above). Can only be set at create " +
+					"time and cannot be changed after provisioning.",
+				Type:     schema.TypeString,
+				Optional: true,
 			},
 			"peering_gateway_cxp_id": {
 				Description: "The ID of the CXP peering gateway associated with the connector.",

--- a/alkira/resource_alkira_connector_azure_vnet_third_party.go
+++ b/alkira/resource_alkira_connector_azure_vnet_third_party.go
@@ -70,13 +70,9 @@ func resourceAlkiraConnectorAzureVnetThirdParty() *schema.Resource {
 				Required:    true,
 			},
 			"scale_group_id": {
-				Description: "The ID of a scale group to place this " +
-					"connector on. A scale group is a set of " +
-					"dedicated CXP nodes used to isolate a connector " +
-					"or distribute many connectors for performance. " +
-					"Typically available only on high-capacity CXPs " +
-					"(10Gb and above). Can only be set at create " +
-					"time and cannot be changed after provisioning.",
+				Description: "The ID of the scale group associated with " +
+					"the connector. Can only be set at create time and " +
+					"cannot be changed after provisioning.",
 				Type:     schema.TypeString,
 				Optional: true,
 			},

--- a/alkira/resource_alkira_connector_gcp_interconnect.go
+++ b/alkira/resource_alkira_connector_gcp_interconnect.go
@@ -204,13 +204,9 @@ func resourceAlkiraConnectorGcpInterconnect() *schema.Resource {
 			},
 
 			"scale_group_id": {
-				Description: "The ID of a scale group to place this " +
-					"connector on. A scale group is a set of " +
-					"dedicated CXP nodes used to isolate a connector " +
-					"or distribute many connectors for performance. " +
-					"Typically available only on high-capacity CXPs " +
-					"(10Gb and above). Can only be set at create " +
-					"time and cannot be changed after provisioning.",
+				Description: "The ID of the scale group associated with " +
+					"the connector. Can only be set at create time and " +
+					"cannot be changed after provisioning.",
 				Type:     schema.TypeString,
 				Optional: true,
 			},

--- a/alkira/resource_alkira_connector_gcp_interconnect.go
+++ b/alkira/resource_alkira_connector_gcp_interconnect.go
@@ -204,8 +204,13 @@ func resourceAlkiraConnectorGcpInterconnect() *schema.Resource {
 			},
 
 			"scale_group_id": {
-				Description: "The ID of the scale group associated with " +
-					"the connector.",
+				Description: "The ID of a scale group to place this " +
+					"connector on. A scale group is a set of " +
+					"dedicated CXP nodes used to isolate a connector " +
+					"or distribute many connectors for performance. " +
+					"Typically available only on high-capacity CXPs " +
+					"(10Gb and above). Can only be set at create " +
+					"time and cannot be changed after provisioning.",
 				Type:     schema.TypeString,
 				Optional: true,
 			},

--- a/alkira/resource_alkira_connector_gcp_vpc.go
+++ b/alkira/resource_alkira_connector_gcp_vpc.go
@@ -208,13 +208,9 @@ func resourceAlkiraConnectorGcpVpc() *schema.Resource {
 				Default:  64522,
 			},
 			"scale_group_id": {
-				Description: "The ID of a scale group to place this " +
-					"connector on. A scale group is a set of " +
-					"dedicated CXP nodes used to isolate a connector " +
-					"or distribute many connectors for performance. " +
-					"Typically available only on high-capacity CXPs " +
-					"(10Gb and above). Can only be set at create " +
-					"time and cannot be changed after provisioning.",
+				Description: "The ID of the scale group associated with " +
+					"the connector. Can only be set at create time and " +
+					"cannot be changed after provisioning.",
 				Type:     schema.TypeString,
 				Optional: true,
 			},

--- a/alkira/resource_alkira_connector_gcp_vpc.go
+++ b/alkira/resource_alkira_connector_gcp_vpc.go
@@ -208,9 +208,15 @@ func resourceAlkiraConnectorGcpVpc() *schema.Resource {
 				Default:  64522,
 			},
 			"scale_group_id": {
-				Description: "The ID of the scale group associated with the connector.",
-				Type:        schema.TypeString,
-				Optional:    true,
+				Description: "The ID of a scale group to place this " +
+					"connector on. A scale group is a set of " +
+					"dedicated CXP nodes used to isolate a connector " +
+					"or distribute many connectors for performance. " +
+					"Typically available only on high-capacity CXPs " +
+					"(10Gb and above). Can only be set at create " +
+					"time and cannot be changed after provisioning.",
+				Type:     schema.TypeString,
+				Optional: true,
 			},
 		},
 	}

--- a/alkira/resource_alkira_connector_ipsec.go
+++ b/alkira/resource_alkira_connector_ipsec.go
@@ -353,13 +353,9 @@ func resourceAlkiraConnectorIPSec() *schema.Resource {
 				Optional: true,
 			},
 			"scale_group_id": {
-				Description: "The ID of a scale group to place this " +
-					"connector on. A scale group is a set of " +
-					"dedicated CXP nodes used to isolate a connector " +
-					"or distribute many connectors for performance. " +
-					"Typically available only on high-capacity CXPs " +
-					"(10Gb and above). Can only be set at create " +
-					"time and cannot be changed after provisioning.",
+				Description: "The ID of the scale group associated with " +
+					"the connector. Can only be set at create time and " +
+					"cannot be changed after provisioning.",
 				Type:     schema.TypeString,
 				Optional: true,
 			},

--- a/alkira/resource_alkira_connector_ipsec.go
+++ b/alkira/resource_alkira_connector_ipsec.go
@@ -353,9 +353,15 @@ func resourceAlkiraConnectorIPSec() *schema.Resource {
 				Optional: true,
 			},
 			"scale_group_id": {
-				Description: "The ID of the scale group associated with the connector.",
-				Type:        schema.TypeString,
-				Optional:    true,
+				Description: "The ID of a scale group to place this " +
+					"connector on. A scale group is a set of " +
+					"dedicated CXP nodes used to isolate a connector " +
+					"or distribute many connectors for performance. " +
+					"Typically available only on high-capacity CXPs " +
+					"(10Gb and above). Can only be set at create " +
+					"time and cannot be changed after provisioning.",
+				Type:     schema.TypeString,
+				Optional: true,
 			},
 			"segment_id": {
 				Description: "The ID of the segment associated with the connector.",

--- a/alkira/resource_alkira_connector_prisma_sdwan.go
+++ b/alkira/resource_alkira_connector_prisma_sdwan.go
@@ -94,8 +94,13 @@ func resourceAlkiraConnectorPrismaSDWAN() *schema.Resource {
 				Default:     true,
 			},
 			"scale_group_id": {
-				Description: "The ID of the scale group associated " +
-					"with the connector.",
+				Description: "The ID of a scale group to place this " +
+					"connector on. A scale group is a set of " +
+					"dedicated CXP nodes used to isolate a connector " +
+					"or distribute many connectors for performance. " +
+					"Typically available only on high-capacity CXPs " +
+					"(10Gb and above). Can only be set at create " +
+					"time and cannot be changed after provisioning.",
 				Type:     schema.TypeString,
 				Optional: true,
 			},

--- a/alkira/resource_alkira_connector_prisma_sdwan.go
+++ b/alkira/resource_alkira_connector_prisma_sdwan.go
@@ -94,13 +94,9 @@ func resourceAlkiraConnectorPrismaSDWAN() *schema.Resource {
 				Default:     true,
 			},
 			"scale_group_id": {
-				Description: "The ID of a scale group to place this " +
-					"connector on. A scale group is a set of " +
-					"dedicated CXP nodes used to isolate a connector " +
-					"or distribute many connectors for performance. " +
-					"Typically available only on high-capacity CXPs " +
-					"(10Gb and above). Can only be set at create " +
-					"time and cannot be changed after provisioning.",
+				Description: "The ID of the scale group associated with " +
+					"the connector. Can only be set at create time and " +
+					"cannot be changed after provisioning.",
 				Type:     schema.TypeString,
 				Optional: true,
 			},

--- a/docs/resources/connector_aruba_edge.md
+++ b/docs/resources/connector_aruba_edge.md
@@ -68,7 +68,7 @@ resource "alkira_connector_aruba_edge" "test1" {
 - `description` (String) The description of the connector.
 - `enabled` (Boolean) Whether the connector is enabled. Default is `true`.
 - `group` (String) The group of the connector.
-- `scale_group_id` (String) The ID of a scale group to place this connector on. A scale group is a set of dedicated CXP nodes used to isolate a connector or distribute many connectors for performance. Typically available only on high-capacity CXPs (10Gb and above). Can only be set at create time and cannot be changed after provisioning.
+- `scale_group_id` (String) The ID of the scale group associated with the connector. Can only be set at create time and cannot be changed after provisioning.
 - `tunnel_protocol` (String) The tunnel protocol to be used. IPSEC and GRE are the only valid options. IPSEC can only be used with azure. GRE can only be used with AWS. IPSEC is the default selection.
 
 ### Read-Only

--- a/docs/resources/connector_aruba_edge.md
+++ b/docs/resources/connector_aruba_edge.md
@@ -68,6 +68,7 @@ resource "alkira_connector_aruba_edge" "test1" {
 - `description` (String) The description of the connector.
 - `enabled` (Boolean) Whether the connector is enabled. Default is `true`.
 - `group` (String) The group of the connector.
+- `scale_group_id` (String) The ID of a scale group to place this connector on. A scale group is a set of dedicated CXP nodes used to isolate a connector or distribute many connectors for performance. Typically available only on high-capacity CXPs (10Gb and above). Can only be set at create time and cannot be changed after provisioning.
 - `tunnel_protocol` (String) The tunnel protocol to be used. IPSEC and GRE are the only valid options. IPSEC can only be used with azure. GRE can only be used with AWS. IPSEC is the default selection.
 
 ### Read-Only
@@ -89,7 +90,6 @@ Optional:
 
 - `advertise_default_route` (Boolean) Enables or disables access to the internet when traffic arrives via this connector. The default value is `false`.
 - `advertise_on_prem_routes` (Boolean) Allow routes from the branch/premises to be advertised to the cloud. The default value is False.
-- `scale_group_id` (String) The ID of the scale group associated with the connector.
 
 
 <a id="nestedblock--instances"></a>

--- a/docs/resources/connector_aws_dx.md
+++ b/docs/resources/connector_aws_dx.md
@@ -78,7 +78,7 @@ resource "alkira_connector_aws_dx" "test" {
 - `enabled` (Boolean) Is the connector enabled. Default is `true`.
 - `group` (String) The group of the connector.
 - `loopback_prefixes` (Set of String) A list of `/26` prefixes provided by Alkira and used to allocate loopback IPs across DX instances. Required only when using tunnel scale options. Without tunnel scale options, each instance accepts the required loopbacks correctly. Eg: `["10.30.0.0/26"]`
-- `scale_group_id` (String) The ID of the scale group associated with the connector.
+- `scale_group_id` (String) The ID of a scale group to place this connector on. A scale group is a set of dedicated CXP nodes used to isolate a connector or distribute many connectors for performance. Typically available only on high-capacity CXPs (10Gb and above). Can only be set at create time and cannot be changed after provisioning.
 
 ### Read-Only
 

--- a/docs/resources/connector_aws_dx.md
+++ b/docs/resources/connector_aws_dx.md
@@ -78,7 +78,7 @@ resource "alkira_connector_aws_dx" "test" {
 - `enabled` (Boolean) Is the connector enabled. Default is `true`.
 - `group` (String) The group of the connector.
 - `loopback_prefixes` (Set of String) A list of `/26` prefixes provided by Alkira and used to allocate loopback IPs across DX instances. Required only when using tunnel scale options. Without tunnel scale options, each instance accepts the required loopbacks correctly. Eg: `["10.30.0.0/26"]`
-- `scale_group_id` (String) The ID of a scale group to place this connector on. A scale group is a set of dedicated CXP nodes used to isolate a connector or distribute many connectors for performance. Typically available only on high-capacity CXPs (10Gb and above). Can only be set at create time and cannot be changed after provisioning.
+- `scale_group_id` (String) The ID of the scale group associated with the connector. Can only be set at create time and cannot be changed after provisioning.
 
 ### Read-Only
 

--- a/docs/resources/connector_aws_tgw.md
+++ b/docs/resources/connector_aws_tgw.md
@@ -39,7 +39,7 @@ resource "alkira_connector_aws_tgw" "example" {
 - `description` (String) The description of the connector.
 - `enabled` (Boolean) Is the connector enabled. Default is `true`.
 - `group` (String) The group of the connector.
-- `scale_group_id` (String) The ID of the scale group associated with the connector.
+- `scale_group_id` (String) The ID of a scale group to place this connector on. A scale group is a set of dedicated CXP nodes used to isolate a connector or distribute many connectors for performance. Typically available only on high-capacity CXPs (10Gb and above). Can only be set at create time and cannot be changed after provisioning.
 - `static_route_prefix_list_ids` (Set of Number) Policy Prefixes to be associated with connector's VPN route.
 
 ### Read-Only

--- a/docs/resources/connector_aws_tgw.md
+++ b/docs/resources/connector_aws_tgw.md
@@ -39,7 +39,7 @@ resource "alkira_connector_aws_tgw" "example" {
 - `description` (String) The description of the connector.
 - `enabled` (Boolean) Is the connector enabled. Default is `true`.
 - `group` (String) The group of the connector.
-- `scale_group_id` (String) The ID of a scale group to place this connector on. A scale group is a set of dedicated CXP nodes used to isolate a connector or distribute many connectors for performance. Typically available only on high-capacity CXPs (10Gb and above). Can only be set at create time and cannot be changed after provisioning.
+- `scale_group_id` (String) The ID of the scale group associated with the connector. Can only be set at create time and cannot be changed after provisioning.
 - `static_route_prefix_list_ids` (Set of Number) Policy Prefixes to be associated with connector's VPN route.
 
 ### Read-Only

--- a/docs/resources/connector_aws_vpc.md
+++ b/docs/resources/connector_aws_vpc.md
@@ -219,7 +219,7 @@ resource "alkira_connector_aws_vpc" "connector" {
 - `failover_cxps` (Set of String) A list of additional CXPs where the connector should be provisioned for failover.
 - `group` (String) The group of the connector.
 - `overlay_subnets` (List of String) Overlay subnet.
-- `scale_group_id` (String) The ID of a scale group to place this connector on. A scale group is a set of dedicated CXP nodes used to isolate a connector or distribute many connectors for performance. Typically available only on high-capacity CXPs (10Gb and above). Can only be set at create time and cannot be changed after provisioning.
+- `scale_group_id` (String) The ID of the scale group associated with the connector. Can only be set at create time and cannot be changed after provisioning.
 - `tgw_attachment` (Block List) TGW attachment. (see [below for nested schema](#nestedblock--tgw_attachment))
 - `tgw_connect_enabled` (Boolean) When it's set to `true`, Alkira will use TGW Connect attachments to build connection to AWS Transit Gateway. Connect Attachments suppport GRE tunnel protocol for high performance and BGP for dynamic routing. This applies to all TGW attachments. This field can be set to `true` only if the VPC is in the same AWS region as the Alkira CXP it is being deployed onto.
 - `vpc_cidr` (List of String) The list of CIDR attached to the target VPC for routing purpose. It could be only specified if `vpc_subnet` is not specified.

--- a/docs/resources/connector_aws_vpc.md
+++ b/docs/resources/connector_aws_vpc.md
@@ -219,7 +219,7 @@ resource "alkira_connector_aws_vpc" "connector" {
 - `failover_cxps` (Set of String) A list of additional CXPs where the connector should be provisioned for failover.
 - `group` (String) The group of the connector.
 - `overlay_subnets` (List of String) Overlay subnet.
-- `scale_group_id` (String) The ID of the scale group associated with the connector.
+- `scale_group_id` (String) The ID of a scale group to place this connector on. A scale group is a set of dedicated CXP nodes used to isolate a connector or distribute many connectors for performance. Typically available only on high-capacity CXPs (10Gb and above). Can only be set at create time and cannot be changed after provisioning.
 - `tgw_attachment` (Block List) TGW attachment. (see [below for nested schema](#nestedblock--tgw_attachment))
 - `tgw_connect_enabled` (Boolean) When it's set to `true`, Alkira will use TGW Connect attachments to build connection to AWS Transit Gateway. Connect Attachments suppport GRE tunnel protocol for high performance and BGP for dynamic routing. This applies to all TGW attachments. This field can be set to `true` only if the VPC is in the same AWS region as the Alkira CXP it is being deployed onto.
 - `vpc_cidr` (List of String) The list of CIDR attached to the target VPC for routing purpose. It could be only specified if `vpc_subnet` is not specified.

--- a/docs/resources/connector_azure_vhub.md
+++ b/docs/resources/connector_azure_vhub.md
@@ -76,7 +76,7 @@ resource "alkira_connector_azure_vhub" "test2" {
 - `description` (String) The description of the connector.
 - `enabled` (Boolean) Is the connector enabled. Default is `true`.
 - `group` (String) The group of the connector.
-- `scale_group_id` (String) The ID of the scale group associated with the connector.
+- `scale_group_id` (String) The ID of a scale group to place this connector on. A scale group is a set of dedicated CXP nodes used to isolate a connector or distribute many connectors for performance. Typically available only on high-capacity CXPs (10Gb and above). Can only be set at create time and cannot be changed after provisioning.
 
 ### Read-Only
 

--- a/docs/resources/connector_azure_vhub.md
+++ b/docs/resources/connector_azure_vhub.md
@@ -76,7 +76,7 @@ resource "alkira_connector_azure_vhub" "test2" {
 - `description` (String) The description of the connector.
 - `enabled` (Boolean) Is the connector enabled. Default is `true`.
 - `group` (String) The group of the connector.
-- `scale_group_id` (String) The ID of a scale group to place this connector on. A scale group is a set of dedicated CXP nodes used to isolate a connector or distribute many connectors for performance. Typically available only on high-capacity CXPs (10Gb and above). Can only be set at create time and cannot be changed after provisioning.
+- `scale_group_id` (String) The ID of the scale group associated with the connector. Can only be set at create time and cannot be changed after provisioning.
 
 ### Read-Only
 

--- a/docs/resources/connector_azure_vnet.md
+++ b/docs/resources/connector_azure_vnet.md
@@ -141,7 +141,7 @@ resource "alkira_connector_azure_vnet" "peering" {
 - `peering_gateway_cxp_id` (Number) The ID of the CXP peering gateway associated with the connector.
 - `routing_options` (String) Routing options for the entire VNET, either `ADVERTISE_DEFAULT_ROUTE` or `ADVERTISE_CUSTOM_PREFIX`. Default value is `AVERTISE_DEFAULT_ROUTE`.
 - `routing_prefix_list_ids` (List of Number) Prefix List IDs.
-- `scale_group_id` (String) The ID of a scale group to place this connector on. A scale group is a set of dedicated CXP nodes used to isolate a connector or distribute many connectors for performance. Typically available only on high-capacity CXPs (10Gb and above). Can only be set at create time and cannot be changed after provisioning.
+- `scale_group_id` (String) The ID of the scale group associated with the connector. Can only be set at create time and cannot be changed after provisioning.
 - `service_tags` (List of String) list of service tags from Azure. Providing a service tag here would result in service tag route configuration on VNET route table, so that the traffic toward the service would directly steer towards those services, and would not go via Alkira network.
 - `udr_list_ids` (Set of Number) User defined routes list (`list_udr`).
 - `vnet_cidr` (Block Set) Configure routing options on specified VNET CIDR. (see [below for nested schema](#nestedblock--vnet_cidr))

--- a/docs/resources/connector_azure_vnet.md
+++ b/docs/resources/connector_azure_vnet.md
@@ -141,7 +141,7 @@ resource "alkira_connector_azure_vnet" "peering" {
 - `peering_gateway_cxp_id` (Number) The ID of the CXP peering gateway associated with the connector.
 - `routing_options` (String) Routing options for the entire VNET, either `ADVERTISE_DEFAULT_ROUTE` or `ADVERTISE_CUSTOM_PREFIX`. Default value is `AVERTISE_DEFAULT_ROUTE`.
 - `routing_prefix_list_ids` (List of Number) Prefix List IDs.
-- `scale_group_id` (String) The ID of the scale group associated with the connector.
+- `scale_group_id` (String) The ID of a scale group to place this connector on. A scale group is a set of dedicated CXP nodes used to isolate a connector or distribute many connectors for performance. Typically available only on high-capacity CXPs (10Gb and above). Can only be set at create time and cannot be changed after provisioning.
 - `service_tags` (List of String) list of service tags from Azure. Providing a service tag here would result in service tag route configuration on VNET route table, so that the traffic toward the service would directly steer towards those services, and would not go via Alkira network.
 - `udr_list_ids` (Set of Number) User defined routes list (`list_udr`).
 - `vnet_cidr` (Block Set) Configure routing options on specified VNET CIDR. (see [below for nested schema](#nestedblock--vnet_cidr))

--- a/docs/resources/connector_azure_vnet_third_party.md
+++ b/docs/resources/connector_azure_vnet_third_party.md
@@ -54,7 +54,7 @@ resource "alkira_connector_azure_vnet_third_party" "example" {
 - `description` (String) The description of the connector.
 - `enabled` (Boolean) Is the connector enabled. Default is `true`.
 - `group` (String) The group of the connector.
-- `scale_group_id` (String) The ID of a scale group to place this connector on. A scale group is a set of dedicated CXP nodes used to isolate a connector or distribute many connectors for performance. Typically available only on high-capacity CXPs (10Gb and above). Can only be set at create time and cannot be changed after provisioning.
+- `scale_group_id` (String) The ID of the scale group associated with the connector. Can only be set at create time and cannot be changed after provisioning.
 
 ### Read-Only
 

--- a/docs/resources/connector_gcp_interconnect.md
+++ b/docs/resources/connector_gcp_interconnect.md
@@ -135,7 +135,7 @@ resource "alkira_connector_gcp_interconnect" "example_gcp_interconnect_2" {
 - `description` (String) The description of the connector.
 - `enabled` (Boolean) Whether the connector is enabled. Default value is `true`.
 - `group` (String) The group of the connector.
-- `scale_group_id` (String) The ID of the scale group associated with the connector.
+- `scale_group_id` (String) The ID of a scale group to place this connector on. A scale group is a set of dedicated CXP nodes used to isolate a connector or distribute many connectors for performance. Typically available only on high-capacity CXPs (10Gb and above). Can only be set at create time and cannot be changed after provisioning.
 
 ### Read-Only
 

--- a/docs/resources/connector_gcp_interconnect.md
+++ b/docs/resources/connector_gcp_interconnect.md
@@ -135,7 +135,7 @@ resource "alkira_connector_gcp_interconnect" "example_gcp_interconnect_2" {
 - `description` (String) The description of the connector.
 - `enabled` (Boolean) Whether the connector is enabled. Default value is `true`.
 - `group` (String) The group of the connector.
-- `scale_group_id` (String) The ID of a scale group to place this connector on. A scale group is a set of dedicated CXP nodes used to isolate a connector or distribute many connectors for performance. Typically available only on high-capacity CXPs (10Gb and above). Can only be set at create time and cannot be changed after provisioning.
+- `scale_group_id` (String) The ID of the scale group associated with the connector. Can only be set at create time and cannot be changed after provisioning.
 
 ### Read-Only
 

--- a/docs/resources/connector_gcp_vpc.md
+++ b/docs/resources/connector_gcp_vpc.md
@@ -111,7 +111,7 @@ resource "alkira_connector_gcp_vpc" "gcp_subnet" {
 - `gcp_project_id` (String) GCP Project ID.
 - `gcp_routing` (Block List) GCP Routing describes the routes that are to be imported to the VPC from the CXP. This essentially controls how traffic is routed between the CXP and the VPC. When routing option is not provided, the traffic exiting the VPC will be sent to the CXP (i.e a default route to CXP will be added to all route tables on that VPC) (see [below for nested schema](#nestedblock--gcp_routing))
 - `group` (String) The group of the connector.
-- `scale_group_id` (String) The ID of the scale group associated with the connector.
+- `scale_group_id` (String) The ID of a scale group to place this connector on. A scale group is a set of dedicated CXP nodes used to isolate a connector or distribute many connectors for performance. Typically available only on high-capacity CXPs (10Gb and above). Can only be set at create time and cannot be changed after provisioning.
 - `vpc_subnet` (Block Set) The list of subnets of the target GCP VPC for routing purpose. Given connector supports multiple prefixes per subnet, each prefix under a subnet will be a new entry. (see [below for nested schema](#nestedblock--vpc_subnet))
 
 ### Read-Only

--- a/docs/resources/connector_gcp_vpc.md
+++ b/docs/resources/connector_gcp_vpc.md
@@ -111,7 +111,7 @@ resource "alkira_connector_gcp_vpc" "gcp_subnet" {
 - `gcp_project_id` (String) GCP Project ID.
 - `gcp_routing` (Block List) GCP Routing describes the routes that are to be imported to the VPC from the CXP. This essentially controls how traffic is routed between the CXP and the VPC. When routing option is not provided, the traffic exiting the VPC will be sent to the CXP (i.e a default route to CXP will be added to all route tables on that VPC) (see [below for nested schema](#nestedblock--gcp_routing))
 - `group` (String) The group of the connector.
-- `scale_group_id` (String) The ID of a scale group to place this connector on. A scale group is a set of dedicated CXP nodes used to isolate a connector or distribute many connectors for performance. Typically available only on high-capacity CXPs (10Gb and above). Can only be set at create time and cannot be changed after provisioning.
+- `scale_group_id` (String) The ID of the scale group associated with the connector. Can only be set at create time and cannot be changed after provisioning.
 - `vpc_subnet` (Block Set) The list of subnets of the target GCP VPC for routing purpose. Given connector supports multiple prefixes per subnet, each prefix under a subnet will be a new entry. (see [below for nested schema](#nestedblock--vpc_subnet))
 
 ### Read-Only

--- a/docs/resources/connector_ipsec.md
+++ b/docs/resources/connector_ipsec.md
@@ -472,7 +472,7 @@ resource "alkira_connector_ipsec" "multi_site_advanced" {
 - `group` (String) The group of the connector. (see resource `alkira_group`)
 - `policy_options` (Block Set) Policy options, both `on_prem_prefix_list_ids` and `cxp_prefix_list_ids` must be provided if `vpn_mode` is `POLICY_BASED`. (see [below for nested schema](#nestedblock--policy_options))
 - `routing_options` (Block Set) Routing options, type is `STATIC`, `DYNAMIC`, or`BOTH` must be provided if `vpn_mode` is `ROUTE_BASED` (see [below for nested schema](#nestedblock--routing_options))
-- `scale_group_id` (String) The ID of a scale group to place this connector on. A scale group is a set of dedicated CXP nodes used to isolate a connector or distribute many connectors for performance. Typically available only on high-capacity CXPs (10Gb and above). Can only be set at create time and cannot be changed after provisioning.
+- `scale_group_id` (String) The ID of the scale group associated with the connector. Can only be set at create time and cannot be changed after provisioning.
 - `segment_options` (Block Set) Additional options for each segment associated with the connector. (see [below for nested schema](#nestedblock--segment_options))
 
 ### Read-Only

--- a/docs/resources/connector_ipsec.md
+++ b/docs/resources/connector_ipsec.md
@@ -472,7 +472,7 @@ resource "alkira_connector_ipsec" "multi_site_advanced" {
 - `group` (String) The group of the connector. (see resource `alkira_group`)
 - `policy_options` (Block Set) Policy options, both `on_prem_prefix_list_ids` and `cxp_prefix_list_ids` must be provided if `vpn_mode` is `POLICY_BASED`. (see [below for nested schema](#nestedblock--policy_options))
 - `routing_options` (Block Set) Routing options, type is `STATIC`, `DYNAMIC`, or`BOTH` must be provided if `vpn_mode` is `ROUTE_BASED` (see [below for nested schema](#nestedblock--routing_options))
-- `scale_group_id` (String) The ID of the scale group associated with the connector.
+- `scale_group_id` (String) The ID of a scale group to place this connector on. A scale group is a set of dedicated CXP nodes used to isolate a connector or distribute many connectors for performance. Typically available only on high-capacity CXPs (10Gb and above). Can only be set at create time and cannot be changed after provisioning.
 - `segment_options` (Block Set) Additional options for each segment associated with the connector. (see [below for nested schema](#nestedblock--segment_options))
 
 ### Read-Only

--- a/docs/resources/connector_prisma_sdwan.md
+++ b/docs/resources/connector_prisma_sdwan.md
@@ -61,7 +61,7 @@ resource "alkira_connector_prisma_sdwan" "test1" {
 - `description` (String) The description of the connector.
 - `enabled` (Boolean) Is the connector enabled. Default is `true`.
 - `group` (String) The group of the connector.
-- `scale_group_id` (String) The ID of a scale group to place this connector on. A scale group is a set of dedicated CXP nodes used to isolate a connector or distribute many connectors for performance. Typically available only on high-capacity CXPs (10Gb and above). Can only be set at create time and cannot be changed after provisioning.
+- `scale_group_id` (String) The ID of the scale group associated with the connector. Can only be set at create time and cannot be changed after provisioning.
 - `tunnel_protocol` (String) The tunnel protocol. It could be either `IPSEC` or `GRE`. Default value is `IPSEC`.
 
 ### Read-Only

--- a/docs/resources/connector_prisma_sdwan.md
+++ b/docs/resources/connector_prisma_sdwan.md
@@ -61,7 +61,7 @@ resource "alkira_connector_prisma_sdwan" "test1" {
 - `description` (String) The description of the connector.
 - `enabled` (Boolean) Is the connector enabled. Default is `true`.
 - `group` (String) The group of the connector.
-- `scale_group_id` (String) The ID of the scale group associated with the connector.
+- `scale_group_id` (String) The ID of a scale group to place this connector on. A scale group is a set of dedicated CXP nodes used to isolate a connector or distribute many connectors for performance. Typically available only on high-capacity CXPs (10Gb and above). Can only be set at create time and cannot be changed after provisioning.
 - `tunnel_protocol` (String) The tunnel protocol. It could be either `IPSEC` or `GRE`. Default value is `IPSEC`.
 
 ### Read-Only


### PR DESCRIPTION
## Summary

Standardizes the `scale_group_id` attribute description across all connector resources. The description now reads:

> The ID of the scale group associated with the connector. Can only be set at create time and cannot be changed after provisioning.

This keeps the wording concise while making the key constraint explicit: updating `scale_group_id` on an already-provisioned connector is rejected by the backend and errors out on `terraform apply`.

## Changes

- Updated the `scale_group_id` schema `Description` in 11 connector resources (aruba_edge, aws_dx, aws_tgw, aws_vpc, azure_vhub, azure_vnet, azure_vnet_third_party, gcp_interconnect, gcp_vpc, ipsec, prisma_sdwan).
- Updated the corresponding `docs/resources/connector_*.md` attribute docs.

Doc-only change. `go build ./...` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)