### PR TITLE
AK-71042: add allow_list to alkira_connector_juniper_sdwan

### DIFF
--- a/alkira/resource_alkira_connector_juniper_sdwan.go
+++ b/alkira/resource_alkira_connector_juniper_sdwan.go
@@ -33,6 +33,17 @@ func resourceAlkiraConnectorJuniperSdwan() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
+			"allow_list": {
+				Description: "Management-access allow-list of IPv4 CIDRs or " +
+					"IP addresses. When set, only these sources can reach " +
+					"the management interface of the connector instances.",
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem: &schema.Schema{
+					Type:         schema.TypeString,
+					ValidateFunc: validateIPv4CidrOrIP,
+				},
+			},
 			"name": {
 				Description: "The name of the connector.",
 				Type:        schema.TypeString,
@@ -273,6 +284,7 @@ func resourceConnectorJuniperSdwanRead(ctx context.Context, d *schema.ResourceDa
 		}}
 	}
 
+	d.Set("allow_list", connector.AllowList)
 	d.Set("billing_tag_ids", connector.BillingTags)
 	d.Set("cxp", connector.Cxp)
 	d.Set("group", connector.Group)
@@ -415,6 +427,7 @@ func generateConnectorJuniperSdwanRequest(d *schema.ResourceData, m any) (*alkir
 
 	// Construct the request payload
 	connector := &alkira.ConnectorJuniperSdwan{
+		AllowList:             convertTypeSetToStringList(d.Get("allow_list").(*schema.Set)),
 		BillingTags:           convertTypeSetToIntList(d.Get("billing_tag_ids").(*schema.Set)),
 		Instances:             instances,
 		JuniperSsrVrfMappings: expandJuniperSdwanVrfMappings(d.Get("juniper_ssr_vrf_mapping").(*schema.Set)),

--- a/alkira/resource_alkira_connector_juniper_sdwan_test.go
+++ b/alkira/resource_alkira_connector_juniper_sdwan_test.go
@@ -1,0 +1,59 @@
+package alkira
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestJuniperSdwanAllowListSchema(t *testing.T) {
+	resourceSchema := resourceAlkiraConnectorJuniperSdwan().Schema
+
+	t.Run("field exists and is Optional TypeSet of String", func(t *testing.T) {
+		field, ok := resourceSchema["allow_list"]
+		require.True(t, ok, "allow_list must be present in schema")
+		assert.Equal(t, schema.TypeSet, field.Type)
+		assert.True(t, field.Optional)
+		assert.False(t, field.Required)
+
+		elem, ok := field.Elem.(*schema.Schema)
+		require.True(t, ok, "allow_list Elem must be a *schema.Schema")
+		assert.Equal(t, schema.TypeString, elem.Type)
+		assert.NotNil(t, elem.ValidateFunc, "allow_list elements must be validated")
+	})
+}
+
+func TestJuniperSdwanAllowListValidator(t *testing.T) {
+	validate := resourceAlkiraConnectorJuniperSdwan().Schema["allow_list"].Elem.(*schema.Schema).ValidateFunc
+
+	valid := []string{"10.0.0.0/24", "192.168.1.0/24", "10.0.0.5", "10.0.0.5/32"}
+	for _, v := range valid {
+		_, errs := validate(v, "allow_list")
+		assert.Emptyf(t, errs, "expected %q to be accepted (IPv4 CIDR or IPv4 IP)", v)
+	}
+
+	invalid := []string{"not-an-ip", "10.0.0.0/33", "999.0.0.1", "2001:db8::/32", "::1", "::ffff:1.2.3.4", "10.0.0.5/24"}
+	for _, v := range invalid {
+		_, errs := validate(v, "allow_list")
+		assert.NotEmptyf(t, errs, "expected %q to be rejected", v)
+	}
+}
+
+func TestJuniperSdwanAllowListExpand(t *testing.T) {
+	t.Run("populated set produces expected slice", func(t *testing.T) {
+		set := schema.NewSet(schema.HashString, []interface{}{
+			"10.0.0.0/24", "10.0.0.5", "10.0.0.0/24", // duplicate collapses
+		})
+
+		got := convertTypeSetToStringList(set)
+		assert.ElementsMatch(t, []string{"10.0.0.0/24", "10.0.0.5"}, got)
+	})
+
+	t.Run("empty set produces empty slice", func(t *testing.T) {
+		set := schema.NewSet(schema.HashString, []interface{}{})
+		got := convertTypeSetToStringList(set)
+		assert.Empty(t, got)
+	})
+}

--- a/docs/resources/connector_juniper_sdwan.md
+++ b/docs/resources/connector_juniper_sdwan.md
@@ -39,7 +39,7 @@ resource "alkira_connector_juniper_sdwan" "juniper" {
 
 - `availability_zone` (Number) Availability zone of the Juniper instance(s)
 - `cxp` (String) The CXP where the connector should be provisioned.
-- `instance` (Block List, Min: 1) Juniper SSR Connector Instances (see [below for nested schema](#nestedblock--instance))
+- `instance` (Block List, Min: 1, Max: 1) Juniper SSR Connector Instance. Only one instance is supported per connector. (see [below for nested schema](#nestedblock--instance))
 - `juniper_ssr_version` (String) The Juniper SSR Version.
 - `juniper_ssr_vrf_mapping` (Block Set, Min: 1, Max: 1) Juniper SSR Vrf Mapping. (see [below for nested schema](#nestedblock--juniper_ssr_vrf_mapping))
 - `name` (String) The name of the connector.
@@ -47,6 +47,7 @@ resource "alkira_connector_juniper_sdwan" "juniper" {
 
 ### Optional
 
+- `allow_list` (Set of String) Management-access allow-list of IPv4 CIDRs or IP addresses. When set, only these sources can reach the management interface of the connector instances.
 - `billing_tag_ids` (Set of Number) Billing tags to be associated with the resource. (see resource `alkira_billing_tag`).
 - `description` (String) The description of the connector.
 - `enabled` (Boolean) Is the connector enabled. Default is `true`.
@@ -90,6 +91,8 @@ Optional:
 ## Import
 
 Import is supported using the following syntax:
+
+The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
 
 ```shell
 terraform import alkira_connector_juniper_sdwan.example CONNECTOR_ID


### PR DESCRIPTION
## Summary
- Add optional `allow_list` attribute (`TypeSet` of `String`) to `alkira_connector_juniper_sdwan` resource for management-access IP/CIDR whitelisting
- Add plan-time validation via `validateIPv4CidrOrIP` (rejects IPv6, garbage input, host-bits-set CIDRs) — matches the Cisco cat8k `allow_list` pattern
- Vendor updated `alkira-client-go` with `AllowList` field on `ConnectorJuniperSdwan` struct
- Regenerate docs and add unit tests

## Changes
- `alkira/resource_alkira_connector_juniper_sdwan.go`: Schema (`allow_list`), read path (`d.Set`), expand path (`convertTypeSetToStringList`)
- `alkira/resource_alkira_connector_juniper_sdwan_test.go`: New — schema, validator, and expand tests
- `docs/resources/connector_juniper_sdwan.md`: Regenerated via `make doc`
- `go.mod`, `go.sum`, `vendor/`: Updated `alkira-client-go` dependency

## Backward Compatibility
- Existing configs without `allow_list` are unaffected (`omitempty` omits the field from the request body)
- No `CustomizeDiff` type-gate needed — Juniper SSR is single-mode

## Test plan
- [x] `go build ./...` compiles cleanly
- [x] `go test ./alkira/... -run TestJuniperSdwan` — all 3 test cases pass
- [x] `make doc` regenerates docs with new attribute

🤖 Generated with [Claude Code](https://claude.com/claude-code)