### PR TITLE
AK-71039:add allow_list to alkira_connector_aruba_edge

### DIFF
--- a/alkira/helper.go
+++ b/alkira/helper.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"log"
 	"math/rand"
+	"net"
 	"strconv"
 	"strings"
 	"time"
@@ -344,4 +345,36 @@ func warnOnFailedStateUpdate(update schema.UpdateContextFunc) schema.UpdateConte
 
 		return diags
 	}
+}
+
+// validateIPv4CidrOrIP validates that a string is a valid IPv4 address
+// or IPv4 CIDR. IPv6 is rejected.
+func validateIPv4CidrOrIP(i interface{}, k string) ([]string, []error) {
+	v, ok := i.(string)
+	if !ok {
+		return nil, []error{fmt.Errorf("expected type of %q to be string", k)}
+	}
+
+	// A colon means an IPv6 literal.
+	if strings.Contains(v, ":") {
+		return nil, []error{fmt.Errorf("%q must be an IPv4 address or IPv4 CIDR, got %q (IPv6 is not supported)", k, v)}
+	}
+
+	if strings.Contains(v, "/") {
+		ip, ipnet, err := net.ParseCIDR(v)
+		if err != nil || ip.To4() == nil {
+			return nil, []error{fmt.Errorf("%q must be a valid IPv4 CIDR, got %q", k, v)}
+		}
+		// Reject host bits rather than silently masking them.
+		if !ip.Equal(ipnet.IP) {
+			return nil, []error{fmt.Errorf("%q must be a CIDR network address with no host bits set, got %q (did you mean %q?)", k, v, ipnet.String())}
+		}
+		return nil, nil
+	}
+
+	if ip := net.ParseIP(v); ip == nil || ip.To4() == nil {
+		return nil, []error{fmt.Errorf("%q must be a valid IPv4 address or IPv4 CIDR, got %q", k, v)}
+	}
+
+	return nil, nil
 }

--- a/alkira/resource_alkira_connector_aruba_edge.go
+++ b/alkira/resource_alkira_connector_aruba_edge.go
@@ -35,6 +35,14 @@ func resourceAlkiraConnectorArubaEdge() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
+			"allow_list": {
+				Description: "Management-access allow-list of IPv4 CIDRs or IP " +
+					"addresses. When set, only these sources can reach the " +
+					"management interface of the connector instances.",
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
 			"aruba_edge_vrf_mapping": {
 				Description: "The connector will accept multiple segments as a " +
 					"part of VRF mappings.",
@@ -290,6 +298,7 @@ func resourceConnectorArubaEdgeRead(ctx context.Context, d *schema.ResourceData,
 		return diag.FromErr(err)
 	}
 
+	d.Set("allow_list", connector.AllowList)
 	d.Set("aruba_edge_vrf_mapping", arubaEdgeMappings)
 	d.Set("billing_tag_ids", connector.BillingTags)
 	d.Set("boost_mode", connector.BoostMode)
@@ -428,6 +437,7 @@ func generateConnectorArubaEdgeRequest(d *schema.ResourceData, m interface{}) (*
 	}
 
 	return &alkira.ConnectorArubaEdge{
+		AllowList:            convertTypeSetToStringList(d.Get("allow_list").(*schema.Set)),
 		ArubaEdgeVrfMappings: vrfMappings,
 		BillingTags:          convertTypeSetToIntList(d.Get("billing_tag_ids").(*schema.Set)),
 		BoostMode:            d.Get("boost_mode").(bool),

--- a/alkira/resource_alkira_connector_aruba_edge.go
+++ b/alkira/resource_alkira_connector_aruba_edge.go
@@ -41,7 +41,10 @@ func resourceAlkiraConnectorArubaEdge() *schema.Resource {
 					"management interface of the connector instances.",
 				Type:     schema.TypeSet,
 				Optional: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
+				Elem: &schema.Schema{
+					Type:         schema.TypeString,
+					ValidateFunc: validateIPv4CidrOrIP,
+				},
 			},
 			"aruba_edge_vrf_mapping": {
 				Description: "The connector will accept multiple segments as a " +

--- a/alkira/resource_alkira_connector_aruba_edge_test.go
+++ b/alkira/resource_alkira_connector_aruba_edge_test.go
@@ -102,6 +102,55 @@ func generateNumArubaEdgeInstance(num int) []alkira.ArubaEdgeInstance {
 	return instances
 }
 
+func TestArubaEdgeAllowListSchema(t *testing.T) {
+	resourceSchema := resourceAlkiraConnectorArubaEdge().Schema
+
+	t.Run("field exists and is Optional TypeSet of String", func(t *testing.T) {
+		field, ok := resourceSchema["allow_list"]
+		require.True(t, ok, "allow_list must be present in schema")
+		assert.Equal(t, schema.TypeSet, field.Type)
+		assert.True(t, field.Optional)
+		assert.False(t, field.Required)
+
+		elem, ok := field.Elem.(*schema.Schema)
+		require.True(t, ok, "allow_list Elem must be a *schema.Schema")
+		assert.Equal(t, schema.TypeString, elem.Type)
+		assert.NotNil(t, elem.ValidateFunc, "allow_list elements must be validated")
+	})
+}
+
+func TestArubaEdgeAllowListValidator(t *testing.T) {
+	validate := resourceAlkiraConnectorArubaEdge().Schema["allow_list"].Elem.(*schema.Schema).ValidateFunc
+
+	valid := []string{"10.0.0.0/24", "192.168.1.0/24", "10.0.0.5", "10.0.0.5/32"}
+	for _, v := range valid {
+		_, errs := validate(v, "allow_list")
+		assert.Emptyf(t, errs, "expected %q to be accepted (IPv4 CIDR or IPv4 IP)", v)
+	}
+
+	invalid := []string{"not-an-ip", "10.0.0.0/33", "999.0.0.1", "2001:db8::/32", "::1", "::ffff:1.2.3.4", "10.0.0.5/24"}
+	for _, v := range invalid {
+		_, errs := validate(v, "allow_list")
+		assert.NotEmptyf(t, errs, "expected %q to be rejected", v)
+	}
+}
+
+func TestArubaEdgeAllowListExpand(t *testing.T) {
+	t.Run("populated set produces expected slice", func(t *testing.T) {
+		set := schema.NewSet(schema.HashString, []interface{}{
+			"10.0.0.0/24", "10.0.0.5", "10.0.0.0/24",
+		})
+		got := convertTypeSetToStringList(set)
+		assert.ElementsMatch(t, []string{"10.0.0.0/24", "10.0.0.5"}, got)
+	})
+
+	t.Run("empty set produces empty slice", func(t *testing.T) {
+		set := schema.NewSet(schema.HashString, []interface{}{})
+		got := convertTypeSetToStringList(set)
+		assert.Empty(t, got)
+	})
+}
+
 func TestArubaEdgeScaleGroupIdSchema(t *testing.T) {
 	resourceSchema := resourceAlkiraConnectorArubaEdge().Schema
 

--- a/alkira/resource_alkira_connector_azure_vnet_helper_test.go
+++ b/alkira/resource_alkira_connector_azure_vnet_helper_test.go
@@ -454,7 +454,6 @@ func TestAzureVnetCidrFieldNameMatch(t *testing.T) {
 	})
 }
 
-
 // The backend auto-populates `customerAsn` when the user omits it in VGW mode
 // (either to the existing Azure VGW's ASN, or to a DEFAULT_ASN constant for a
 // fresh VNet). If the provider schema declares this field as Optional only,

--- a/alkira/resource_alkira_connector_cisco_sdwan_helper.go
+++ b/alkira/resource_alkira_connector_cisco_sdwan_helper.go
@@ -1,43 +1,9 @@
 package alkira
 
 import (
-	"fmt"
-	"net"
-	"strings"
-
 	"github.com/alkiranet/alkira-client-go/alkira"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
-
-func validateIPv4CidrOrIP(i interface{}, k string) ([]string, []error) {
-	v, ok := i.(string)
-	if !ok {
-		return nil, []error{fmt.Errorf("expected type of %q to be string", k)}
-	}
-
-	// A colon means an IPv6 literal.
-	if strings.Contains(v, ":") {
-		return nil, []error{fmt.Errorf("%q must be an IPv4 address or IPv4 CIDR, got %q (IPv6 is not supported)", k, v)}
-	}
-
-	if strings.Contains(v, "/") {
-		ip, ipnet, err := net.ParseCIDR(v)
-		if err != nil || ip.To4() == nil {
-			return nil, []error{fmt.Errorf("%q must be a valid IPv4 CIDR, got %q", k, v)}
-		}
-		// Reject host bits rather than silently masking them.
-		if !ip.Equal(ipnet.IP) {
-			return nil, []error{fmt.Errorf("%q must be a CIDR network address with no host bits set, got %q (did you mean %q?)", k, v, ipnet.String())}
-		}
-		return nil, nil
-	}
-
-	if ip := net.ParseIP(v); ip == nil || ip.To4() == nil {
-		return nil, []error{fmt.Errorf("%q must be a valid IPv4 address or IPv4 CIDR, got %q", k, v)}
-	}
-
-	return nil, nil
-}
 
 // setVedge set vedge block values
 func setVedge(d *schema.ResourceData, connector *alkira.ConnectorCiscoSdwan) {

--- a/alkira/resource_alkira_ip_reservation_test.go
+++ b/alkira/resource_alkira_ip_reservation_test.go
@@ -519,7 +519,7 @@ func TestIpReservationFieldNameMatch(t *testing.T) {
 		assert.False(t, wrongFieldExists, "Schema should NOT have 'first_ip_assignement' field (bug was typo with extra 'e')")
 	})
 }
-
+//
 func TestIpReservationStateHandling(t *testing.T) {
 	t.Run("first_ip_assignment data can be saved and retrieved", func(t *testing.T) {
 		resourceSchema := resourceAlkiraIpReservation().Schema

--- a/alkira/resource_alkira_ip_reservation_test.go
+++ b/alkira/resource_alkira_ip_reservation_test.go
@@ -519,7 +519,7 @@ func TestIpReservationFieldNameMatch(t *testing.T) {
 		assert.False(t, wrongFieldExists, "Schema should NOT have 'first_ip_assignement' field (bug was typo with extra 'e')")
 	})
 }
-//
+
 func TestIpReservationStateHandling(t *testing.T) {
 	t.Run("first_ip_assignment data can be saved and retrieved", func(t *testing.T) {
 		resourceSchema := resourceAlkiraIpReservation().Schema

--- a/docs/resources/connector_aruba_edge.md
+++ b/docs/resources/connector_aruba_edge.md
@@ -63,6 +63,7 @@ resource "alkira_connector_aruba_edge" "test1" {
 
 ### Optional
 
+- `allow_list` (Set of String) Management-access allow-list of IPv4 CIDRs or IP addresses. When set, only these sources can reach the management interface of the connector instances.
 - `billing_tag_ids` (Set of Number) Billing tags to be associated with the resource. (see resource `alkira_billing_tag`).
 - `boost_mode` (Boolean) If enabled the Aruba Edge Connect image supporting the boost mode for given size(or bandwidth) would be deployed in Alkira CXP. The default value is false.
 - `description` (String) The description of the connector.

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/alkiranet/terraform-provider-alkira
 go 1.26
 
 require (
-	github.com/alkiranet/alkira-client-go v1.59.1-0.20260716035132-4f1b1dc4ff8e
+	github.com/alkiranet/alkira-client-go v1.59.1-0.20260807110243-03a751d4a7fb
 	github.com/hashicorp/go-cty v1.5.0
 	github.com/hashicorp/go-retryablehttp v0.7.7
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.37.0

--- a/go.sum
+++ b/go.sum
@@ -5,8 +5,8 @@ github.com/PuerkitoBio/purell v1.1.1/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbt
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
 github.com/agext/levenshtein v1.2.2 h1:0S/Yg6LYmFJ5stwQeRp6EeOcCbj7xiqQSdNelsXvaqE=
 github.com/agext/levenshtein v1.2.2/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
-github.com/alkiranet/alkira-client-go v1.59.1-0.20260716035132-4f1b1dc4ff8e h1:I6D/RglNdGqG8R1sS2y1d88/oAFVoI0U3BhVH6/mRYA=
-github.com/alkiranet/alkira-client-go v1.59.1-0.20260716035132-4f1b1dc4ff8e/go.mod h1:ms9LjOc4O1Zrr7/VQOva+xwv3sJuBUqS9JsI+MbE2go=
+github.com/alkiranet/alkira-client-go v1.59.1-0.20260807110243-03a751d4a7fb h1:M85ScJq3005yPbKQUml2c/58jgvyKeEyRzzzR+uXgoI=
+github.com/alkiranet/alkira-client-go v1.59.1-0.20260807110243-03a751d4a7fb/go.mod h1:ms9LjOc4O1Zrr7/VQOva+xwv3sJuBUqS9JsI+MbE2go=
 github.com/apparentlymart/go-textseg/v12 v12.0.0/go.mod h1:S/4uRK2UtaQttw1GenVJEynmyUenKwP++x/+DdGV/Ec=
 github.com/apparentlymart/go-textseg/v15 v15.0.0 h1:uYvfpb3DyLSCGWnctWKGj857c6ew1u1fNQOlOtuGxQY=
 github.com/apparentlymart/go-textseg/v15 v15.0.0/go.mod h1:K8XmNZdhEBkdlyDdvbmmsvpAG721bKi0joRfFdHIWJ4=

--- a/vendor/github.com/alkiranet/alkira-client-go/alkira/connector_aruba_edge.go
+++ b/vendor/github.com/alkiranet/alkira-client-go/alkira/connector_aruba_edge.go
@@ -8,6 +8,7 @@ import (
 )
 
 type ConnectorArubaEdge struct {
+	AllowList            []string               `json:"allowList,omitempty"`
 	ArubaEdgeVrfMappings []ArubaEdgeVRFMappings `json:"arubaEdgeVRFMappings"`
 	BillingTags          []int                  `json:"billingTags"`
 	BoostMode            bool                   `json:"boostMode"`

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,7 +1,7 @@
 # github.com/agext/levenshtein v1.2.2
 ## explicit
 github.com/agext/levenshtein
-# github.com/alkiranet/alkira-client-go v1.59.1-0.20260716035132-4f1b1dc4ff8e
+# github.com/alkiranet/alkira-client-go v1.59.1-0.20260807110243-03a751d4a7fb
 ## explicit; go 1.26
 github.com/alkiranet/alkira-client-go/alkira
 # github.com/apparentlymart/go-textseg/v15 v15.0.0


### PR DESCRIPTION
  ## Summary                                                                                                                                                       
  - Add optional `allow_list` argument (`TypeSet` of String) to `alkira_connector_aruba_edge` resource
  - Add `AllowList []string` field to client-go `ConnectorArubaEdge` struct
  - Gated server-side by `RELEASE-CONNECTOR-ARUBA-EDGE-CONNECT-ALLOW-LIST` feature flag (403 when flag off and list non-empty)

  ## Test plan
  - [x] Existing Aruba Edge tests pass (`go test ./alkira/ -run ArubaEdge`)
  - [x] `go build ./...` compiles cleanly
