### PR TITLE
AK-71457: [REL 66] fix Bluecat anycast spurious diff (TypeList -> TypeSet) (#711)

### DIFF
--- a/alkira/resource_alkira_service_bluecat.go
+++ b/alkira/resource_alkira_service_bluecat.go
@@ -32,6 +32,14 @@ func resourceAlkiraBluecat() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			StateContext: importWithReadValidation(resourceBluecatRead),
 		},
+		SchemaVersion: 1,
+		StateUpgraders: []schema.StateUpgrader{
+			{
+				Version: 0,
+				Type:    resourceBluecatV0().CoreConfigSchema().ImpliedType(),
+				Upgrade: resourceBluecatStateUpgradeV0,
+			},
+		},
 		Schema: map[string]*schema.Schema{
 			"bdds_anycast": {
 				Type:        schema.TypeSet,
@@ -43,7 +51,7 @@ func resourceAlkiraBluecat() *schema.Resource {
 							Description: "The IPs to be used for AnyCast. The IPs used for AnyCast MUST " +
 								"NOT overlap the CIDR of `alkira_segment` resource associated with " +
 								"the service.",
-							Type:     schema.TypeList,
+							Type:     schema.TypeSet,
 							Optional: true,
 							Elem:     &schema.Schema{Type: schema.TypeString},
 						},
@@ -53,7 +61,7 @@ func resourceAlkiraBluecat() *schema.Resource {
 								"have a configured Bluecat service in order to take advantage of " +
 								"this feature. It is NOT required that the `backup_cxps` should have " +
 								"a configured Bluecat service before it can be designated as a backup.",
-							Type:     schema.TypeList,
+							Type:     schema.TypeSet,
 							Optional: true,
 							Elem:     &schema.Schema{Type: schema.TypeString},
 						},
@@ -70,7 +78,7 @@ func resourceAlkiraBluecat() *schema.Resource {
 							Description: "The IPs to be used for AnyCast. The IPs used for AnyCast MUST " +
 								"NOT overlap the CIDR of `alkira_segment` resource associated with " +
 								"the service.",
-							Type:     schema.TypeList,
+							Type:     schema.TypeSet,
 							Optional: true,
 							Elem:     &schema.Schema{Type: schema.TypeString},
 						},
@@ -80,7 +88,7 @@ func resourceAlkiraBluecat() *schema.Resource {
 								"have a configured Bluecat service in order to take advantage of " +
 								"this feature. It is NOT required that the `backup_cxps` should have " +
 								"a configured Bluecat service before it can be designated as a backup.",
-							Type:     schema.TypeList,
+							Type:     schema.TypeSet,
 							Optional: true,
 							Elem:     &schema.Schema{Type: schema.TypeString},
 						},

--- a/alkira/resource_alkira_service_bluecat_helper.go
+++ b/alkira/resource_alkira_service_bluecat_helper.go
@@ -209,11 +209,11 @@ func expandBluecatAnycast(in *schema.Set) (*alkira.BluecatAnycast, error) {
 
 	for _, option := range in.List() {
 		cfg := option.(map[string]interface{})
-		if v, ok := cfg["ips"].([]interface{}); ok {
-			anycast.Ips = convertTypeListToStringList(v)
+		if v, ok := cfg["ips"].(*schema.Set); ok {
+			anycast.Ips = convertTypeSetToStringList(v)
 		}
-		if v, ok := cfg["backup_cxps"].([]interface{}); ok {
-			anycast.BackupCxps = convertTypeListToStringList(v)
+		if v, ok := cfg["backup_cxps"].(*schema.Set); ok {
+			anycast.BackupCxps = convertTypeSetToStringList(v)
 		}
 	}
 	return anycast, nil

--- a/alkira/resource_alkira_service_bluecat_helper_test.go
+++ b/alkira/resource_alkira_service_bluecat_helper_test.go
@@ -506,8 +506,30 @@ func TestExpandBluecatAnycast(t *testing.T) {
 				},
 				[]interface{}{
 					map[string]interface{}{
-						"ips":         []interface{}{"192.168.1.10", "192.168.1.11"},
-						"backup_cxps": []interface{}{"cxp1", "cxp2"},
+						"ips":         schema.NewSet(schema.HashString, []interface{}{"192.168.1.10", "192.168.1.11"}),
+						"backup_cxps": schema.NewSet(schema.HashString, []interface{}{"cxp1", "cxp2"}),
+					},
+				},
+			),
+			expected: &alkira.BluecatAnycast{
+				Ips:        []string{"192.168.1.10", "192.168.1.11"},
+				BackupCxps: []string{"cxp1", "cxp2"},
+			},
+			expectError: false,
+		},
+		{
+			// IPs are now a TypeSet, so a reordered config must expand to
+			// the same set of values. This is the AK-69549 regression guard:
+			// order from the API must not produce a spurious diff.
+			name: "reordered ips expand to same set",
+			input: schema.NewSet(
+				func(i interface{}) int {
+					return schema.HashString("test")
+				},
+				[]interface{}{
+					map[string]interface{}{
+						"ips":         schema.NewSet(schema.HashString, []interface{}{"192.168.1.11", "192.168.1.10"}),
+						"backup_cxps": schema.NewSet(schema.HashString, []interface{}{"cxp2", "cxp1"}),
 					},
 				},
 			),
@@ -546,7 +568,10 @@ func TestExpandBluecatAnycast(t *testing.T) {
 				}
 			} else {
 				assert.NoError(t, err)
-				assert.Equal(t, tt.expected, result)
+				// ips/backup_cxps are TypeSet now; compare without
+				// regard to order.
+				assert.ElementsMatch(t, tt.expected.Ips, result.Ips)
+				assert.ElementsMatch(t, tt.expected.BackupCxps, result.BackupCxps)
 			}
 		})
 	}

--- a/alkira/resource_alkira_service_bluecat_migrations.go
+++ b/alkira/resource_alkira_service_bluecat_migrations.go
@@ -1,0 +1,193 @@
+package alkira
+
+import (
+	"context"
+	"log"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+// resourceBluecatV0 returns the V0 schema (TypeList for the anycast `ips` and
+// `backup_cxps` fields) used before the migration to TypeSet. This is needed by
+// the state upgrader to parse old state formats. Only the schema structure
+// matters here (it feeds CoreConfigSchema().ImpliedType()), so validators and
+// set-hash functions are intentionally omitted.
+func resourceBluecatV0() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"bdds_anycast": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"ips": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						"backup_cxps": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+					},
+				},
+			},
+			"edge_anycast": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"ips": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						"backup_cxps": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+					},
+				},
+			},
+			"billing_tag_ids": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeInt},
+			},
+			"cxp": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"global_cidr_list_id": {
+				Type:     schema.TypeInt,
+				Required: true,
+			},
+			"provision_state": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"instance": {
+				Type:     schema.TypeSet,
+				Required: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"id": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"bdds_options": {
+							Type:     schema.TypeList,
+							Optional: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"client_id": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+									"activation_key": {
+										Type:      schema.TypeString,
+										Required:  true,
+										Sensitive: true,
+									},
+									"license_credential_id": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"hostname": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+									"model": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+									"version": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+								},
+							},
+						},
+						"edge_options": {
+							Type:     schema.TypeList,
+							Optional: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"config_data": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+									"credential_id": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"hostname": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+									"version": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+								},
+							},
+						},
+						"type": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+					},
+				},
+			},
+			"license_type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"segment_ids": {
+				Type:     schema.TypeSet,
+				Required: true,
+				MinItems: 1,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"service_group_name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"service_group_id": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"service_group_implicit_group_id": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+		},
+	}
+}
+
+// resourceBluecatStateUpgradeV0 migrates the state from V0 (TypeList for the
+// anycast `ips` and `backup_cxps` fields) to V1 (TypeSet). The values are plain
+// strings, so no type conversion is required: the SDK re-keys the flat-map
+// entries from positional indices (e.g. "bdds_anycast.<hash>.ips.0") to
+// hash-based keys when it re-encodes the returned state under the V1 schema.
+func resourceBluecatStateUpgradeV0(_ context.Context, rawState map[string]interface{}, _ interface{}) (map[string]interface{}, error) {
+	log.Printf("[DEBUG] Starting ServiceBluecat state migration from V0 to V1 (TypeList -> TypeSet for anycast ips/backup_cxps)")
+	log.Printf("[INFO] ServiceBluecat state migration from V0 to V1 completed successfully")
+	return rawState, nil
+}

--- a/alkira/resource_alkira_service_bluecat_test.go
+++ b/alkira/resource_alkira_service_bluecat_test.go
@@ -157,11 +157,11 @@ func TestAlkiraServiceBluecat_buildServiceBluecatRequestWithAnycast(t *testing.T
 	require.Equal(t, expectedServiceGroupName, request.ServiceGroupName)
 	require.Equal(t, expectedGlobalCidrListId, request.GlobalCidrListId)
 
-	// Verify anycast configurations
-	require.Equal(t, []string{"192.168.1.10", "192.168.1.11"}, request.BddsAnycast.Ips)
-	require.Equal(t, []string{"US-EAST", "EU-WEST"}, request.BddsAnycast.BackupCxps)
-	require.Equal(t, []string{"192.168.2.10"}, request.EdgeAnycast.Ips)
-	require.Equal(t, []string{"US-EAST"}, request.EdgeAnycast.BackupCxps)
+	// Verify anycast configurations (ips/backup_cxps are sets, order-agnostic)
+	require.ElementsMatch(t, []string{"192.168.1.10", "192.168.1.11"}, request.BddsAnycast.Ips)
+	require.ElementsMatch(t, []string{"US-EAST", "EU-WEST"}, request.BddsAnycast.BackupCxps)
+	require.ElementsMatch(t, []string{"192.168.2.10"}, request.EdgeAnycast.Ips)
+	require.ElementsMatch(t, []string{"US-EAST"}, request.EdgeAnycast.BackupCxps)
 
 	// Basic test completed successfully
 	assert.True(t, true, "Bluecat anycast service request test completed successfully")
@@ -730,6 +730,11 @@ func getStringFromMapBluecat(m map[string]interface{}, key string) string {
 
 func getStringSliceFromMapBluecat(m map[string]interface{}, key string) []string {
 	if val, ok := m[key]; ok {
+		// ips/backup_cxps are TypeSet (post AK-69549); accept both the
+		// set form returned by d.Get and the raw list form.
+		if set, ok := val.(*schema.Set); ok {
+			val = set.List()
+		}
 		if list, ok := val.([]interface{}); ok {
 			result := make([]string, len(list))
 			for i, v := range list {

--- a/docs/changes/README.md
+++ b/docs/changes/README.md
@@ -1,0 +1,31 @@
+# docs/changes
+
+Per-release changelog. One file per provider release. The release notes are assembled from these files at release time.
+
+## How it works
+
+- **`unreleased.md`** — the file currently being edited during the release-in-progress cycle. PRs that change user-visible behavior append an entry here.
+- **`vX.Y.Z.md`** — frozen snapshot of `unreleased.md` at the moment the release was cut. Renamed from `unreleased.md`; a new empty `unreleased.md` is created for the next cycle.
+
+## When to add an entry
+
+Mandatory for any change that's user-visible and not obvious from the auto-generated schema markdown:
+
+- Resource behavior changes (filtering, drift fixes, new Read fields)
+- Schema additions, removals, or type changes
+- Backend contract changes the provider relies on
+- `ConflictsWith` / `Required` / `Optional` / `Default` / `Computed` transitions
+- State migrations (`SchemaVersion` bumps)
+
+Skip for: pure refactor with no behavior change, test-only changes, doc-only changes, or dependency bumps without functional impact.
+
+## What to write
+
+Short. Release-note tight. Cover only what shipped — not future plans.
+
+- One H2 heading per change, format: `## <Resource or area> — <one-line summary> (<JIRA-ID>)`
+- What changed
+- User impact (drift, breaking changes, behavior shifts)
+- Migration steps if any (HCL changes, state import notes)
+
+Don't narrate the why or the history. Don't preview future tickets — they get their own entry when they ship.

--- a/docs/changes/unreleased.md
+++ b/docs/changes/unreleased.md
@@ -1,0 +1,11 @@
+# Unreleased
+
+User-visible changes since the last release. Renamed to the release version when cut (e.g. `v1.6.0.md`).
+
+## Bluecat service — anycast `ips`/`backup_cxps` changed to sets to stop spurious diffs (AK-69549)
+
+`ips` and `backup_cxps` inside the `bdds_anycast` and `edge_anycast` blocks of `alkira_service_bluecat` are now `Set of String` instead of `List of String`. The API returns these values in a different order than configured; as ordered lists they re-hashed the surrounding anycast block, so every plan showed the block as removed and re-added even when nothing changed. As sets, order no longer matters.
+
+A state migration (`SchemaVersion` 0 → 1) re-keys existing state from positional to set form on first refresh.
+
+**Impact:** Bluecat services that previously showed a perpetual no-op diff on `bdds_anycast` / `edge_anycast` now plan clean. No HCL changes required — order within `ips` / `backup_cxps` is now irrelevant. The first plan after upgrade is idempotent; the migration runs automatically.

--- a/docs/resources/service_bluecat.md
+++ b/docs/resources/service_bluecat.md
@@ -386,8 +386,8 @@ Read-Only:
 
 Optional:
 
-- `backup_cxps` (List of String) The `backup_cxps` to be used when the current Bluecat service is not available. It also needs to have a configured Bluecat service in order to take advantage of this feature. It is NOT required that the `backup_cxps` should have a configured Bluecat service before it can be designated as a backup.
-- `ips` (List of String) The IPs to be used for AnyCast. The IPs used for AnyCast MUST NOT overlap the CIDR of `alkira_segment` resource associated with the service.
+- `backup_cxps` (Set of String) The `backup_cxps` to be used when the current Bluecat service is not available. It also needs to have a configured Bluecat service in order to take advantage of this feature. It is NOT required that the `backup_cxps` should have a configured Bluecat service before it can be designated as a backup.
+- `ips` (Set of String) The IPs to be used for AnyCast. The IPs used for AnyCast MUST NOT overlap the CIDR of `alkira_segment` resource associated with the service.
 
 
 <a id="nestedblock--edge_anycast"></a>
@@ -395,8 +395,8 @@ Optional:
 
 Optional:
 
-- `backup_cxps` (List of String) The `backup_cxps` to be used when the current Bluecat service is not available. It also needs to have a configured Bluecat service in order to take advantage of this feature. It is NOT required that the `backup_cxps` should have a configured Bluecat service before it can be designated as a backup.
-- `ips` (List of String) The IPs to be used for AnyCast. The IPs used for AnyCast MUST NOT overlap the CIDR of `alkira_segment` resource associated with the service.
+- `backup_cxps` (Set of String) The `backup_cxps` to be used when the current Bluecat service is not available. It also needs to have a configured Bluecat service in order to take advantage of this feature. It is NOT required that the `backup_cxps` should have a configured Bluecat service before it can be designated as a backup.
+- `ips` (Set of String) The IPs to be used for AnyCast. The IPs used for AnyCast MUST NOT overlap the CIDR of `alkira_segment` resource associated with the service.
 
 ## Import
 


### PR DESCRIPTION
Cherry-pick of AK-69549 (PR #711, `b7e86d73`) onto REL 66. Applied clean.

Jira: AK-71457 (clone of AK-69549)

The inner `ips` / `backup_cxps` fields in `bdds_anycast` / `edge_anycast` were ordered lists while the API returns them in a different order, re-hashing the surrounding set block so every plan showed the block as removed and re-added.

Carries a state migration: `SchemaVersion` 0 → 1 with a registered `StateUpgrader` (`resource_alkira_service_bluecat_migrations.go`). Needs to be in the branch before the release is cut.

`go build`, `go vet`, `go test ./alkira/` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)