### PR TITLE
AK-70005: add allow_list to alkira_connector_cisco_sdwan (cat8k-gated)

### DIFF
--- a/alkira/resource_alkira_connector_cisco_sdwan.go
+++ b/alkira/resource_alkira_connector_cisco_sdwan.go
@@ -28,6 +28,13 @@ func resourceAlkiraConnectorCiscoSdwan() *schema.Resource {
 				d.SetNew("provision_state", "SUCCESS")
 			}
 
+			// allow_list is only supported on Cisco Catalyst 8000V (cat8k)
+			// connectors. Fail fast at plan time for other types.
+			if d.Get("allow_list").(*schema.Set).Len() > 0 && d.Get("type").(string) != "CAT8000V" {
+				return fmt.Errorf("[ERROR] `allow_list` is only supported on Cisco "+
+					"Catalyst 8000V (CAT8000V) connectors; `type` is %q", d.Get("type").(string))
+			}
+
 			return nil
 		},
 		Importer: &schema.ResourceImporter{
@@ -201,6 +208,17 @@ func resourceAlkiraConnectorCiscoSdwan() *schema.Resource {
 				Type:        schema.TypeString,
 				Optional:    true,
 			},
+			"allow_list": {
+				Description: "Management-access allow-list of IPv4 CIDRs or IP " +
+					"addresses. Only supported on Cisco Catalyst 8000V " +
+					"(`CAT8000V`) connectors.",
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem: &schema.Schema{
+					Type:         schema.TypeString,
+					ValidateFunc: validateIPv4CidrOrIP,
+				},
+			},
 		},
 	}
 }
@@ -286,6 +304,7 @@ func resourceConnectorCiscoSdwanRead(ctx context.Context, d *schema.ResourceData
 	d.Set("type", connector.Type)
 	d.Set("tunnel_protocol", connector.TunnelProtocol)
 	d.Set("description", connector.Description)
+	d.Set("allow_list", connector.AllowList)
 
 	// Set vedge
 	setVedge(d, connector)
@@ -432,6 +451,7 @@ func generateConnectorCiscoSdwanRequest(d *schema.ResourceData, m interface{}) (
 		Version:              d.Get("version").(string),
 		TunnelProtocol:       d.Get("tunnel_protocol").(string),
 		Description:          d.Get("description").(string),
+		AllowList:            convertTypeSetToStringList(d.Get("allow_list").(*schema.Set)),
 	}
 
 	return connector, nil

--- a/alkira/resource_alkira_connector_cisco_sdwan_helper.go
+++ b/alkira/resource_alkira_connector_cisco_sdwan_helper.go
@@ -1,9 +1,43 @@
 package alkira
 
 import (
+	"fmt"
+	"net"
+	"strings"
+
 	"github.com/alkiranet/alkira-client-go/alkira"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
+
+func validateIPv4CidrOrIP(i interface{}, k string) ([]string, []error) {
+	v, ok := i.(string)
+	if !ok {
+		return nil, []error{fmt.Errorf("expected type of %q to be string", k)}
+	}
+
+	// A colon means an IPv6 literal.
+	if strings.Contains(v, ":") {
+		return nil, []error{fmt.Errorf("%q must be an IPv4 address or IPv4 CIDR, got %q (IPv6 is not supported)", k, v)}
+	}
+
+	if strings.Contains(v, "/") {
+		ip, ipnet, err := net.ParseCIDR(v)
+		if err != nil || ip.To4() == nil {
+			return nil, []error{fmt.Errorf("%q must be a valid IPv4 CIDR, got %q", k, v)}
+		}
+		// Reject host bits rather than silently masking them.
+		if !ip.Equal(ipnet.IP) {
+			return nil, []error{fmt.Errorf("%q must be a CIDR network address with no host bits set, got %q (did you mean %q?)", k, v, ipnet.String())}
+		}
+		return nil, nil
+	}
+
+	if ip := net.ParseIP(v); ip == nil || ip.To4() == nil {
+		return nil, []error{fmt.Errorf("%q must be a valid IPv4 address or IPv4 CIDR, got %q", k, v)}
+	}
+
+	return nil, nil
+}
 
 // setVedge set vedge block values
 func setVedge(d *schema.ResourceData, connector *alkira.ConnectorCiscoSdwan) {

--- a/alkira/resource_alkira_connector_cisco_sdwan_test.go
+++ b/alkira/resource_alkira_connector_cisco_sdwan_test.go
@@ -1,0 +1,103 @@
+package alkira
+
+import (
+	"context"
+	"testing"
+
+	"github.com/alkiranet/alkira-client-go/alkira"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCiscoSdwanAllowListSchema(t *testing.T) {
+	resourceSchema := resourceAlkiraConnectorCiscoSdwan().Schema
+
+	t.Run("field exists and is Optional TypeSet of String", func(t *testing.T) {
+		field, ok := resourceSchema["allow_list"]
+		require.True(t, ok, "allow_list must be present in schema")
+		assert.Equal(t, schema.TypeSet, field.Type)
+		assert.True(t, field.Optional)
+		assert.False(t, field.Required)
+
+		elem, ok := field.Elem.(*schema.Schema)
+		require.True(t, ok, "allow_list Elem must be a *schema.Schema")
+		assert.Equal(t, schema.TypeString, elem.Type)
+		assert.NotNil(t, elem.ValidateFunc, "allow_list elements must be validated")
+	})
+}
+
+func TestCiscoSdwanAllowListValidator(t *testing.T) {
+	validate := resourceAlkiraConnectorCiscoSdwan().Schema["allow_list"].Elem.(*schema.Schema).ValidateFunc
+
+	valid := []string{"10.0.0.0/24", "192.168.1.0/24", "10.0.0.5", "10.0.0.5/32"}
+	for _, v := range valid {
+		_, errs := validate(v, "allow_list")
+		assert.Emptyf(t, errs, "expected %q to be accepted (IPv4 CIDR or IPv4 IP)", v)
+	}
+
+	// Rejected at plan time: garbage, out-of-range masks, IPv6, and
+	// host-bits-set CIDRs (not silently masked).
+	invalid := []string{"not-an-ip", "10.0.0.0/33", "999.0.0.1", "2001:db8::/32", "::1", "::ffff:1.2.3.4", "10.0.0.5/24"}
+	for _, v := range invalid {
+		_, errs := validate(v, "allow_list")
+		assert.NotEmptyf(t, errs, "expected %q to be rejected", v)
+	}
+}
+
+// TestCiscoSdwanAllowListExpand documents the request-expansion contract:
+// a TypeSet is converted with convertTypeSetToStringList (not the List helper),
+// which de-duplicates entries.
+func TestCiscoSdwanAllowListExpand(t *testing.T) {
+	set := schema.NewSet(schema.HashString, []interface{}{
+		"10.0.0.0/24", "10.0.0.5", "10.0.0.0/24", // duplicate collapses
+	})
+
+	got := convertTypeSetToStringList(set)
+
+	assert.ElementsMatch(t, []string{"10.0.0.0/24", "10.0.0.5"}, got)
+}
+
+func TestCiscoSdwanAllowListCat8kGate(t *testing.T) {
+	client := &alkira.AlkiraClient{}
+
+	baseConfig := func(connType string, allowList []interface{}) map[string]interface{} {
+		return map[string]interface{}{
+			"name":       "test",
+			"cxp":        "US-WEST",
+			"size":       "SMALL",
+			"version":    "20.9.1",
+			"type":       connType,
+			"allow_list": allowList,
+		}
+	}
+
+	tests := []struct {
+		name      string
+		connType  string
+		allowList []interface{}
+		wantError bool
+	}{
+		{"cat8k with allow_list is allowed", "CAT8000V", []interface{}{"10.0.0.0/24"}, false},
+		{"non-cat8k with allow_list is rejected", "CSR", []interface{}{"10.0.0.0/24"}, true},
+		{"non-cat8k without allow_list is allowed", "CSR", []interface{}{}, false},
+		{"cat8k without allow_list is allowed", "CAT8000V", []interface{}{}, false},
+	}
+
+	resource := resourceAlkiraConnectorCiscoSdwan()
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := terraform.NewResourceConfigRaw(baseConfig(tt.connType, tt.allowList))
+			_, err := resource.Diff(context.Background(), nil, cfg, client)
+
+			if tt.wantError {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "CAT8000V")
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/docs/resources/connector_cisco_sdwan.md
+++ b/docs/resources/connector_cisco_sdwan.md
@@ -48,6 +48,7 @@ resource "alkira_connector_cisco_sdwan" "test" {
 
 ### Optional
 
+- `allow_list` (Set of String) Management-access allow-list of IPv4 CIDRs or IP addresses. Only supported on Cisco Catalyst 8000V (`CAT8000V`) connectors.
 - `billing_tag_ids` (Set of Number) Billing tags to be associated with the resource. (see resource `alkira_billing_tag`).
 - `description` (String) The description of the connector.
 - `enabled` (Boolean) Is the connector enabled. Default is `true`.

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/alkiranet/terraform-provider-alkira
 go 1.26
 
 require (
-	github.com/alkiranet/alkira-client-go v1.59.1-0.20260707001840-0c295f61322e
+	github.com/alkiranet/alkira-client-go v1.59.1-0.20260716035132-4f1b1dc4ff8e
 	github.com/hashicorp/go-cty v1.5.0
 	github.com/hashicorp/go-retryablehttp v0.7.7
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.37.0

--- a/go.sum
+++ b/go.sum
@@ -5,8 +5,8 @@ github.com/PuerkitoBio/purell v1.1.1/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbt
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
 github.com/agext/levenshtein v1.2.2 h1:0S/Yg6LYmFJ5stwQeRp6EeOcCbj7xiqQSdNelsXvaqE=
 github.com/agext/levenshtein v1.2.2/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
-github.com/alkiranet/alkira-client-go v1.59.1-0.20260707001840-0c295f61322e h1:2SsVfGMa7HQW0q90MKqxvA3wjF0m2PR7IQNuMUmlCDE=
-github.com/alkiranet/alkira-client-go v1.59.1-0.20260707001840-0c295f61322e/go.mod h1:ms9LjOc4O1Zrr7/VQOva+xwv3sJuBUqS9JsI+MbE2go=
+github.com/alkiranet/alkira-client-go v1.59.1-0.20260716035132-4f1b1dc4ff8e h1:I6D/RglNdGqG8R1sS2y1d88/oAFVoI0U3BhVH6/mRYA=
+github.com/alkiranet/alkira-client-go v1.59.1-0.20260716035132-4f1b1dc4ff8e/go.mod h1:ms9LjOc4O1Zrr7/VQOva+xwv3sJuBUqS9JsI+MbE2go=
 github.com/apparentlymart/go-textseg/v12 v12.0.0/go.mod h1:S/4uRK2UtaQttw1GenVJEynmyUenKwP++x/+DdGV/Ec=
 github.com/apparentlymart/go-textseg/v15 v15.0.0 h1:uYvfpb3DyLSCGWnctWKGj857c6ew1u1fNQOlOtuGxQY=
 github.com/apparentlymart/go-textseg/v15 v15.0.0/go.mod h1:K8XmNZdhEBkdlyDdvbmmsvpAG721bKi0joRfFdHIWJ4=

--- a/vendor/github.com/alkiranet/alkira-client-go/alkira/connector_cisco_sdwan.go
+++ b/vendor/github.com/alkiranet/alkira-client-go/alkira/connector_cisco_sdwan.go
@@ -39,6 +39,7 @@ type ConnectorCiscoSdwan struct {
 	ImplicitGroupId      int                        `json:"implicitGroupId,omitempty"`
 	Enabled              bool                       `json:"enabled"`
 	Description          string                     `json:"description,omitempty"`
+	AllowList            []string                   `json:"allowList,omitempty"`
 }
 
 // NewConnectorCiscoSdwan initialize a new connector

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,7 +1,7 @@
 # github.com/agext/levenshtein v1.2.2
 ## explicit
 github.com/agext/levenshtein
-# github.com/alkiranet/alkira-client-go v1.59.1-0.20260707001840-0c295f61322e
+# github.com/alkiranet/alkira-client-go v1.59.1-0.20260716035132-4f1b1dc4ff8e
 ## explicit; go 1.26
 github.com/alkiranet/alkira-client-go/alkira
 # github.com/apparentlymart/go-textseg/v15 v15.0.0


### PR DESCRIPTION
Add an optional allow_list attribute (Set of IPv4 CIDRs/IPs) to the Cisco SD-WAN connector resource for connector-level management-access control, in parity with Fortinet. Elements are validated by a new validateIPv4CidrOrIP helper: IPv4 address or IPv4 CIDR only (IPv6 is rejected, and host-bits-set CIDRs are rejected rather than silently masked), matching the backend, which is IPv4-only and requires the network address. Via CustomizeDiff, allow_list is only permitted on Cisco Catalyst 8000V (CAT8000V) connectors. Wire the value through read and request expansion (using the Set helper) and document the attribute via tfplugindocs.

Re-vendor alkira-client-go to pick up the ConnectorCiscoSdwan.AllowList field (AK-70004).