### PR TITLE
AK-71057: add allow_list to alkira_service_fortinet

### DIFF
--- a/alkira/resource_alkira_service_fortinet.go
+++ b/alkira/resource_alkira_service_fortinet.go
@@ -34,6 +34,17 @@ func resourceAlkiraServiceFortinet() *schema.Resource {
 			StateContext: importWithReadValidation(resourceFortinetRead),
 		},
 		Schema: map[string]*schema.Schema{
+			"allow_list": {
+				Description: "Management-access allow-list of IPv4 CIDRs or " +
+					"IP addresses. When set, only these sources can reach " +
+					"the management interface of the service instances.",
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem: &schema.Schema{
+					Type:         schema.TypeString,
+					ValidateFunc: validateIPv4CidrOrIP,
+				},
+			},
 			"auto_scale": {
 				Description: "Whether enable auto scale for Fortinet firewall. " +
 					"It could be either `ON` and `OFF`. Default value is `OFF`.",
@@ -345,6 +356,7 @@ func resourceFortinetRead(ctx context.Context, d *schema.ResourceData, m interfa
 		}}
 	}
 
+	d.Set("allow_list", f.AllowList)
 	d.Set("auto_scale", f.AutoScale)
 	d.Set("billing_tag_ids", f.BillingTags)
 	d.Set("credential_id", f.CredentialId)

--- a/alkira/resource_alkira_service_fortinet_helper.go
+++ b/alkira/resource_alkira_service_fortinet_helper.go
@@ -293,6 +293,7 @@ func generateFortinetRequest(d *schema.ResourceData, m interface{}) (*alkira.Ser
 	}
 
 	service := &alkira.ServiceFortinet{
+		AllowList:        convertTypeSetToStringList(d.Get("allow_list").(*schema.Set)),
 		AutoScale:        d.Get("auto_scale").(string),
 		BillingTags:      billingTagIds,
 		CredentialId:     d.Get("credential_id").(string),

--- a/alkira/resource_alkira_service_fortinet_test.go
+++ b/alkira/resource_alkira_service_fortinet_test.go
@@ -1,7 +1,15 @@
 package alkira
 
 import (
+	"context"
+	"encoding/json"
+	"net/http"
 	"testing"
+
+	"github.com/alkiranet/alkira-client-go/alkira"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestFortinetRead(t *testing.T) {
@@ -66,3 +74,158 @@ func TestFortinetReadAutoScale(t *testing.T) {
 // 		w.Header().Set("Content-Type", "application/json")
 // 	})
 // }
+
+func TestAlkiraServiceFortinetAllowListSchema(t *testing.T) {
+	resourceSchema := resourceAlkiraServiceFortinet().Schema
+
+	t.Run("field exists and is Optional TypeSet of String", func(t *testing.T) {
+		field, ok := resourceSchema["allow_list"]
+		require.True(t, ok, "allow_list must be present in schema")
+		assert.Equal(t, schema.TypeSet, field.Type)
+		assert.True(t, field.Optional)
+		assert.False(t, field.Required)
+
+		elem, ok := field.Elem.(*schema.Schema)
+		require.True(t, ok, "allow_list Elem must be a *schema.Schema")
+		assert.Equal(t, schema.TypeString, elem.Type)
+		assert.NotNil(t, elem.ValidateFunc, "allow_list elements must be validated")
+	})
+}
+
+func TestAlkiraServiceFortinetAllowListValidator(t *testing.T) {
+	validate := resourceAlkiraServiceFortinet().Schema["allow_list"].Elem.(*schema.Schema).ValidateFunc
+
+	valid := []string{"10.0.0.0/24", "192.168.1.0/24", "10.0.0.5", "10.0.0.5/32"}
+	for _, v := range valid {
+		_, errs := validate(v, "allow_list")
+		assert.Emptyf(t, errs, "expected %q to be accepted (IPv4 CIDR or IPv4 IP)", v)
+	}
+
+	invalid := []string{"not-an-ip", "10.0.0.0/33", "999.0.0.1", "2001:db8::/32", "::1", "::ffff:1.2.3.4", "10.0.0.5/24"}
+	for _, v := range invalid {
+		_, errs := validate(v, "allow_list")
+		assert.NotEmptyf(t, errs, "expected %q to be rejected", v)
+	}
+}
+
+func TestAlkiraServiceFortinetAllowListExpand(t *testing.T) {
+	tests := []struct {
+		name     string
+		elements []interface{}
+		expected []string
+	}{
+		{
+			name:     "populated set",
+			elements: []interface{}{"10.0.0.0/24", "10.0.0.5"},
+			expected: []string{"10.0.0.0/24", "10.0.0.5"},
+		},
+		{
+			name:     "duplicates collapse",
+			elements: []interface{}{"10.0.0.0/24", "10.0.0.5", "10.0.0.0/24"},
+			expected: []string{"10.0.0.0/24", "10.0.0.5"},
+		},
+		{
+			name:     "empty set produces no entries",
+			elements: []interface{}{},
+			expected: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := convertTypeSetToStringList(schema.NewSet(schema.HashString, tt.elements))
+			assert.ElementsMatch(t, tt.expected, got)
+		})
+	}
+}
+
+// TestAlkiraServiceFortinetAllowListGenerateRequest drives the real
+// generateFortinetRequest path to confirm allow_list lands on the request
+// payload via the Set helper, and that an absent allow_list is omitted.
+func TestAlkiraServiceFortinetAllowListGenerateRequest(t *testing.T) {
+	// generateFortinetRequest resolves the management server segment by ID,
+	// so the mock returns a segment for any lookup.
+	mockClient := createMockAlkiraClient(t, func(w http.ResponseWriter, req *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(alkira.Segment{
+			Id:   json.Number("1"),
+			Name: "test-segment",
+		})
+	})
+
+	// generateFortinetRequest requires at least one instance. A pre-set
+	// credential_id keeps expansion from creating a credential.
+	instances := []interface{}{
+		map[string]interface{}{
+			"name":          "fortinet-instance-1",
+			"credential_id": "cred-1",
+		},
+	}
+
+	tests := []struct {
+		name      string
+		allowList interface{}
+		expected  []string
+	}{
+		{
+			name:      "populated allow_list",
+			allowList: []interface{}{"10.0.0.0/24", "10.0.0.5"},
+			expected:  []string{"10.0.0.0/24", "10.0.0.5"},
+		},
+		{
+			name:      "allow_list absent",
+			allowList: nil,
+			expected:  nil,
+		},
+		{
+			name:      "allow_list explicitly empty",
+			allowList: []interface{}{},
+			expected:  nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			raw := map[string]interface{}{"instances": instances}
+			if tt.allowList != nil {
+				raw["allow_list"] = tt.allowList
+			}
+
+			r := resourceAlkiraServiceFortinet()
+			d := schema.TestResourceDataRaw(t, r.Schema, raw)
+
+			service, err := generateFortinetRequest(d, mockClient)
+			require.NoError(t, err, "generateFortinetRequest should not return error")
+			assert.ElementsMatch(t, tt.expected, service.AllowList)
+		})
+	}
+}
+
+// TestAlkiraServiceFortinetAllowListRead confirms resourceFortinetRead
+// populates allow_list from the API response with no resulting diff.
+func TestAlkiraServiceFortinetAllowListRead(t *testing.T) {
+	allowList := []string{"10.0.0.0/24", "10.0.0.5"}
+
+	client := createMockAlkiraClient(t, func(w http.ResponseWriter, req *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(alkira.ServiceFortinet{
+			Id:        json.Number("1"),
+			Name:      "test-fortinet-service",
+			AllowList: allowList,
+		})
+	})
+
+	r := resourceAlkiraServiceFortinet()
+	d := r.TestResourceData()
+	d.SetId("1")
+
+	// Assert on the full diagnostics: a failed GET surfaces as a *Warning*
+	// here, which HasError() would not catch.
+	diags := resourceFortinetRead(context.Background(), d, client)
+	require.Empty(t, diags, "resourceFortinetRead should return no diagnostics")
+
+	got := convertTypeSetToStringList(d.Get("allow_list").(*schema.Set))
+	assert.ElementsMatch(t, allowList, got, "allow_list should round-trip from the API response")
+}

--- a/docs/resources/service_fortinet.md
+++ b/docs/resources/service_fortinet.md
@@ -65,6 +65,7 @@ resource "alkira_service_fortinet" "test1" {
 
 ### Optional
 
+- `allow_list` (Set of String) Management-access allow-list of IPv4 CIDRs or IP addresses. When set, only these sources can reach the management interface of the service instances.
 - `auto_scale` (String) Whether enable auto scale for Fortinet firewall. It could be either `ON` and `OFF`. Default value is `OFF`.
 - `billing_tag_ids` (Set of Number) IDs of billing tags to associate with the service.
 - `description` (String) The description of the service.


### PR DESCRIPTION
## Summary

Adds an optional `allow_list` attribute to `alkira_service_fortinet`, whitelisting source IPs/CIDRs that may reach the firewall's management surface. Part of AK-70969 (self-service mgmt-access allow-list across all third-party SD-WANs and firewalls), following the same shape as the five merged connector resources and #758 (AK-71054, `alkira_service_pan`).

`ServiceFortinet.AllowList` (`json:"allowList,omitempty"`) from AK-71036 is already vendored, so no re-vendor is needed here.

## Changes

- **`alkira/resource_alkira_service_fortinet.go`** — `allow_list` schema attribute (`TypeSet`, `Optional`, String elem with per-element validation); `d.Set("allow_list", f.AllowList)` in `resourceFortinetRead`.
- **`alkira/resource_alkira_service_fortinet_helper.go`** — `AllowList: convertTypeSetToStringList(...)` in `generateFortinetRequest` (Set path, not `convertTypeListToStringList`, which would panic on a Set).
- **`alkira/resource_alkira_service_fortinet_test.go`** — table-driven unit tests (below).
- **`docs/resources/service_fortinet.md`** — new attribute line.

**No type-gate.** Fortinet FW is single-mode and not sub-scoped, so unlike Cisco cat8k there is no `CAT8000V`-style gate to add. The resource's existing `CustomizeDiff` closure is unchanged.

## Two deviations from the ticket — please review

Both are identical to #758, so a decision there applies here too.

**1. Validator is `validateIPv4CidrOrIP`, not `validation.IsCIDR`.**

The ticket says to use `validation.IsCIDR` "matching the Cisco cat8k allow_list already on dev" — but cat8k on `dev` actually uses `validateIPv4CidrOrIP`, and that helper was hoisted into `alkira/helper.go` in d59a526d precisely so the sibling tickets could share it. All five merged siblings (aruba, versa, vmware, juniper, prisma) use it.

It is also closer to the backend contract, which is IPv4-only and requires the network address:

| input | `validateIPv4CidrOrIP` | `validation.IsCIDR` |
|---|---|---|
| `10.0.0.5` (bare IP) | accepted | **rejected** |
| `2001:db8::/32` | rejected | **accepted** |
| `10.0.0.5/24` (host bits set) | rejected | **accepted** |

Using `IsCIDR` would make the two firewall resources inconsistent with the six connectors. Happy to switch if the ticket's wording was deliberate.

**2. The doc change is the single generated line, not a full `tfplugindocs` run.**

`make doc` regenerates the entire docs tree: ~80 unrelated files rewritten plus deletion of `docs/guides/release-notes-v1.4.3.md` and `v1.4.4.md`. I kept only the `allow_list` line, matching the 1-line doc diff in each sibling PR, and verified it by re-running `make doc` and diffing — byte-identical to the generator's output for this attribute.

## Pre-existing issue found (out of scope)

Regenerating showed `docs/resources/service_fortinet.md` on `dev` is also missing **`alkira_admin_password`** — it exists in the schema (and is `Sensitive`) but was never regenerated into the docs. Same class of drift as the `scm_*` attributes I flagged on `service_pan.md` in #758; worth folding both into one docs-sync follow-up.

## Testing

Table-driven unit tests using testify + `schema.TestResourceDataRaw` / `schema.NewSet`, no live backend (the repo has no enabled acceptance suite — `testAccPreCheck` is commented out in `provider_test.go`):

- `TestAlkiraServiceFortinetAllowListSchema` — asserts `TypeSet`, `Optional`, String `Elem` carrying a `ValidateFunc`.
- `TestAlkiraServiceFortinetAllowListValidator` — accepts IPv4 CIDRs and bare IPv4; rejects malformed, out-of-range, IPv6, IPv4-mapped-IPv6, and host-bits-set CIDRs.
- `TestAlkiraServiceFortinetAllowListExpand` — populated set, duplicate collapsing, and empty set (no panic, no entries).
- `TestAlkiraServiceFortinetAllowListGenerateRequest` — drives the real `generateFortinetRequest` path via `schema.TestResourceDataRaw` and asserts `AllowList` on the resulting `ServiceFortinet`, across populated / absent / explicitly-empty (absent and empty both yield no entries, so `omitempty` drops the field). Uses a mock client for the management-server segment lookup and a pre-set instance `credential_id` to avoid credential creation.
- `TestAlkiraServiceFortinetAllowListRead` — `resourceFortinetRead` against a mock client round-trips `allow_list` from the API response.

Note: the pre-existing `TestFortinetRead` in this file is `t.Skip`-ped ("mock server response format doesn't match API client expectations"). My read test does not depend on that path — it exercises `resourceFortinetRead` with a `ManagementServer`-less payload, so it runs for real rather than being skipped.

Verified locally:

- `go build ./...` — clean
- `go vet ./alkira/` — clean
- `gofmt -l alkira/` — no output
- `go test ./alkira/ -count=1` — **full package suite passes** (105s), no regressions

`golangci-lint` is not installed on this machine, so the repo lint target was not run — CI will cover it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)