### PR TITLE
[CLONE-66] AK-70617 - reject additional_tunnels_per_node that conflicts with tunnel options

### DIFF
--- a/alkira/resource_alkira_network_entity_scale_options.go
+++ b/alkira/resource_alkira_network_entity_scale_options.go
@@ -20,6 +20,13 @@ func resourceAlkiraNetworkEntityScaleOptions() *schema.Resource {
 		ReadContext:   resourceNetworkEntityScaleOptionsRead,
 		UpdateContext: resourceNetworkEntityScaleOptionsUpdate,
 		DeleteContext: resourceNetworkEntityScaleOptionsDelete,
+		CustomizeDiff: func(ctx context.Context, d *schema.ResourceDiff, m interface{}) error {
+			if err := validateAdditionalTunnelsPerNodeMatchesTunnelOptions(d.Get("segment_scale_options").([]any)); err != nil {
+				return err
+			}
+
+			return nil
+		},
 		Importer: &schema.ResourceImporter{
 			StateContext: importWithReadValidation(resourceNetworkEntityScaleOptionsRead),
 		},
@@ -64,7 +71,7 @@ func resourceAlkiraNetworkEntityScaleOptions() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"additional_tunnels_per_node": {
-							Description: "Number of additional Tunnels to be added per node. By default there is one tunnel per node. There are 2 nodes per connector or service on an average. Maximum tunnels are based on the limits allocated to a tenant. Either additionalTunnelsPerNode or additionalNodes either must be defined in a scale option.",
+							Description: "Number of additional Tunnels to be added per node. By default there is one tunnel per node. There are 2 nodes per connector or service on an average. Maximum tunnels are based on the limits allocated to a tenant. Either additionalTunnelsPerNode or additionalNodes either must be defined in a scale option. When `additional_tunnel_options_per_node` (labels) are configured, this must equal the number of labels — the API derives it from the label count.",
 							Type:        schema.TypeInt,
 							Optional:    true,
 						},
@@ -127,6 +134,36 @@ func resourceAlkiraNetworkEntityScaleOptions() *schema.Resource {
 			},
 		},
 	}
+}
+
+// validateAdditionalTunnelsPerNodeMatchesTunnelOptions enforces that, when
+// additional_tunnel_options_per_node (labels) are set, additional_tunnels_per_node
+// equals the label count. The API derives additional_tunnels_per_node from the
+// number of labels, so a differing value - including the zero value produced when
+// the field is omitted - would diverge from the API-stored value and drift on
+// every plan. Failing here surfaces a clear plan-time error instead.
+func validateAdditionalTunnelsPerNodeMatchesTunnelOptions(segmentScaleOptions []any) error {
+	for i, raw := range segmentScaleOptions {
+		sso, ok := raw.(map[string]any)
+		if !ok {
+			continue
+		}
+
+		labels, _ := sso["additional_tunnel_options_per_node"].([]any)
+		if len(labels) == 0 {
+			continue
+		}
+
+		tunnelsPerNode, _ := sso["additional_tunnels_per_node"].(int)
+		if tunnelsPerNode != len(labels) {
+			return fmt.Errorf(
+				"segment_scale_options[%d]: additional_tunnels_per_node (%d) must equal "+
+					"the number of additional_tunnel_options_per_node (%d)",
+				i, tunnelsPerNode, len(labels))
+		}
+	}
+
+	return nil
 }
 
 // convertEntityIdToInt converts entity_id string to int

--- a/alkira/resource_alkira_network_entity_scale_options_test.go
+++ b/alkira/resource_alkira_network_entity_scale_options_test.go
@@ -1,0 +1,75 @@
+// Package alkira - Copyright (C) 2023-2025 Alkira Inc. All Rights Reserved.
+package alkira
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// segmentScaleOption builds a segment_scale_options block map as the SDK would
+// hand it to CustomizeDiff: additional_tunnels_per_node as int (0 when omitted)
+// and additional_tunnel_options_per_node as a []interface{} of labelCount labels.
+func segmentScaleOption(tunnelsPerNode, labelCount int) map[string]interface{} {
+	labels := make([]interface{}, labelCount)
+	for i := 0; i < labelCount; i++ {
+		labels[i] = map[string]interface{}{"id": i + 1, "label": "label", "enabled": true}
+	}
+	return map[string]interface{}{
+		"segment_id":                         1,
+		"additional_tunnels_per_node":        tunnelsPerNode,
+		"additional_tunnel_options_per_node": labels,
+	}
+}
+
+func TestValidateAdditionalTunnelsPerNodeMatchesTunnelOptions(t *testing.T) {
+	tests := []struct {
+		name      string
+		options   []interface{}
+		wantError bool
+	}{
+		{
+			name:      "matching count is valid",
+			options:   []interface{}{segmentScaleOption(2, 2)},
+			wantError: false,
+		},
+		{
+			name:      "mismatched count is rejected",
+			options:   []interface{}{segmentScaleOption(2, 1)},
+			wantError: true,
+		},
+		{
+			name:      "omitted tunnels per node with labels is rejected",
+			options:   []interface{}{segmentScaleOption(0, 1)},
+			wantError: true,
+		},
+		{
+			name:      "no labels leaves tunnels per node untouched",
+			options:   []interface{}{segmentScaleOption(3, 0)},
+			wantError: false,
+		},
+		{
+			name:      "empty options is valid",
+			options:   []interface{}{},
+			wantError: false,
+		},
+		{
+			name:      "one bad segment among many is rejected",
+			options:   []interface{}{segmentScaleOption(2, 2), segmentScaleOption(1, 3)},
+			wantError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateAdditionalTunnelsPerNodeMatchesTunnelOptions(tt.options)
+			if tt.wantError {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "additional_tunnels_per_node")
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/docs/resources/network_entity_scale_options.md
+++ b/docs/resources/network_entity_scale_options.md
@@ -98,7 +98,7 @@ Optional:
 
 - `additional_nodes` (Number) Number of additional nodes to be added. By default there are 2 nodes per connector or service on an average. Maximum nodes are based on the limits allocated to a tenant. Either additionalTunnelsPerNode or additionalNodes either must be defined in a scale option.
 - `additional_tunnel_options_per_node` (Block List) Additional tunnel options per node configuration. (see [below for nested schema](#nestedblock--segment_scale_options--additional_tunnel_options_per_node))
-- `additional_tunnels_per_node` (Number) Number of additional Tunnels to be added per node. By default there is one tunnel per node. There are 2 nodes per connector or service on an average. Maximum tunnels are based on the limits allocated to a tenant. Either additionalTunnelsPerNode or additionalNodes either must be defined in a scale option.
+- `additional_tunnels_per_node` (Number) Number of additional Tunnels to be added per node. By default there is one tunnel per node. There are 2 nodes per connector or service on an average. Maximum tunnels are based on the limits allocated to a tenant. Either additionalTunnelsPerNode or additionalNodes either must be defined in a scale option. When `additional_tunnel_options_per_node` (labels) are configured, this must equal the number of labels — the API derives it from the label count.
 - `zone_name` (String) optional field, if provided only tunnels associated with given zone would be scaled. Not applicable if scale options are defined for a connector.
 
 <a id="nestedblock--segment_scale_options--additional_tunnel_options_per_node"></a>


### PR DESCRIPTION
Cherry-pick of PR #733 for REL 66 release.

**Original Issue:** AK-70045
**Clone for REL 66:** AK-70617
**Release branch:** release/2026-06-18-66

## Summary
`alkira_network_entity_scale_options` exposed `additional_tunnels_per_node` as an optional user value, but the API derives it from the number of `additional_tunnel_options_per_node` (labels) and always stores that count. A config value that differs from the label count (including the zero value when the field is omitted) diverges from the API-stored value and drifts on every plan (AK-70045).

## Changes
- `CustomizeDiff` guard: when `additional_tunnel_options_per_node` is set, require `additional_tunnels_per_node` to equal the label count, otherwise fail the plan with a clear message.
- Schema `Description` + regenerated docs surface the constraint at write time.
- Field stays optional customer input — no `Computed`, no `alkira-client-go` change.
- Logic extracted into `validateAdditionalTunnelsPerNodeMatchesTunnelOptions`, unit tested (matching / mismatched / omitted / no-labels / empty / multi-segment).

## Backport note
REL 66 does not have the unrelated `state` FAILED→SUCCESS `CustomizeDiff` coercion (a separate feature not in this release), so only the AK-70617 validation was applied. The test file is a minimal, self-contained version (REL 66 has no scale-options test file / `warnOnFailedScaleOptionsUpdate`). Build + unit test verified green locally.

## Related
Server-side counterpart: tenant-provisioning-service PR #5529 (clone of #5499).

## Original PR
#733

## Cherry-picked commit(s)
- 0f1a67a4c4b08aae437ac2e9efaa318b12a09d65
- 679ac73b53bb00281f0f304d2f01eca3aee5413f