### PR TITLE
AK-69977 enable serialization_enabled by default in the provider

### DIFF
--- a/alkira/provider.go
+++ b/alkira/provider.go
@@ -1,8 +1,10 @@
 package alkira
 
 import (
+	"fmt"
 	"log"
 	"os"
+	"strconv"
 
 	"github.com/alkiranet/alkira-client-go/alkira"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -57,11 +59,10 @@ func Provider() *schema.Provider {
 				DefaultFunc: envDefaultFunc("ALKIRA_ASYNC_VAL"),
 			},
 			"serialization_enabled": {
-				Description: "Enable API serialization.",
+				Description: "Enable API serialization. Enabled by default.",
 				Type:        schema.TypeBool,
 				Optional:    true,
-				Default:     false,
-				DefaultFunc: envDefaultFunc("ALKIRA_API_SERIALIZATION_ENABLED"),
+				DefaultFunc: boolEnvDefaultFunc("ALKIRA_API_SERIALIZATION_ENABLED", true),
 			},
 			"serialization_timeout": {
 				Description: "API serialization timeout in seconds.",
@@ -203,6 +204,26 @@ func envDefaultFunc(k string) schema.SchemaDefaultFunc {
 		}
 
 		return nil, nil
+	}
+}
+
+// boolEnvDefaultFunc resolves a boolean schema default from an environment
+// variable, falling back to dv when the variable is unset. When set, the value
+// is parsed with strconv.ParseBool so the variable can both enable ("true",
+// "1") and disable ("false", "0") the attribute.
+func boolEnvDefaultFunc(k string, dv bool) schema.SchemaDefaultFunc {
+	return func() (interface{}, error) {
+		v := os.Getenv(k)
+		if v == "" {
+			return dv, nil
+		}
+
+		parsed, err := strconv.ParseBool(v)
+		if err != nil {
+			return nil, fmt.Errorf("invalid boolean value %q for %s: %w", v, k, err)
+		}
+
+		return parsed, nil
 	}
 }
 

--- a/alkira/provider_test.go
+++ b/alkira/provider_test.go
@@ -1,6 +1,7 @@
 package alkira
 
 import (
+	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -33,6 +34,71 @@ func TestProvider(t *testing.T) {
 
 func TestProvider_impl(t *testing.T) {
 	var _ = Provider()
+}
+
+func TestProviderSerializationEnabledDefault(t *testing.T) {
+	const key = "ALKIRA_API_SERIALIZATION_ENABLED"
+	t.Setenv(key, "")
+	os.Unsetenv(key)
+
+	s := Provider().Schema["serialization_enabled"]
+	if s == nil {
+		t.Fatal("serialization_enabled schema not found")
+	}
+
+	def, err := s.DefaultValue()
+	if err != nil {
+		t.Fatalf("error loading default: %s", err)
+	}
+
+	if def != true {
+		t.Fatalf("expected serialization_enabled default to be true, got %v", def)
+	}
+}
+
+func TestBoolEnvDefaultFunc(t *testing.T) {
+	const key = "ALKIRA_API_SERIALIZATION_ENABLED"
+	f := boolEnvDefaultFunc(key, true)
+
+	cases := []struct {
+		name    string
+		set     bool
+		value   string
+		want    interface{}
+		wantErr bool
+	}{
+		{name: "unset falls back to default", set: false, want: true},
+		{name: "explicit true", set: true, value: "true", want: true},
+		{name: "explicit false disables", set: true, value: "false", want: false},
+		{name: "numeric one enables", set: true, value: "1", want: true},
+		{name: "numeric zero disables", set: true, value: "0", want: false},
+		{name: "invalid value errors", set: true, value: "yes-please", wantErr: true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.set {
+				t.Setenv(key, tc.value)
+			} else {
+				t.Setenv(key, "")
+				os.Unsetenv(key)
+			}
+
+			got, err := f()
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got value %v", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %s", err)
+			}
+			if got != tc.want {
+				t.Fatalf("expected %v, got %v", tc.want, got)
+			}
+		})
+	}
 }
 
 // UNUSED: Commented out to suppress linter warnings

--- a/docs/index.md
+++ b/docs/index.md
@@ -115,7 +115,7 @@ once `provision_state` is `SUCCESS`.
 - `api_key` (String) Your Alkira API key. This is the recommended authentication method. API keys can be managed from Portal -> Settings -> User Management.
 - `password` (String, Deprecated) Your Tenant Password. If this is not provided then `api_key` must have a value.
 - `provision` (Boolean) With provision or not.
-- `serialization_enabled` (Boolean) Enable API serialization.
+- `serialization_enabled` (Boolean) Enable API serialization. Enabled by default.
 - `serialization_timeout` (Number) API serialization timeout in seconds.
 - `username` (String, Deprecated) Your username. If this is not provided then `api_key` must have a value.
 - `validation` (Boolean) Asynchronous validations.


### PR DESCRIPTION
## Summary

[REL 66] clone of the rel65 change (PR #721 / commit `f1445eff`). Makes `serialization_enabled` default to `true` on the rel66 release line so API serialization is on without opt-in.

- Defaulted `serialization_enabled` to `true` via a new `boolEnvDefaultFunc`.
- `ALKIRA_API_SERIALIZATION_ENABLED` is parsed with `strconv.ParseBool`, so it can force serialization both on (`true`/`1`) and off (`false`/`0`). Explicit provider config still takes precedence.
- Updated the attribute and `docs/index.md` descriptions to document the default.

## Tests

- `TestProviderSerializationEnabledDefault` — schema default resolves to `true` when the env var is unset.
- `TestBoolEnvDefaultFunc` — 6 subcases: unset→default, `true`, `false`, `1`, `0`, invalid→error.
- `go build ./...` clean; both tests pass.

Jira: https://alkiranet.atlassian.net/browse/AK-69977

🤖 Generated with [Claude Code](https://claude.com/claude-code)