### PR TITLE
AK-65429: revert WriteOnly changes on alkira_credential_oci_vcn (rel65)

### DIFF
--- a/alkira/resource_alkira_credential_oci_vcn.go
+++ b/alkira/resource_alkira_credential_oci_vcn.go
@@ -3,12 +3,9 @@ package alkira
 import (
 	"context"
 	"fmt"
-	"os"
-	"strings"
 
 	"github.com/alkiranet/alkira-client-go/alkira"
 
-	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -38,29 +35,33 @@ func resourceAlkiraCredentialOciVcn() *schema.Resource {
 				Description: "OCID of the user.",
 				Type:        schema.TypeString,
 				Required:    true,
-				Sensitive:   true,
-				WriteOnly:   true,
+				DefaultFunc: schema.EnvDefaultFunc(
+					"AK_OCI_USER_OCID",
+					nil),
 			},
 			"fingerprint": {
 				Description: "Fingerprint of the API key of the user.",
 				Type:        schema.TypeString,
 				Required:    true,
-				Sensitive:   true,
-				WriteOnly:   true,
+				DefaultFunc: schema.EnvDefaultFunc(
+					"AK_OCI_FINGERPRINT",
+					nil),
 			},
 			"key": {
 				Description: "API key of the user.",
 				Type:        schema.TypeString,
 				Required:    true,
-				Sensitive:   true,
-				WriteOnly:   true,
+				DefaultFunc: schema.EnvDefaultFunc(
+					"AK_OCI_KEY",
+					nil),
 			},
 			"tenant_ocid": {
 				Description: "OCID of the tenant.",
 				Type:        schema.TypeString,
 				Required:    true,
-				Sensitive:   true,
-				WriteOnly:   true,
+				DefaultFunc: schema.EnvDefaultFunc(
+					"AK_OCI_TENANT_OCID",
+					nil),
 			},
 		},
 	}
@@ -69,11 +70,7 @@ func resourceAlkiraCredentialOciVcn() *schema.Resource {
 func resourceCredentialOciVcn(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*alkira.AlkiraClient)
 
-	c, err := generateCredentialOciVcnRequest(d)
-
-	if err != nil {
-		return diag.FromErr(err)
-	}
+	c := generateCredentialOciVcnRequest(d)
 
 	credentialId, err := client.CreateCredential(d.Get("name").(string), alkira.CredentialTypeOciVcn, c, 0)
 
@@ -86,36 +83,15 @@ func resourceCredentialOciVcn(ctx context.Context, d *schema.ResourceData, meta 
 }
 
 func resourceCredentialOciVcnRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client := meta.(*alkira.AlkiraClient)
-
-	credential, err := client.GetCredentialById(d.Id())
-	if err != nil {
-		if strings.Contains(err.Error(), "not found") {
-			d.SetId("")
-			return nil
-		}
-		return diag.FromErr(err)
-	}
-
-	d.Set("name", credential.Name)
-
-	// Sensitive fields (user_ocid, fingerprint, key, tenant_ocid)
-	// are NOT returned by the API for security reasons and are
-	// maintained in the user's HCL configuration via WriteOnly.
-
 	return nil
 }
 
 func resourceCredentialOciVcnUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*alkira.AlkiraClient)
 
-	c, err := generateCredentialOciVcnRequest(d)
+	c := generateCredentialOciVcnRequest(d)
 
-	if err != nil {
-		return diag.FromErr(err)
-	}
-
-	err = client.UpdateCredential(d.Id(), d.Get("name").(string), alkira.CredentialTypeOciVcn, c, 0)
+	err := client.UpdateCredential(d.Id(), d.Get("name").(string), alkira.CredentialTypeOciVcn, c, 0)
 
 	if err != nil {
 		return diag.FromErr(err)
@@ -143,59 +119,13 @@ func resourceCredentialOciVcnDelete(ctx context.Context, d *schema.ResourceData,
 	return nil
 }
 
-// getOciVcnCredentialValue gets a value from config or environment variable.
-// For WriteOnly fields, reads from raw config since values are not stored in state.
-func getOciVcnCredentialValue(d *schema.ResourceData, field string, envVar string, required bool) (string, error) {
-	// First try raw config (for WriteOnly fields)
-	attrPath := cty.Path{cty.GetAttrStep{Name: field}}
-	val, diags := d.GetRawConfigAt(attrPath)
-
-	if !diags.HasError() && !val.IsNull() && val.IsKnown() && val.Type() == cty.String {
-		strVal := val.AsString()
-		if strVal != "" {
-			return strVal, nil
-		}
-	}
-
-	// Fall back to environment variable
-	envValue := os.Getenv(envVar)
-	if envValue != "" {
-		return envValue, nil
-	}
-
-	if required {
-		return "", fmt.Errorf("required field '%s' is not set in configuration and environment variable '%s' is not set", field, envVar)
-	}
-	return "", nil
-}
-
-func generateCredentialOciVcnRequest(d *schema.ResourceData) (alkira.CredentialOciVcn, error) {
-	userOcid, err := getOciVcnCredentialValue(d, "user_ocid", "AK_OCI_USER_OCID", true)
-	if err != nil {
-		return alkira.CredentialOciVcn{}, err
-	}
-
-	fingerprint, err := getOciVcnCredentialValue(d, "fingerprint", "AK_OCI_FINGERPRINT", true)
-	if err != nil {
-		return alkira.CredentialOciVcn{}, err
-	}
-
-	key, err := getOciVcnCredentialValue(d, "key", "AK_OCI_KEY", true)
-	if err != nil {
-		return alkira.CredentialOciVcn{}, err
-	}
-
-	tenantOcid, err := getOciVcnCredentialValue(d, "tenant_ocid", "AK_OCI_TENANT_OCID", true)
-	if err != nil {
-		return alkira.CredentialOciVcn{}, err
-	}
-
+func generateCredentialOciVcnRequest(d *schema.ResourceData) alkira.CredentialOciVcn {
 	c := alkira.CredentialOciVcn{
-		UserId:      userOcid,
-		FingerPrint: fingerprint,
-		Key:         key,
-		TenantId:    tenantOcid,
+		UserId:      d.Get("user_ocid").(string),
+		FingerPrint: d.Get("fingerprint").(string),
+		Key:         d.Get("key").(string),
+		TenantId:    d.Get("tenant_ocid").(string),
 	}
 
-	return c, nil
+	return c
 }

--- a/docs/resources/credential_oci_vcn.md
+++ b/docs/resources/credential_oci_vcn.md
@@ -36,11 +36,11 @@ resource "alkira_credential_oci_vcn" "example" {
 
 ### Required
 
-- `fingerprint` (String, Sensitive) Fingerprint of the API key of the user.
-- `key` (String, Sensitive) API key of the user.
+- `fingerprint` (String) Fingerprint of the API key of the user.
+- `key` (String) API key of the user.
 - `name` (String) Name of the credential.
-- `tenant_ocid` (String, Sensitive) OCID of the tenant.
-- `user_ocid` (String, Sensitive) OCID of the user.
+- `tenant_ocid` (String) OCID of the tenant.
+- `user_ocid` (String) OCID of the user.
 
 ### Read-Only
 


### PR DESCRIPTION
Backport of the credential WriteOnly revert (dev #631), split one-per-PR.

Removes the WriteOnly handling added in AK-65429/#549 from `alkira_credential_oci_vcn`. The WriteOnly conversions imposed a Terraform CLI >= 1.11 floor and changed sensitive-field state handling. vendor/go.mod untouched.

`go build ./...` and `go test ./alkira/...` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)