### PR TITLE
[CLONE-66] AK-70583 - fix Fortinet acceptance fixture password to meet preprod policy

### DIFF
--- a/acceptance/service_fortinet.tf
+++ b/acceptance/service_fortinet.tf
@@ -1,6 +1,6 @@
 resource "alkira_service_fortinet" "test1" {
   username                     = "admin"
-  password                     = "Ak12345678"
+  password                     = "Ak123456789!"
   cxp                          = var.cxp
   license_type                 = "BRING_YOUR_OWN"
   management_server_segment_id = alkira_segment.test1.id


### PR DESCRIPTION
Cherry-pick of PR #734 for REL 66 release.

**Original Issue:** AK-70555
**Clone for REL 66:** AK-70583

## Summary
`acceptance/service_fortinet.tf` used `password = "Ak12345678"` (10 chars, no special character), which the tightened Fortinet FW password policy (backend change AK-69179, credentials-java, not feature-flagged) rejects with `constraint.invalidpassword`: passwords must be 12–128 chars with at least 1 uppercase, 1 lowercase, 1 digit, and 1 special character. This failed `acceptance-test-preprod` on `terraform apply` of `alkira_service_fortinet.test1`.

## Changes
- Update the fixture password to `Ak123456789!` (12 chars: upper/lower/digit/special) so the resource provisions under the new policy.

## Original PR
#734

## Cherry-picked Commit(s)
- f9d761aeb2ca0c2688f4463c837cf0ab59b145e3