### PR TITLE
AK-70555: fix Fortinet acceptance fixture password to meet preprod policy

### DIFF
--- a/acceptance/service_fortinet.tf
+++ b/acceptance/service_fortinet.tf
@@ -1,6 +1,6 @@
 resource "alkira_service_fortinet" "test1" {
   username                     = "admin"
-  password                     = "Ak12345678"
+  password                     = "Ak123456789!"
   cxp                          = var.cxp
   license_type                 = "BRING_YOUR_OWN"
   management_server_segment_id = alkira_segment.test1.id


### PR DESCRIPTION
## Problem

`acceptance/service_fortinet.tf` used `password = "Ak12345678"` (10 chars, no special character). The Fortinet FW password policy was tightened in `credentials-java` by **AK-69179** (commit `8525842`, 2026-06-03, *not* behind a feature flag):

```
OLD: ^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)[a-zA-Z\d]{8,}$
     → min 8 chars, upper/lower/digit, NO special chars allowed
NEW: ^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[\W_]).{12,128}$
     → 12-128 chars, upper/lower/digit, special char REQUIRED
```

**Preprod** already runs a build with AK-69179 and rejected the old fixture:
```
constraint.invalidpassword: password must be 12-128 characters with at least
1 uppercase, 1 lowercase, 1 digit, and 1 special character
```

## Fix

`password = "Ak123456789!"` — 12 chars, upper/lower/digit/special. This satisfies the **new** policy, which is the destination state for both environments.

## Note on `acceptance-test-prod` (expected transient failure)

Prod has **not yet deployed AK-69179**, so it still enforces the OLD policy and rejects the special character:
```
constraint.invalidpassword: Password should be minimum of 8 characters long ...
No special characters allowed.
```

The old-prod and new-preprod policies are mutually exclusive, so **no single fixture value can pass both while prod lags**. Since AK-69179 is not feature-flagged, once prod picks up that build it will enforce the same new policy and `Ak123456789!` will pass prod too.

**Action for reviewer/merger:** the `acceptance-test-prod` red is a known transient failure caused by the prod deployment lag, not by this change. It will clear on its own once prod deploys AK-69179; the prod check can be overridden to merge.

Jira: AK-70555

🤖 Generated with [Claude Code](https://claude.com/claude-code)
