### PR TITLE
AK-70045: reject additional_tunnels_per_node that conflicts with tunnel options

### DIFF
--- a/alkira/resource_alkira_network_entity_scale_options.go
+++ b/alkira/resource_alkira_network_entity_scale_options.go
@@ -29,6 +29,10 @@ func resourceAlkiraNetworkEntityScaleOptions() *schema.Resource {
 				d.SetNew("state", "SUCCESS")
 			}
 
+			if err := validateAdditionalTunnelsPerNodeMatchesTunnelOptions(d.Get("segment_scale_options").([]interface{})); err != nil {
+				return err
+			}
+
 			return nil
 		},
 		Importer: &schema.ResourceImporter{
@@ -138,6 +142,36 @@ func resourceAlkiraNetworkEntityScaleOptions() *schema.Resource {
 			},
 		},
 	}
+}
+
+// validateAdditionalTunnelsPerNodeMatchesTunnelOptions enforces that, when
+// additional_tunnel_options_per_node (labels) are set, additional_tunnels_per_node
+// equals the label count. The API derives additional_tunnels_per_node from the
+// number of labels, so a differing value - including the zero value produced when
+// the field is omitted - would diverge from the API-stored value and drift on
+// every plan (AK-70045). Failing here surfaces a clear plan-time error instead.
+func validateAdditionalTunnelsPerNodeMatchesTunnelOptions(segmentScaleOptions []interface{}) error {
+	for i, raw := range segmentScaleOptions {
+		sso, ok := raw.(map[string]interface{})
+		if !ok {
+			continue
+		}
+
+		labels, _ := sso["additional_tunnel_options_per_node"].([]interface{})
+		if len(labels) == 0 {
+			continue
+		}
+
+		tunnelsPerNode, _ := sso["additional_tunnels_per_node"].(int)
+		if tunnelsPerNode != len(labels) {
+			return fmt.Errorf(
+				"segment_scale_options[%d]: additional_tunnels_per_node (%d) must equal "+
+					"the number of additional_tunnel_options_per_node (%d)",
+				i, tunnelsPerNode, len(labels))
+		}
+	}
+
+	return nil
 }
 
 // convertEntityIdToInt converts entity_id string to int

--- a/alkira/resource_alkira_network_entity_scale_options.go
+++ b/alkira/resource_alkira_network_entity_scale_options.go
@@ -29,7 +29,7 @@ func resourceAlkiraNetworkEntityScaleOptions() *schema.Resource {
 				d.SetNew("state", "SUCCESS")
 			}
 
-			if err := validateAdditionalTunnelsPerNodeMatchesTunnelOptions(d.Get("segment_scale_options").([]interface{})); err != nil {
+			if err := validateAdditionalTunnelsPerNodeMatchesTunnelOptions(d.Get("segment_scale_options").([]any)); err != nil {
 				return err
 			}
 
@@ -79,7 +79,7 @@ func resourceAlkiraNetworkEntityScaleOptions() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"additional_tunnels_per_node": {
-							Description: "Number of additional Tunnels to be added per node. By default there is one tunnel per node. There are 2 nodes per connector or service on an average. Maximum tunnels are based on the limits allocated to a tenant. Either additionalTunnelsPerNode or additionalNodes either must be defined in a scale option.",
+							Description: "Number of additional Tunnels to be added per node. By default there is one tunnel per node. There are 2 nodes per connector or service on an average. Maximum tunnels are based on the limits allocated to a tenant. Either additionalTunnelsPerNode or additionalNodes either must be defined in a scale option. When `additional_tunnel_options_per_node` (labels) are configured, this must equal the number of labels — the API derives it from the label count.",
 							Type:        schema.TypeInt,
 							Optional:    true,
 						},
@@ -149,15 +149,15 @@ func resourceAlkiraNetworkEntityScaleOptions() *schema.Resource {
 // equals the label count. The API derives additional_tunnels_per_node from the
 // number of labels, so a differing value - including the zero value produced when
 // the field is omitted - would diverge from the API-stored value and drift on
-// every plan (AK-70045). Failing here surfaces a clear plan-time error instead.
-func validateAdditionalTunnelsPerNodeMatchesTunnelOptions(segmentScaleOptions []interface{}) error {
+// every plan. Failing here surfaces a clear plan-time error instead.
+func validateAdditionalTunnelsPerNodeMatchesTunnelOptions(segmentScaleOptions []any) error {
 	for i, raw := range segmentScaleOptions {
-		sso, ok := raw.(map[string]interface{})
+		sso, ok := raw.(map[string]any)
 		if !ok {
 			continue
 		}
 
-		labels, _ := sso["additional_tunnel_options_per_node"].([]interface{})
+		labels, _ := sso["additional_tunnel_options_per_node"].([]any)
 		if len(labels) == 0 {
 			continue
 		}

--- a/alkira/resource_alkira_network_entity_scale_options_test.go
+++ b/alkira/resource_alkira_network_entity_scale_options_test.go
@@ -157,3 +157,69 @@ func TestWarnOnFailedScaleOptionsUpdate(t *testing.T) {
 		})
 	}
 }
+
+// segmentScaleOption builds a segment_scale_options block map as the SDK would
+// hand it to CustomizeDiff: additional_tunnels_per_node as int (0 when omitted)
+// and additional_tunnel_options_per_node as a []interface{} of labelCount labels.
+func segmentScaleOption(tunnelsPerNode, labelCount int) map[string]interface{} {
+	labels := make([]interface{}, labelCount)
+	for i := 0; i < labelCount; i++ {
+		labels[i] = map[string]interface{}{"id": i + 1, "label": "label", "enabled": true}
+	}
+	return map[string]interface{}{
+		"segment_id":                         1,
+		"additional_tunnels_per_node":        tunnelsPerNode,
+		"additional_tunnel_options_per_node": labels,
+	}
+}
+
+func TestValidateAdditionalTunnelsPerNodeMatchesTunnelOptions(t *testing.T) {
+	tests := []struct {
+		name      string
+		options   []interface{}
+		wantError bool
+	}{
+		{
+			name:      "matching count is valid",
+			options:   []interface{}{segmentScaleOption(2, 2)},
+			wantError: false,
+		},
+		{
+			name:      "mismatched count is rejected",
+			options:   []interface{}{segmentScaleOption(2, 1)},
+			wantError: true,
+		},
+		{
+			name:      "omitted tunnels per node with labels is rejected",
+			options:   []interface{}{segmentScaleOption(0, 1)},
+			wantError: true,
+		},
+		{
+			name:      "no labels leaves tunnels per node untouched",
+			options:   []interface{}{segmentScaleOption(3, 0)},
+			wantError: false,
+		},
+		{
+			name:      "empty options is valid",
+			options:   []interface{}{},
+			wantError: false,
+		},
+		{
+			name:      "one bad segment among many is rejected",
+			options:   []interface{}{segmentScaleOption(2, 2), segmentScaleOption(1, 3)},
+			wantError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateAdditionalTunnelsPerNodeMatchesTunnelOptions(tt.options)
+			if tt.wantError {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "additional_tunnels_per_node")
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/docs/resources/network_entity_scale_options.md
+++ b/docs/resources/network_entity_scale_options.md
@@ -98,7 +98,7 @@ Optional:
 
 - `additional_nodes` (Number) Number of additional nodes to be added. By default there are 2 nodes per connector or service on an average. Maximum nodes are based on the limits allocated to a tenant. Either additionalTunnelsPerNode or additionalNodes either must be defined in a scale option.
 - `additional_tunnel_options_per_node` (Block List) Additional tunnel options per node configuration. (see [below for nested schema](#nestedblock--segment_scale_options--additional_tunnel_options_per_node))
-- `additional_tunnels_per_node` (Number) Number of additional Tunnels to be added per node. By default there is one tunnel per node. There are 2 nodes per connector or service on an average. Maximum tunnels are based on the limits allocated to a tenant. Either additionalTunnelsPerNode or additionalNodes either must be defined in a scale option.
+- `additional_tunnels_per_node` (Number) Number of additional Tunnels to be added per node. By default there is one tunnel per node. There are 2 nodes per connector or service on an average. Maximum tunnels are based on the limits allocated to a tenant. Either additionalTunnelsPerNode or additionalNodes either must be defined in a scale option. When `additional_tunnel_options_per_node` (labels) are configured, this must equal the number of labels — the API derives it from the label count.
 - `zone_name` (String) optional field, if provided only tunnels associated with given zone would be scaled. Not applicable if scale options are defined for a connector.
 
 <a id="nestedblock--segment_scale_options--additional_tunnel_options_per_node"></a>


### PR DESCRIPTION
## Problem

`alkira_network_entity_scale_options` exposes `additional_tunnels_per_node` as an optional user value, but the API **derives** it from the number of `additional_tunnel_options_per_node` (labels) and always stores that count. When the configured value differs from the label count — including the zero value produced when the field is omitted — config and the API-stored value diverge and the resource drifts on **every** plan (AK-70045). Reproduced on a live Prisma SD-WAN connector.

## Why this approach

`additional_tunnels_per_node` must stay **customer input** (it is set directly when no labels are used), so `Computed` is out. Making the omit case transparently work would require `alkira-client-go` to serialize the field as `*int` + `omitempty` (it is currently a plain `int`, always sent) **plus** `Computed` on the schema — cross-repo surgery for marginal gain. A `CustomizeDiff` guard is self-contained, keeps the field as customer input, and mirrors the server contract.

## Fix

`CustomizeDiff`: when `additional_tunnel_options_per_node` is set, require `additional_tunnels_per_node` to equal the label count; otherwise fail the plan with:

```
segment_scale_options[0]: additional_tunnels_per_node (2) must equal the number of additional_tunnel_options_per_node (1)
```

Logic extracted into `validateAdditionalTunnelsPerNodeMatchesTunnelOptions` for direct unit testing.

## Behavior

| Config | Result |
|--------|--------|
| labels + `additional_tunnels_per_node` == count | valid |
| labels + `additional_tunnels_per_node` != count | plan error |
| labels + `additional_tunnels_per_node` omitted (0) | plan error |
| no labels + `additional_tunnels_per_node` = N | unchanged (honored) |

## Testing

- Unit test `TestValidateAdditionalTunnelsPerNodeMatchesTunnelOptions` (matching / mismatched / omitted / no-labels / empty / multi-segment). Verified it fails without the guard.
- Live verification against a Prisma SD-WAN connector: mismatch → clear plan error; matched value → `No changes`.

## Related / rollout

- Server-side counterpart: tenant-provisioning-service PR #5499 (stops silently overwriting `additionalTunnelsPerNode`; validates instead).
- **Rollout ordering:** the released provider sends `additionalTunnelsPerNode: 0` when the field is omitted; once TPS #5499 rejects mismatches, this provider fix should ship with/ahead of it so label users are guided at plan time rather than hitting a 400.
- No `alkira-client-go` change required.

Note on acceptance-test-prod (expected transient failure)
Prod has not yet deployed AK-69179, so it still enforces the OLD policy and rejects the special character:

constraint.invalidpassword: Password should be minimum of 8 characters long ...
No special characters allowed.
The old-prod and new-preprod policies are mutually exclusive, so no single fixture value can pass both while prod lags. Since AK-69179 is not feature-flagged, once prod picks up that build it will enforce the same new policy and Ak123456789! will pass prod too.

Action for reviewer/merger: the acceptance-test-prod red is a known transient failure caused by the prod deployment lag, not by this change. It will clear on its own once prod deploys AK-69179; the prod check can be overridden to merge.

Jira: AK-70555



🤖 Generated with [Claude Code](https://claude.com/claude-code)