### PR TITLE
docs(claude-md): drop cross-repo backend-guide pointer

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,5 +2,5 @@
 
 ## Architecture
 
-See [ARCHITECTURE.md](ARCHITECTURE.md) for this service's deep dive (responsibility, interfaces, dependencies, data, deployment, failure impact, debugging guide, health). See [alkiranet/test-cloud-scripts/docs/backend-architecture-guide/](https://github.com/alkiranet/test-cloud-scripts/tree/main/docs/backend-architecture-guide/) for cross-repo backend context.
+See [ARCHITECTURE.md](ARCHITECTURE.md) for this service's deep dive (responsibility, interfaces, dependencies, data, deployment, failure impact, debugging guide, health).
 


### PR DESCRIPTION
## Summary

Removes the link to the internal cross-repo backend architecture guide from `CLAUDE.md`, keeping only the in-repo [`ARCHITECTURE.md`](ARCHITECTURE.md) reference.

## Why

`terraform-provider-alkira` is a public repo. The previous `CLAUDE.md` pointed at a cross-repo guide that is not part of this repo's public surface. The in-repo `ARCHITECTURE.md` already provides the deep dive, so the external pointer is unnecessary and is removed.

## Changes

- `CLAUDE.md`: deleted the sentence linking to the external backend architecture guide; kept the `ARCHITECTURE.md` pointer.

## Notes

- Docs-only change; no code, schema, or behavior impact.
- Per repo convention, no version bump or changelog entry for docs-only changes.