### PR TITLE
AK-70532: document Bluecat instance set diff & sensitive redaction

### DIFF
--- a/docs/resources/service_bluecat.md
+++ b/docs/resources/service_bluecat.md
@@ -31,9 +31,30 @@ BDDS instances it must be configured for EDGE instances also and vice versa.
 ## Instances
 
 Bluecat services support flexible instance configurations.
-There can be BDDS instances only services, 
+There can be BDDS instances only services,
 EDGE instances only services or a
 hybrid scenario with both BDDS and EDGE instances.
+
+### Reading `instance` plan output
+
+The `instance` blocks are a set keyed on `hostname` + `type`. Terraform has no
+in-place edit for a set element, so changing a field on an existing instance
+(for example `version` or `model`) is rendered as a removal (`- instance`)
+followed by an addition (`+ instance`). This is how Terraform represents a
+changed set element — it does **not** mean the instance is destroyed and
+recreated. On apply the provider sends a single update and the backend
+reconciles the instances in place. Removing N instances plans exactly N
+removals (with no re-add) as long as the remaining instances still match what
+is deployed.
+
+Each `instance` also contains a sensitive field (`activation_key`), and
+Terraform redacts the entire element of a set when any nested value is
+sensitive. As a result the whole `instance` block shows as `# At least one
+attribute in this block is (or was) sensitive, so its contents will not be
+displayed`, hiding the non-sensitive fields (`name`, `hostname`, `version`,
+`model`) as well — and this applies to `EDGE` instances too even though they
+carry no secret. To tell which instance changed, compare your configuration
+against the deployed instance `hostname` / `version`.
 
 
 ## Example Usage

--- a/templates/resources/service_bluecat.md.tmpl
+++ b/templates/resources/service_bluecat.md.tmpl
@@ -31,9 +31,30 @@ BDDS instances it must be configured for EDGE instances also and vice versa.
 ## Instances
 
 Bluecat services support flexible instance configurations.
-There can be BDDS instances only services, 
+There can be BDDS instances only services,
 EDGE instances only services or a
 hybrid scenario with both BDDS and EDGE instances.
+
+### Reading `instance` plan output
+
+The `instance` blocks are a set keyed on `hostname` + `type`. Terraform has no
+in-place edit for a set element, so changing a field on an existing instance
+(for example `version` or `model`) is rendered as a removal (`- instance`)
+followed by an addition (`+ instance`). This is how Terraform represents a
+changed set element — it does **not** mean the instance is destroyed and
+recreated. On apply the provider sends a single update and the backend
+reconciles the instances in place. Removing N instances plans exactly N
+removals (with no re-add) as long as the remaining instances still match what
+is deployed.
+
+Each `instance` also contains a sensitive field (`activation_key`), and
+Terraform redacts the entire element of a set when any nested value is
+sensitive. As a result the whole `instance` block shows as `# At least one
+attribute in this block is (or was) sensitive, so its contents will not be
+displayed`, hiding the non-sensitive fields (`name`, `hostname`, `version`,
+`model`) as well — and this applies to `EDGE` instances too even though they
+carry no secret. To tell which instance changed, compare your configuration
+against the deployed instance `hostname` / `version`.
 
 
 ## Example Usage


### PR DESCRIPTION
## Summary

Docs-only. Documents two Terraform behaviors on `alkira_service_bluecat` that QA reported as a bug but are expected:

1. **Instance edits render as remove + add.** The `instance` block is a `TypeSet` keyed on `hostname` + `type`. Terraform has no in-place edit for set elements, so changing a field on an existing instance (e.g. `version`, `model`) shows as `- instance` + `+ instance`. This is *not* a destroy/recreate — on apply the provider sends a single update and the backend reconciles in place. Removing N instances plans exactly N removals when the remaining instances match what's deployed.

2. **Instance block is fully redacted in plan.** Each instance carries a sensitive field (`activation_key`), and Terraform redacts the *entire* element of a set when any nested value is sensitive — hiding `name`/`hostname`/`version`/`model` too, and applying to `EDGE` instances as well. This is a Terraform core limitation for sets.

The note lives in `templates/resources/service_bluecat.md.tmpl` (new `### Reading instance plan output` subsection under Instances); `docs/resources/service_bluecat.md` regenerated. The resource description is unchanged — kept short.

## Background

AK-70532 was filed as a regression (instance shows delete + re-add). Reproduced with the customer's config/state and confirmed with QA: the affected instance had a real `version` change (config `9.6.2` vs deployed `9.5.4`); verified on the backend (tenant-provisioning-service) that the version is stored verbatim with no normalization. With the config aligned to the deployed state, removing N instances plans exactly N removals and nothing churns.

Switching `instance` from a set to a list would give readable per-instance `~` diffs, but sets were adopted specifically to fix wrong-instance deletion (AK-65582), so we keep the set and document the behavior instead.

## Testing

- `go build ./...` clean.
- `docs/resources/service_bluecat.md` regenerated via `tfplugindocs` (worktree-safe, `--provider-name`); only the bluecat doc changed.
- No schema / behavior / state change — template + generated doc only.

Jira: https://alkiranet.atlassian.net/browse/AK-70532