### PR TITLE
[CLONE-65] AK-70199: add description field to alkira_internet_application (#709)

### DIFF
--- a/alkira/resource_alkira_internet_applications.go
+++ b/alkira/resource_alkira_internet_applications.go
@@ -68,6 +68,11 @@ func resourceAlkiraInternetApplication() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 			},
+			"description": {
+				Description: "The description of the internet application.",
+				Type:        schema.TypeString,
+				Optional:    true,
+			},
 			"fqdn_prefix": {
 				Description: "User provided FQDN prefix that will be " +
 					"published on AWS Route 53.",
@@ -300,6 +305,7 @@ func resourceInternetApplicationRead(ctx context.Context, d *schema.ResourceData
 	d.Set("byoip_id", app.ByoipId)
 	d.Set("connector_id", app.ConnectorId)
 	d.Set("connector_type", app.ConnectorType)
+	d.Set("description", app.Description)
 	d.Set("fqdn_prefix", app.FqdnPrefix)
 	d.Set("name", app.Name)
 	d.Set("internet_protocol", app.InternetProtocol)
@@ -472,6 +478,7 @@ func generateInternetApplicationRequest(d *schema.ResourceData, m interface{}) (
 		ByoipId:                       d.Get("byoip_id").(int),
 		ConnectorId:                   d.Get("connector_id").(int),
 		ConnectorType:                 d.Get("connector_type").(string),
+		Description:                   d.Get("description").(string),
 		FqdnPrefix:                    d.Get("fqdn_prefix").(string),
 		InboundConnectorId:            d.Get("inbound_connector_id").(string),
 		InboundConnectorType:          d.Get("inbound_connector_type").(string),

--- a/docs/resources/internet_application.md
+++ b/docs/resources/internet_application.md
@@ -64,6 +64,7 @@ resource "alkira_internet_application" "test" {
 - `bi_directional_az` (String) Bi-directional IFA AZ. The value could be either `AZ0` or `AZ1`
 - `billing_tag_ids` (Set of Number) Billing tags to be associated with the resource. (see resource `alkira_billing_tag`).
 - `byoip_id` (Number) BYOIP ID.
+- `description` (String) The description of the internet application.
 - `ilb_credential_id` (String) The credential ID of AWS account for `target` This field can only be used when `connector_type` is `AWS_VPC` and `target`'s `type` is `ILB_NAME`.
 - `inbound_connector_id` (String) Inbound connector ID.
 - `inbound_connector_type` (String) This field defines how the internet application to be opened up to the public. Value `DEFAULT` means that the native cloud internet connector is used. In this case, Alkira takes care of creating this inbound internet connector implicitly. When value `AKAMAI_PROLEXIC` is used it means that the inbound traffic is through `alkira_connector_akamai_prolexic`. You need to create and configure that connector and use it with the internet application.


### PR DESCRIPTION
Backport of #709 (original AK-69747) onto `release/2026-05-01-65`. Adds the `description` field to `alkira_internet_application`. Cherry-picked from dev `7d8c1f69`.

No conflicts with other rel65 backport/revert PRs. `go build` + `go test ./alkira/...` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)