### PR TITLE
AK-71048: add allow_list to alkira_connector_prisma_sdwan

### DIFF
--- a/alkira/resource_alkira_connector_prisma_sdwan.go
+++ b/alkira/resource_alkira_connector_prisma_sdwan.go
@@ -34,6 +34,17 @@ func resourceAlkiraConnectorPrismaSDWAN() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
+			"allow_list": {
+				Description: "Management-access allow-list of IPv4 CIDRs or " +
+					"IP addresses. When set, only these sources can reach " +
+					"the management interface of the connector instances.",
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem: &schema.Schema{
+					Type:         schema.TypeString,
+					ValidateFunc: validateIPv4CidrOrIP,
+				},
+			},
 			"name": {
 				Description: "The name of the connector.",
 				Type:        schema.TypeString,
@@ -253,6 +264,7 @@ func resourceConnectorPrismaSDWANRead(ctx context.Context, d *schema.ResourceDat
 		}}
 	}
 
+	d.Set("allow_list", connector.AllowList)
 	d.Set("billing_tag_ids", connector.BillingTags)
 	d.Set("cxp", connector.Cxp)
 	d.Set("description", connector.Description)
@@ -393,6 +405,7 @@ func generateConnectorPrismaSDWANRequest(d *schema.ResourceData, m interface{}) 
 
 	// Construct the request payload
 	connector := &alkira.ConnectorPrismaSDWAN{
+		AllowList:              convertTypeSetToStringList(d.Get("allow_list").(*schema.Set)),
 		BillingTags:            convertTypeSetToIntList(d.Get("billing_tag_ids").(*schema.Set)),
 		Cxp:                    d.Get("cxp").(string),
 		Description:            d.Get("description").(string),

--- a/alkira/resource_alkira_connector_prisma_sdwan_test.go
+++ b/alkira/resource_alkira_connector_prisma_sdwan_test.go
@@ -72,6 +72,55 @@ func TestPrismaSDWANDeflateInstances(t *testing.T) {
 	}
 }
 
+func TestPrismaSDWANAllowListSchema(t *testing.T) {
+	resourceSchema := resourceAlkiraConnectorPrismaSDWAN().Schema
+
+	t.Run("field exists and is Optional TypeSet of String", func(t *testing.T) {
+		field, ok := resourceSchema["allow_list"]
+		require.True(t, ok, "allow_list must be present in schema")
+		assert.Equal(t, schema.TypeSet, field.Type)
+		assert.True(t, field.Optional)
+		assert.False(t, field.Required)
+
+		elem, ok := field.Elem.(*schema.Schema)
+		require.True(t, ok, "allow_list Elem must be a *schema.Schema")
+		assert.Equal(t, schema.TypeString, elem.Type)
+		assert.NotNil(t, elem.ValidateFunc, "allow_list elements must be validated")
+	})
+}
+
+func TestPrismaSDWANAllowListValidator(t *testing.T) {
+	validate := resourceAlkiraConnectorPrismaSDWAN().Schema["allow_list"].Elem.(*schema.Schema).ValidateFunc
+
+	valid := []string{"10.0.0.0/24", "192.168.1.0/24", "10.0.0.5", "10.0.0.5/32"}
+	for _, v := range valid {
+		_, errs := validate(v, "allow_list")
+		assert.Emptyf(t, errs, "expected %q to be accepted (IPv4 CIDR or IPv4 IP)", v)
+	}
+
+	invalid := []string{"not-an-ip", "10.0.0.0/33", "999.0.0.1", "2001:db8::/32", "::1", "::ffff:1.2.3.4", "10.0.0.5/24"}
+	for _, v := range invalid {
+		_, errs := validate(v, "allow_list")
+		assert.NotEmptyf(t, errs, "expected %q to be rejected", v)
+	}
+}
+
+func TestPrismaSDWANAllowListExpand(t *testing.T) {
+	t.Run("populated set produces expected slice", func(t *testing.T) {
+		set := schema.NewSet(schema.HashString, []interface{}{
+			"10.0.0.0/24", "10.0.0.5", "10.0.0.0/24",
+		})
+		got := convertTypeSetToStringList(set)
+		assert.ElementsMatch(t, []string{"10.0.0.0/24", "10.0.0.5"}, got)
+	})
+
+	t.Run("empty set produces empty slice", func(t *testing.T) {
+		set := schema.NewSet(schema.HashString, []interface{}{})
+		got := convertTypeSetToStringList(set)
+		assert.Empty(t, got)
+	})
+}
+
 func TestPrismaSDWANScaleGroupIdSchema(t *testing.T) {
 	resourceSchema := resourceAlkiraConnectorPrismaSDWAN().Schema
 

--- a/docs/resources/connector_prisma_sdwan.md
+++ b/docs/resources/connector_prisma_sdwan.md
@@ -2,7 +2,7 @@
 page_title: "alkira_connector_prisma_sdwan Resource - terraform-provider-alkira"
 subcategory: ""
 description: |-
-  Manage Prisma SD-WAN Connector
+  Manage Prisma SD-WAN Connector.
 ---
 
 # alkira_connector_prisma_sdwan (Resource)
@@ -57,6 +57,7 @@ resource "alkira_connector_prisma_sdwan" "test1" {
 
 ### Optional
 
+- `allow_list` (Set of String) Management-access allow-list of IPv4 CIDRs or IP addresses. When set, only these sources can reach the management interface of the connector instances.
 - `billing_tag_ids` (Set of Number) Billing tags to be associated with the resource. (see resource `alkira_billing_tag`).
 - `description` (String) The description of the connector.
 - `enabled` (Boolean) Is the connector enabled. Default is `true`.
@@ -83,6 +84,7 @@ Required:
 Read-Only:
 
 - `id` (Number) The ID of the instance.
+
 
 <a id="nestedblock--target_segment"></a>
 ### Nested Schema for `target_segment`


### PR DESCRIPTION
## Summary
- Add optional `allow_list` attribute (`TypeSet` of `String`) to `alkira_connector_prisma_sdwan` resource for management-access IP/CIDR whitelisting
- Add plan-time validation via `validateIPv4CidrOrIP` (rejects IPv6, garbage input, host-bits-set CIDRs)
- Move `validateIPv4CidrOrIP` from `resource_alkira_connector_cisco_sdwan_helper.go` to `helper.go` for shared use
- Vendor updated `alkira-client-go` with `AllowList` field on `ConnectorPrismaSDWAN` struct
- Add unit tests to existing test file and regenerate docs

## Changes
- `alkira/resource_alkira_connector_prisma_sdwan.go`: Schema (`allow_list`), read path (`d.Set`), expand path (`convertTypeSetToStringList`)
- `alkira/resource_alkira_connector_prisma_sdwan_test.go`: Added allow_list schema, validator, and expand tests
- `alkira/helper.go`: Added `validateIPv4CidrOrIP` (moved from cisco_sdwan_helper)
- `alkira/resource_alkira_connector_cisco_sdwan_helper.go`: Removed `validateIPv4CidrOrIP` (now in helper.go)
- `docs/resources/connector_prisma_sdwan.md`: Regenerated via `make doc`
- `go.mod`, `go.sum`, `vendor/`: Updated `alkira-client-go` dependency

## Backward Compatibility
- Existing configs without `allow_list` are unaffected (`omitempty` omits the field from the request body)
- No `CustomizeDiff` type-gate needed — Prisma SD-WAN is single-mode

## Test plan
- [x] `go build ./...` compiles cleanly
- [x] `go test ./alkira/... -run TestPrismaSDWAN` — all tests pass (existing + new)
- [x] `go test ./alkira/... -run TestCiscoSdwan` — existing Cisco tests still pass after validator move
- [x] `make doc` regenerates docs with new attribute

🤖 Generated with [Claude Code](https://claude.com/claude-code)