### PR TITLE
AK-71456: [REL 66] warn when config changes are skipped on FAILED scale options (#705)

### DIFF
--- a/alkira/resource_alkira_network_entity_scale_options.go
+++ b/alkira/resource_alkira_network_entity_scale_options.go
@@ -18,11 +18,28 @@ func resourceAlkiraNetworkEntityScaleOptions() *schema.Resource {
 		Description:   "Scale Options are flexible configurations that elevate the capacity and performance characteristics of your network resource (any connector or a service) on Alkira's platform based on your specific needs. For example, you are experiencing traffic congestion with any of your exiting branch connectors, that too only on a particular segment, you can choose to define the scale options to add extra capacity to that connector on that segment. This can be done by specifying additional tunnels or additional nodes to the existing connector. \nScale options are made available only in certain scenarios when the existing connector or service is not meeting the required needs. \nUnderstanding scale options is crucial for planning and optimizing your network architecture on Alkira's platform. Choosing the right scale option ensures that your resources can handle the expected load.",
 		CreateContext: resourceNetworkEntityScaleOptionsCreate,
 		ReadContext:   resourceNetworkEntityScaleOptionsRead,
-		UpdateContext: resourceNetworkEntityScaleOptionsUpdate,
+		UpdateContext: warnOnFailedScaleOptionsUpdate(resourceNetworkEntityScaleOptionsUpdate),
 		DeleteContext: resourceNetworkEntityScaleOptionsDelete,
 		CustomizeDiff: func(ctx context.Context, d *schema.ResourceDiff, m interface{}) error {
+			// Reject a config the API cannot honour before doing anything
+			// else, so the practitioner sees the real problem rather than a
+			// downstream symptom.
 			if err := validateAdditionalTunnelsPerNodeMatchesTunnelOptions(d.Get("segment_scale_options").([]any)); err != nil {
 				return err
+			}
+
+			// Retry-by-reapply: a resource left in FAILED provision state
+			// needs a diff for the update path to run at all, so force the
+			// state back to SUCCESS. warnOnFailedScaleOptionsUpdate then
+			// tells the practitioner that the backend skipped their config
+			// changes. This resource keeps its provision state in "state"
+			// rather than "provision_state".
+			client := m.(*alkira.AlkiraClient)
+
+			old, _ := d.GetChange("state")
+
+			if client.Provision && old == "FAILED" {
+				d.SetNew("state", "SUCCESS")
 			}
 
 			return nil
@@ -404,4 +421,45 @@ func generateNetworkEntityScaleOptionsRequest(d *schema.ResourceData) (*alkira.N
 	}
 
 	return networkEntityScaleOptions, nil
+}
+
+// warnOnFailedScaleOptionsUpdate wraps the scale-options UpdateContextFunc and
+// emits a non-fatal warning when an update carrying config changes is applied
+// against a resource in FAILED provision state. In that case, the backend
+// (NetworkEntityScaleOptionsServiceImpl extends AbstractNetworkCRUDService)
+// skips the config update and re-provisions the previously saved config (the
+// retry-by-reapply mechanism), so the requested changes are not saved.
+//
+// This mirrors the generic warnOnFailedStateUpdate helper, but this resource
+// stores its provision state in the "state" field rather than
+// "provision_state", so it needs its own wrapper keyed on "state".
+func warnOnFailedScaleOptionsUpdate(update schema.UpdateContextFunc) schema.UpdateContextFunc {
+	return func(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+		client := m.(*alkira.AlkiraClient)
+
+		// Compute the condition up front for clarity. HasChangesExcept
+		// filters out the retry-only diff forced by CustomizeDiff.
+		oldState, _ := d.GetChange("state")
+
+		warn := client.Provision &&
+			oldState == "FAILED" &&
+			d.HasChangesExcept("state")
+
+		diags := update(ctx, d, m)
+
+		// Suppress the warning if the update itself failed - the
+		// skip message would be misleading in that case.
+		if warn && !diags.HasError() {
+			diags = append(diags, diag.Diagnostic{
+				Severity: diag.Warning,
+				Summary:  "CONFIGURATION CHANGES SKIPPED",
+				Detail: "Resource was in FAILED provision state; the backend " +
+					"re-provisions the previously saved configuration and skips " +
+					"configuration changes until the resource recovers. See the " +
+					"PROVISIONING section in the provider documentation.",
+			})
+		}
+
+		return diags
+	}
 }

--- a/alkira/resource_alkira_network_entity_scale_options_test.go
+++ b/alkira/resource_alkira_network_entity_scale_options_test.go
@@ -2,8 +2,13 @@
 package alkira
 
 import (
+	"context"
 	"testing"
 
+	"github.com/alkiranet/alkira-client-go/alkira"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -69,6 +74,151 @@ func TestValidateAdditionalTunnelsPerNodeMatchesTunnelOptions(t *testing.T) {
 				assert.Contains(t, err.Error(), "additional_tunnels_per_node")
 			} else {
 				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+// TestWarnOnFailedScaleOptionsUpdate mirrors TestWarnOnFailedStateUpdate but
+// exercises the scale-options one-off wrapper, which keys off the "state"
+// field rather than "provision_state".
+func TestWarnOnFailedScaleOptionsUpdate(t *testing.T) {
+	testSchema := map[string]*schema.Schema{
+		"name": {
+			Type:     schema.TypeString,
+			Optional: true,
+		},
+		"state": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
+	}
+
+	// newResourceData builds a ResourceData with prior state and a diff,
+	// mirroring what the SDK hands to UpdateContext during apply. When the
+	// prior state is FAILED, the diff carries the FAILED->SUCCESS change
+	// forced by the resource's CustomizeDiff.
+	newResourceData := func(t *testing.T, state string, configChanged bool) *schema.ResourceData {
+		instanceState := &terraform.InstanceState{
+			ID: "1",
+			Attributes: map[string]string{
+				"name":  "old-name",
+				"state": state,
+			},
+		}
+
+		diffAttrs := map[string]*terraform.ResourceAttrDiff{}
+		if configChanged {
+			diffAttrs["name"] = &terraform.ResourceAttrDiff{
+				Old: "old-name",
+				New: "new-name",
+			}
+		}
+		if state == "FAILED" {
+			diffAttrs["state"] = &terraform.ResourceAttrDiff{
+				Old: "FAILED",
+				New: "SUCCESS",
+			}
+		}
+
+		d, err := schema.InternalMap(testSchema).Data(instanceState,
+			&terraform.InstanceDiff{Attributes: diffAttrs})
+		require.NoError(t, err)
+		return d
+	}
+
+	tests := []struct {
+		name          string
+		provision     bool
+		state         string
+		configChanged bool
+		updateDiags   diag.Diagnostics
+		expectWarning bool
+	}{
+		{
+			name:          "warns on FAILED state with config changes",
+			provision:     true,
+			state:         "FAILED",
+			configChanged: true,
+			expectWarning: true,
+		},
+		{
+			name:          "no warning on retry-only re-apply (no config changes)",
+			provision:     true,
+			state:         "FAILED",
+			configChanged: false,
+			expectWarning: false,
+		},
+		{
+			name:          "no warning on healthy resource",
+			provision:     true,
+			state:         "SUCCESS",
+			configChanged: true,
+			expectWarning: false,
+		},
+		{
+			name:          "no warning when provision mode is off",
+			provision:     false,
+			state:         "FAILED",
+			configChanged: true,
+			expectWarning: false,
+		},
+		{
+			name:          "warning suppressed when update errors",
+			provision:     true,
+			state:         "FAILED",
+			configChanged: true,
+			updateDiags: diag.Diagnostics{{
+				Severity: diag.Error,
+				Summary:  "UPDATE FAILED",
+			}},
+			expectWarning: false,
+		},
+		{
+			name:          "warning appended to update's own warnings",
+			provision:     true,
+			state:         "FAILED",
+			configChanged: true,
+			updateDiags: diag.Diagnostics{{
+				Severity: diag.Warning,
+				Summary:  "PROVISION (UPDATE) FAILED",
+			}},
+			expectWarning: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := newResourceData(t, tt.state, tt.configChanged)
+			client := &alkira.AlkiraClient{Provision: tt.provision}
+
+			updateCalled := false
+			update := func(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+				updateCalled = true
+				return tt.updateDiags
+			}
+
+			diags := warnOnFailedScaleOptionsUpdate(update)(context.Background(), d, client)
+
+			// The wrapped update must always run - the warning never
+			// blocks the request.
+			assert.True(t, updateCalled, "wrapped update should always be invoked")
+
+			warningCount := 0
+			for _, diagnostic := range diags {
+				if diagnostic.Summary == "CONFIGURATION CHANGES SKIPPED" {
+					warningCount++
+					assert.Equal(t, diag.Warning, diagnostic.Severity)
+				}
+			}
+
+			if tt.expectWarning {
+				assert.Equal(t, 1, warningCount, "expected the skip warning to be emitted")
+				// The update's own diagnostics must be preserved.
+				assert.Len(t, diags, len(tt.updateDiags)+1)
+			} else {
+				assert.Zero(t, warningCount, "expected no skip warning")
+				assert.Len(t, diags, len(tt.updateDiags))
 			}
 		})
 	}


### PR DESCRIPTION
Cherry-pick of AK-69575 (PR #705, `0419fe04`) onto REL 66.

Jira: AK-71456 (clone of AK-69575)

AK-69575 shipped in v1.5.1 via REL 65 but was never picked to REL 66, so REL 66 regressed against released behaviour: scale-options resources in FAILED state lost the retry-by-reapply reset and the `CONFIGURATION CHANGES SKIPPED` warning.

Conflicted with AK-70617, which had rewritten the same `CustomizeDiff`. Resolved so it does both: tunnel-count validation first, then the FAILED → SUCCESS reset. Test file rebuilt to keep both test sets.

`go build`, `go vet`, `go test ./alkira/` clean. Diff of this file vs v1.5.1 is now additions only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)