### PR TITLE
AK-71449: document 20/30/40/50LARGE for GCP Interconnect size

### DIFF
--- a/alkira/resource_alkira_connector_gcp_interconnect.go
+++ b/alkira/resource_alkira_connector_gcp_interconnect.go
@@ -42,7 +42,8 @@ func resourceAlkiraConnectorGcpInterconnect() *schema.Resource {
 			},
 			"size": {
 				Description: "The size of the connector, one of `SMALL`, " +
-					"`MEDIUM`, `LARGE`, `2LARGE`, `5LARGE` or `10LARGE`.",
+					"`MEDIUM`, `LARGE`, `2LARGE`, `5LARGE`, `10LARGE`, `20LARGE`, " +
+					"`30LARGE`, `40LARGE` or `50LARGE`.",
 				Type:     schema.TypeString,
 				Required: true,
 			},

--- a/docs/resources/connector_gcp_interconnect.md
+++ b/docs/resources/connector_gcp_interconnect.md
@@ -126,7 +126,7 @@ resource "alkira_connector_gcp_interconnect" "example_gcp_interconnect_2" {
 - `instances` (Block List, Min: 1) A list of instances of the InterConnect (see [below for nested schema](#nestedblock--instances))
 - `loopback_prefixes` (Set of String) A list of prefixes that should be associated with the connector. Eg :["10.30.0.0/24"]
 - `name` (String) The name of the connector.
-- `size` (String) The size of the connector, one of `SMALL`, `MEDIUM`, `LARGE`, `2LARGE`, `5LARGE` or `10LARGE`.
+- `size` (String) The size of the connector, one of `SMALL`, `MEDIUM`, `LARGE`, `2LARGE`, `5LARGE`, `10LARGE`, `20LARGE`, `30LARGE`, `40LARGE` or `50LARGE`.
 - `tunnel_protocol` (String) The tunnel protocol used by the connector.Can be one of `GRE`, `IPSEC`, `VXLAN`, or `VXLAN_GPE`.
 
 ### Optional


### PR DESCRIPTION
Part of [AK-71444](https://alkiranet.atlassian.net/browse/AK-71444). Sub-task: [AK-71449](https://alkiranet.atlassian.net/browse/AK-71449) · [Design](https://github.com/alkiranet/eng-design-specs/blob/dev/features/AK-71444/design/terraform-provider/design.md)

## Change

`size` description now lists all ten sizes, plus the regenerated resource doc:

```diff
- "The size of the connector, one of `SMALL`, `MEDIUM`, `LARGE`, `2LARGE`, `5LARGE` or `10LARGE`."
+ "The size of the connector, one of `SMALL`, `MEDIUM`, `LARGE`, `2LARGE`, `5LARGE`, `10LARGE`,
+  `20LARGE`, `30LARGE`, `40LARGE` or `50LARGE`."
```

## Documentation only — no behavioral change

`size` is a plain `schema.TypeString` with **no `ValidateFunc`**; sizes are validated server-side by TPS. So:

| | |
|---|---|
| Schema | Unchanged — still `TypeString`, `Required` |
| `ForceNew` | Unchanged — resizing stays an in-place update |
| State migration | None |
| Version dependency | **None.** `size = "50LARGE"` already applies on *older* provider releases, since nothing client-side rejects it |

That last point is worth passing to customers: this release is a **discoverability improvement, not a functional prerequisite**. The gating factor is the server-side change ([TPS#5580](https://github.com/alkiranet/tenant-provisioning-service/pull/5580)) and the catalog entry ([inventory-data#1467](https://github.com/alkiranet/inventory-data/pull/1467)).

## Files not changed, and why

| File | Why |
|---|---|
| `docs/data-sources/connector_gcp_interconnect.md` | Verified it does not carry the size description |
| `templates/resources/connector_gcp_interconnect.md.tmpl` | Verified this template does not exist |

## Verification

| Check | Result |
|---|---|
| `go build ./...` | ✅ clean |
| `go vet ./alkira/` | ✅ clean |
| Generated doc matches the code description | ✅ |
| No schema/`ForceNew`/state change; `resource_alkira_connector_simple_test.go` unaffected | ✅ |

## Note for release notes

The newly *supported* sizes are 20/30/40/50LARGE. `10LARGE` was already both supported and documented — it appears in the diff only because the sentence was rewritten.

Independent of the other PRs — safe to merge in any order, though the sizes won't work against a backend until TPS#5580 and inventory-data#1467 land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[AK-71444]: https://alkiranet.atlassian.net/browse/AK-71444?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AK-71449]: https://alkiranet.atlassian.net/browse/AK-71449?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ