### PR TITLE
AK-71184:make aws_account_id optional for AWS VPC connector

### DIFF
--- a/alkira/resource_alkira_connector_aws_vpc.go
+++ b/alkira/resource_alkira_connector_aws_vpc.go
@@ -35,9 +35,10 @@ func resourceAlkiraConnectorAwsVpc() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"aws_account_id": {
-				Description: "AWS Account ID.",
+				Description: "AWS Account ID. If not provided, it will be automatically detected from the VPC.",
 				Type:        schema.TypeString,
-				Required:    true,
+				Optional:    true,
+				Computed:    true,
 			},
 			"aws_region": {
 				Description: "AWS Region where VPC resides.",

--- a/docs/resources/connector_aws_vpc.md
+++ b/docs/resources/connector_aws_vpc.md
@@ -200,7 +200,6 @@ resource "alkira_connector_aws_vpc" "connector" {
 
 ### Required
 
-- `aws_account_id` (String) AWS Account ID.
 - `aws_region` (String) AWS Region where VPC resides.
 - `credential_id` (String) ID of resource `credential_aws_vpc`.
 - `cxp` (String) The CXP where the connector should be provisioned.
@@ -211,6 +210,7 @@ resource "alkira_connector_aws_vpc" "connector" {
 
 ### Optional
 
+- `aws_account_id` (String) AWS Account ID. If not provided, it will be automatically detected from the VPC.
 - `billing_tag_ids` (Set of Number) Billing tags to be associated with the resource. (see resource `alkira_billing_tag`).
 - `description` (String) The description of the connector.
 - `direct_inter_vpc_communication_enabled` (Boolean) Enable direct inter-vpc communication. Default is set to `false`.

--- a/vendor/github.com/alkiranet/alkira-client-go/alkira/connector_aws_vpc.go
+++ b/vendor/github.com/alkiranet/alkira-client-go/alkira/connector_aws_vpc.go
@@ -56,7 +56,7 @@ type ConnectorAwsVpc struct {
 	Size                               string          `json:"size"`
 	TgwAttachments                     []TgwAttachment `json:"tgwAttachments,omitempty"`
 	VpcId                              string          `json:"vpcId"`
-	VpcOwnerId                         string          `json:"vpcOwnerId"`
+	VpcOwnerId                         string          `json:"vpcOwnerId,omitempty"`
 	VpcRouting                         interface{}     `json:"vpcRouting"`
 	TgwConnectEnabled                  bool            `json:"tgwConnectEnabled"`
 	ScaleGroupId                       string          `json:"scaleGroupId,omitempty"`


### PR DESCRIPTION
  ## Summary

  - Make `aws_account_id` optional for `alkira_connector_aws_vpc` resource. TPS now auto-detects
    the VPC owner from AWS when not provided.
  - Add `omitempty` to `VpcOwnerId` JSON tag so an empty string is not sent in the API payload
    when the field is omitted.

  ## Context

  A customer (cyberdefense) provided the wrong `aws_account_id` in their Terraform config, which
  caused provisioning to fail with a confusing "Transit Gateway not found" error. TPS now validates
  `vpcOwnerId` against the actual VPC owner from AWS and rejects mismatches at create time
  (see TPS PR for AK-71184).

  Since TPS can auto-detect the VPC owner from the AWS `DescribeVpcs` API, there's no reason to
  force users to provide it. Making it optional reduces misconfiguration risk.

  ## Changes

  - **`resource_alkira_connector_aws_vpc.go`**: Changed `aws_account_id` from `Required: true` to
    `Optional: true, Computed: true`. `Computed` ensures Terraform picks up the auto-populated value
    from TPS on read.
  - **`vendor/.../connector_aws_vpc.go`**: Added `omitempty` to `VpcOwnerId` JSON tag so the field
    is omitted from the request body when empty.

  ## Backward Compatibility

  - Existing configs that provide `aws_account_id` continue to work as before.
  - New configs can omit `aws_account_id` and TPS will auto-populate it.

  ## Test Plan

  - [x] `go build ./...` passes
  - [ ] Apply existing Terraform config with `aws_account_id` set — should work as before
  - [ ] Apply new config without `aws_account_id` — TPS should auto-detect and populate it
  - [ ] Apply config with wrong `aws_account_id` — TPS should reject with validation error
