### PR TITLE
AK-71054: add allow_list to alkira_service_pan

### DIFF
--- a/alkira/resource_alkira_service_pan.go
+++ b/alkira/resource_alkira_service_pan.go
@@ -71,6 +71,17 @@ func resourceAlkiraServicePan() *schema.Resource {
 			StateContext: importWithReadValidation(resourceServicePanRead),
 		},
 		Schema: map[string]*schema.Schema{
+			"allow_list": {
+				Description: "Management-access allow-list of IPv4 CIDRs or " +
+					"IP addresses. When set, only these sources can reach " +
+					"the management interface of the service instances.",
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem: &schema.Schema{
+					Type:         schema.TypeString,
+					ValidateFunc: validateIPv4CidrOrIP,
+				},
+			},
 			"billing_tag_ids": {
 				Description: "Billing tags to be associated with " +
 					"the resource. (see resource `alkira_billing_tag`).",
@@ -557,6 +568,7 @@ func resourceServicePanRead(ctx context.Context, d *schema.ResourceData, m inter
 		}}
 	}
 
+	d.Set("allow_list", pan.AllowList)
 	d.Set("billing_tag_ids", pan.BillingTagIds)
 	d.Set("bundle", pan.Bundle)
 	d.Set("cxp", pan.CXP)

--- a/alkira/resource_alkira_service_pan_helper.go
+++ b/alkira/resource_alkira_service_pan_helper.go
@@ -459,6 +459,7 @@ func generateServicePanRequest(d *schema.ResourceData, m interface{}) (*alkira.S
 	}
 
 	service := &alkira.ServicePan{
+		AllowList:                   convertTypeSetToStringList(d.Get("allow_list").(*schema.Set)),
 		BillingTagIds:               convertTypeSetToIntList(d.Get("billing_tag_ids").(*schema.Set)),
 		Bundle:                      d.Get("bundle").(string),
 		CXP:                         d.Get("cxp").(string),

--- a/alkira/resource_alkira_service_pan_test.go
+++ b/alkira/resource_alkira_service_pan_test.go
@@ -1,6 +1,7 @@
 package alkira
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"testing"
@@ -456,3 +457,148 @@ func TestAlkiraServicePanFlattenGlobalProtectSegmentOptionsInstanceValues(t *tes
 // 		w.Header().Set("Content-Type", "application/json")
 // 	})
 // }
+
+func TestAlkiraServicePanAllowListSchema(t *testing.T) {
+	resourceSchema := resourceAlkiraServicePan().Schema
+
+	t.Run("field exists and is Optional TypeSet of String", func(t *testing.T) {
+		field, ok := resourceSchema["allow_list"]
+		require.True(t, ok, "allow_list must be present in schema")
+		assert.Equal(t, schema.TypeSet, field.Type)
+		assert.True(t, field.Optional)
+		assert.False(t, field.Required)
+
+		elem, ok := field.Elem.(*schema.Schema)
+		require.True(t, ok, "allow_list Elem must be a *schema.Schema")
+		assert.Equal(t, schema.TypeString, elem.Type)
+		assert.NotNil(t, elem.ValidateFunc, "allow_list elements must be validated")
+	})
+}
+
+func TestAlkiraServicePanAllowListValidator(t *testing.T) {
+	validate := resourceAlkiraServicePan().Schema["allow_list"].Elem.(*schema.Schema).ValidateFunc
+
+	valid := []string{"10.0.0.0/24", "192.168.1.0/24", "10.0.0.5", "10.0.0.5/32"}
+	for _, v := range valid {
+		_, errs := validate(v, "allow_list")
+		assert.Emptyf(t, errs, "expected %q to be accepted (IPv4 CIDR or IPv4 IP)", v)
+	}
+
+	invalid := []string{"not-an-ip", "10.0.0.0/33", "999.0.0.1", "2001:db8::/32", "::1", "::ffff:1.2.3.4", "10.0.0.5/24"}
+	for _, v := range invalid {
+		_, errs := validate(v, "allow_list")
+		assert.NotEmptyf(t, errs, "expected %q to be rejected", v)
+	}
+}
+
+func TestAlkiraServicePanAllowListExpand(t *testing.T) {
+	tests := []struct {
+		name     string
+		elements []interface{}
+		expected []string
+	}{
+		{
+			name:     "populated set",
+			elements: []interface{}{"10.0.0.0/24", "10.0.0.5"},
+			expected: []string{"10.0.0.0/24", "10.0.0.5"},
+		},
+		{
+			name:     "duplicates collapse",
+			elements: []interface{}{"10.0.0.0/24", "10.0.0.5", "10.0.0.0/24"},
+			expected: []string{"10.0.0.0/24", "10.0.0.5"},
+		},
+		{
+			name:     "empty set produces no entries",
+			elements: []interface{}{},
+			expected: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := convertTypeSetToStringList(schema.NewSet(schema.HashString, tt.elements))
+			assert.ElementsMatch(t, tt.expected, got)
+		})
+	}
+}
+
+// TestAlkiraServicePanAllowListGenerateRequest drives the real
+// generateServicePanRequest path to confirm allow_list lands on the request
+// payload via the Set helper, and that an absent allow_list is omitted.
+func TestAlkiraServicePanAllowListGenerateRequest(t *testing.T) {
+	mockClient := createMockAlkiraClient(t, func(w http.ResponseWriter, req *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	// generateServicePanRequest requires at least one instance block.
+	instance := []interface{}{
+		map[string]interface{}{
+			"name":          "pan-instance-1",
+			"credential_id": "cred-1",
+		},
+	}
+
+	tests := []struct {
+		name      string
+		allowList interface{}
+		expected  []string
+	}{
+		{
+			name:      "populated allow_list",
+			allowList: []interface{}{"10.0.0.0/24", "10.0.0.5"},
+			expected:  []string{"10.0.0.0/24", "10.0.0.5"},
+		},
+		{
+			name:      "allow_list absent",
+			allowList: nil,
+			expected:  nil,
+		},
+		{
+			name:      "allow_list explicitly empty",
+			allowList: []interface{}{},
+			expected:  nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			raw := map[string]interface{}{"instance": instance}
+			if tt.allowList != nil {
+				raw["allow_list"] = tt.allowList
+			}
+
+			r := resourceAlkiraServicePan()
+			d := schema.TestResourceDataRaw(t, r.Schema, raw)
+
+			service, err := generateServicePanRequest(d, mockClient)
+			require.NoError(t, err, "generateServicePanRequest should not return error")
+			assert.ElementsMatch(t, tt.expected, service.AllowList)
+		})
+	}
+}
+
+// TestAlkiraServicePanAllowListRead confirms resourceServicePanRead populates
+// allow_list from the API response with no resulting diff.
+func TestAlkiraServicePanAllowListRead(t *testing.T) {
+	allowList := []string{"10.0.0.0/24", "10.0.0.5"}
+
+	client := createMockAlkiraClient(t, func(w http.ResponseWriter, req *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(alkira.ServicePan{
+			Id:        json.Number("1"),
+			Name:      "test-pan-service",
+			AllowList: allowList,
+		})
+	})
+
+	r := resourceAlkiraServicePan()
+	d := r.TestResourceData()
+	d.SetId("1")
+
+	diags := resourceServicePanRead(context.Background(), d, client)
+	require.False(t, diags.HasError(), "resourceServicePanRead should not error: %v", diags)
+
+	got := convertTypeSetToStringList(d.Get("allow_list").(*schema.Set))
+	assert.ElementsMatch(t, allowList, got, "allow_list should round-trip from the API response")
+}

--- a/docs/resources/service_pan.md
+++ b/docs/resources/service_pan.md
@@ -141,6 +141,7 @@ resource "alkira_service_pan" "scm_example" {
 
 ### Optional
 
+- `allow_list` (Set of String) Management-access allow-list of IPv4 CIDRs or IP addresses. When set, only these sources can reach the management interface of the service instances.
 - `billing_tag_ids` (Set of Number) Billing tags to be associated with the resource. (see resource `alkira_billing_tag`).
 - `bundle` (String) The software image bundle that would be used forPAN instance deployment. This is applicable for licenseType`PAY_AS_YOU_GO` only. If not provided, the default`PAN_VM_300_BUNDLE_2` would be used. However `PAN_VM_300_BUNDLE_2`is legacy bundle and is not supported on AWS. It is recommendedto use `VM_SERIES_BUNDLE_1` and `VM_SERIES_BUNDLE_2` (supports Global Protect).
 - `description` (String) The description of the service.


### PR DESCRIPTION
## Summary

Adds an optional `allow_list` attribute to `alkira_service_pan`, whitelisting source IPs/CIDRs that may reach the firewall's management surface. Part of AK-70969 (self-service mgmt-access allow-list across all third-party SD-WANs and firewalls), in parity with the five connector resources already merged to `dev`.

`ServicePan.AllowList` (`json:"allowList,omitempty"`) from AK-71036 is already vendored, so no re-vendor is needed here.

## Changes

- **`alkira/resource_alkira_service_pan.go`** — `allow_list` schema attribute (`TypeSet`, `Optional`, String elem with per-element validation); `d.Set("allow_list", pan.AllowList)` in `resourceServicePanRead`.
- **`alkira/resource_alkira_service_pan_helper.go`** — `AllowList: convertTypeSetToStringList(...)` in `generateServicePanRequest` (Set path, not `convertTypeListToStringList`, which would panic on a Set).
- **`alkira/resource_alkira_service_pan_test.go`** — table-driven unit tests (below).
- **`docs/resources/service_pan.md`** — new attribute line.

**No type-gate.** PAN is single-mode and not sub-scoped, so unlike Cisco cat8k there is no `CAT8000V`-style gate to add. The resource's existing `CustomizeDiff` closure is unchanged, and a non-empty `allow_list` is accepted regardless of `type`/`version`.

## Two deviations from the ticket — please review

**1. Validator is `validateIPv4CidrOrIP`, not `validation.IsCIDR`.**

The ticket says to use `validation.IsCIDR` "matching the Cisco cat8k allow_list already on dev" — but cat8k on `dev` actually uses `validateIPv4CidrOrIP`, and that helper was hoisted from `resource_alkira_connector_cisco_sdwan_helper.go` into `alkira/helper.go` in d59a526d precisely so the sibling tickets could share it. All five merged siblings (aruba, versa, vmware, juniper, prisma) use it.

It is also closer to the backend contract, which is IPv4-only and requires the network address:

| input | `validateIPv4CidrOrIP` | `validation.IsCIDR` |
|---|---|---|
| `10.0.0.5` (bare IP) | accepted | **rejected** |
| `2001:db8::/32` | rejected | **accepted** |
| `10.0.0.5/24` (host bits set) | rejected | **accepted** |

Using `IsCIDR` would make PAN the odd one out in the parent story. Happy to switch if the ticket's wording was deliberate.

**2. The doc change is the single generated line, not a full `tfplugindocs` run.**

`make doc` regenerates the entire docs tree: it rewrites ~80 unrelated files, deletes `docs/guides/release-notes-v1.4.3.md` and `v1.4.4.md`, and in this file *removes* the hand-written "Strata Cloud Manager (SCM) Example Usage" prose, replacing it with comments pulled from the example `.tf`. I reverted all of that and kept only the `allow_list` line, matching the 1-line doc diff in each sibling PR.

I did verify the shortcut: I re-ran `make doc`, extracted the generated `allow_list` line, and diffed it against the committed one — byte-identical, differing only in line number (151 vs 144) due to the pre-existing drift.

## Pre-existing issue found (out of scope, needs its own ticket)

`docs/resources/service_pan.md` on `dev` is missing `routing_type`, `scm_enabled`, and `scm_folder` — they exist in the schema but were never regenerated into the docs. Related: the SCM prose was hand-edited into the `.md` rather than into `templates/`, so **`make doc` is currently destructive** for whoever runs it next. Worth a follow-up to move that prose into the template and document the three attributes.

## Testing

Table-driven unit tests using testify + `schema.TestResourceDataRaw` / `schema.NewSet`, no live backend (the repo has no enabled acceptance suite — `testAccPreCheck` is commented out in `provider_test.go`):

- `TestAlkiraServicePanAllowListSchema` — asserts `TypeSet`, `Optional`, String `Elem` carrying a `ValidateFunc`.
- `TestAlkiraServicePanAllowListValidator` — accepts IPv4 CIDRs and bare IPv4; rejects malformed, out-of-range, IPv6, IPv4-mapped-IPv6, and host-bits-set CIDRs.
- `TestAlkiraServicePanAllowListExpand` — populated set, duplicate collapsing, and empty set (no panic, no entries).
- `TestAlkiraServicePanAllowListGenerateRequest` — drives the real `generateServicePanRequest` path via `schema.TestResourceDataRaw` and asserts `AllowList` on the resulting `ServicePan`, across populated / absent / explicitly-empty (absent and empty both yield no entries, so `omitempty` drops the field).
- `TestAlkiraServicePanAllowListRead` — `resourceServicePanRead` against a mock client round-trips `allow_list` from the API response.

Verified locally:

- `go build ./...` — clean
- `go vet ./alkira/` — clean
- `gofmt -l alkira/` — no output
- `go test ./alkira/ -count=1` — **full package suite passes** (105s), no regressions

`golangci-lint` is not installed on this machine, so the repo lint target was not run — CI will cover it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)