### PR TITLE
AK-69747: add description field to alkira_internet_application

### DIFF
--- a/alkira/resource_alkira_internet_applications.go
+++ b/alkira/resource_alkira_internet_applications.go
@@ -121,6 +121,11 @@ func resourceAlkiraInternetApplication() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 			},
+			"description": {
+				Description: "The description of the internet application.",
+				Type:        schema.TypeString,
+				Optional:    true,
+			},
 			"fqdn_prefix": {
 				Description: "User provided FQDN prefix that will be " +
 					"published on AWS Route 53.",
@@ -359,6 +364,7 @@ func resourceInternetApplicationRead(ctx context.Context, d *schema.ResourceData
 	d.Set("byoip_id", app.ByoipId)
 	d.Set("connector_id", app.ConnectorId)
 	d.Set("connector_type", app.ConnectorType)
+	d.Set("description", app.Description)
 	d.Set("fqdn_prefix", app.FqdnPrefix)
 	d.Set("name", app.Name)
 	d.Set("internet_protocol", app.InternetProtocol)
@@ -532,6 +538,7 @@ func generateInternetApplicationRequest(d *schema.ResourceData, m interface{}) (
 		ByoipId:                       d.Get("byoip_id").(int),
 		ConnectorId:                   d.Get("connector_id").(int),
 		ConnectorType:                 d.Get("connector_type").(string),
+		Description:                   d.Get("description").(string),
 		FqdnPrefix:                    d.Get("fqdn_prefix").(string),
 		InboundConnectorId:            d.Get("inbound_connector_id").(string),
 		InboundConnectorType:          d.Get("inbound_connector_type").(string),

--- a/docs/resources/internet_application.md
+++ b/docs/resources/internet_application.md
@@ -79,6 +79,7 @@ resource "alkira_internet_application" "test_internal_dns" {
 - `bi_directional_az` (String) Bi-directional IFA AZ. The value could be either `AZ0` or `AZ1`
 - `billing_tag_ids` (Set of Number) Billing tags to be associated with the resource. (see resource `alkira_billing_tag`).
 - `byoip_id` (Number) BYOIP ID.
+- `description` (String) The description of the internet application.
 - `ilb_credential_id` (String) The credential ID of AWS account for `target` This field can only be used when `connector_type` is `AWS_VPC` and `target`'s `type` is `ILB_NAME`.
 - `inbound_connector_id` (String) Inbound connector ID.
 - `inbound_connector_type` (String) This field defines how the internet application to be opened up to the public. Value `DEFAULT` means that the native cloud internet connector is used. In this case, Alkira takes care of creating this inbound internet connector implicitly. When value `AKAMAI_PROLEXIC` is used it means that the inbound traffic is through `alkira_connector_akamai_prolexic`. You need to create and configure that connector and use it with the internet application.


### PR DESCRIPTION
## Summary
Adds an optional `description` field to the `alkira_internet_application` resource, bringing it to parity with the UI, which already supports a description on an Internet Facing Application (IFA). Requested by McKesson.

The backend and the `alkira-client-go` `InternetApplication` struct already carry `Description` (`json:"description,omitempty"`), so no client-go change or dependency bump is required — this only wires the existing field through the provider.

## Changes
- `alkira/resource_alkira_internet_applications.go`
  - Add optional `description` (String) to the schema
  - Set `description` from `app.Description` in the read path
  - Include `Description` in the create/update request struct
- `docs/resources/internet_application.md` — regenerated (single new row)

## Testing
- `go build ./...` — clean
- `go test ./alkira/...` — all unit tests pass
- `make lint` (diff vs `origin/dev`) — 0 issues
- `make doc` — diff limited to the new `description` row


## Jira
https://alkiranet.atlassian.net/browse/AK-69747