### PR TITLE
[CLONE 66]AK-71327:make aws_account_id optional for AWS VPC connector (#745)

### DIFF
--- a/alkira/resource_alkira_connector_aws_vpc.go
+++ b/alkira/resource_alkira_connector_aws_vpc.go
@@ -35,9 +35,10 @@ func resourceAlkiraConnectorAwsVpc() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"aws_account_id": {
-				Description: "AWS Account ID.",
+				Description: "AWS Account ID. If not provided, it will be automatically detected from the VPC.",
 				Type:        schema.TypeString,
-				Required:    true,
+				Optional:    true,
+				Computed:    true,
 			},
 			"aws_region": {
 				Description: "AWS Region where VPC resides.",

--- a/docs/resources/connector_aws_vpc.md
+++ b/docs/resources/connector_aws_vpc.md
@@ -200,7 +200,6 @@ resource "alkira_connector_aws_vpc" "connector" {
 
 ### Required
 
-- `aws_account_id` (String) AWS Account ID.
 - `aws_region` (String) AWS Region where VPC resides.
 - `credential_id` (String) ID of resource `credential_aws_vpc`.
 - `cxp` (String) The CXP where the connector should be provisioned.
@@ -211,6 +210,7 @@ resource "alkira_connector_aws_vpc" "connector" {
 
 ### Optional
 
+- `aws_account_id` (String) AWS Account ID. If not provided, it will be automatically detected from the VPC.
 - `billing_tag_ids` (Set of Number) Billing tags to be associated with the resource. (see resource `alkira_billing_tag`).
 - `description` (String) The description of the connector.
 - `direct_inter_vpc_communication_enabled` (Boolean) Enable direct inter-vpc communication. Default is set to `false`.

--- a/vendor/github.com/alkiranet/alkira-client-go/alkira/connector_aws_vpc.go
+++ b/vendor/github.com/alkiranet/alkira-client-go/alkira/connector_aws_vpc.go
@@ -56,7 +56,7 @@ type ConnectorAwsVpc struct {
 	Size                               string          `json:"size"`
 	TgwAttachments                     []TgwAttachment `json:"tgwAttachments,omitempty"`
 	VpcId                              string          `json:"vpcId"`
-	VpcOwnerId                         string          `json:"vpcOwnerId"`
+	VpcOwnerId                         string          `json:"vpcOwnerId,omitempty"`
 	VpcRouting                         interface{}     `json:"vpcRouting"`
 	TgwConnectEnabled                  bool            `json:"tgwConnectEnabled"`
 	ScaleGroupId                       string          `json:"scaleGroupId,omitempty"`


### PR DESCRIPTION
* AK-71184:make aws_account_id optional for AWS VPC connector

* AK-71184: regenerated the doc