### PR TITLE
AK-71060: add allow_list to alkira_service_checkpoint

### DIFF
--- a/alkira/resource_alkira_service_checkpoint.go
+++ b/alkira/resource_alkira_service_checkpoint.go
@@ -34,6 +34,17 @@ func resourceAlkiraCheckpoint() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
+			"allow_list": {
+				Description: "Management-access allow-list of IPv4 CIDRs or " +
+					"IP addresses. When set, only these sources can reach " +
+					"the management interface of the service instances.",
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem: &schema.Schema{
+					Type:         schema.TypeString,
+					ValidateFunc: validateIPv4CidrOrIP,
+				},
+			},
 			"auto_scale": {
 				Description: "Indicate if `auto_scale` should be enabled " +
 					"for your checkpoint firewall. `ON` and `OFF` are " +
@@ -374,6 +385,7 @@ func resourceCheckpointRead(ctx context.Context, d *schema.ResourceData, m inter
 		return diag.FromErr(fmt.Errorf("failed to find segment"))
 	}
 
+	d.Set("allow_list", checkpoint.AllowList)
 	d.Set("auto_scale", checkpoint.AutoScale)
 	d.Set("billing_tag_ids", checkpoint.BillingTags)
 	d.Set("credential_id", checkpoint.CredentialId)

--- a/alkira/resource_alkira_service_checkpoint_helper.go
+++ b/alkira/resource_alkira_service_checkpoint_helper.go
@@ -309,6 +309,7 @@ func generateCheckpointRequest(d *schema.ResourceData, m interface{}) (*alkira.S
 
 	// Assemble request
 	return &alkira.ServiceCheckpoint{
+		AllowList:        convertTypeSetToStringList(d.Get("allow_list").(*schema.Set)),
 		AutoScale:        d.Get("auto_scale").(string),
 		BillingTags:      convertTypeSetToIntList(d.Get("billing_tag_ids").(*schema.Set)),
 		CredentialId:     d.Get("credential_id").(string),

--- a/alkira/resource_alkira_service_checkpoint_test.go
+++ b/alkira/resource_alkira_service_checkpoint_test.go
@@ -1,7 +1,16 @@
 package alkira
 
 import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"strings"
 	"testing"
+
+	"github.com/alkiranet/alkira-client-go/alkira"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestCheckpointRead(t *testing.T) {
@@ -32,3 +41,174 @@ func TestCheckpointRead(t *testing.T) {
 // 		w.Header().Set("Content-Type", "application/json")
 // 	})
 // }
+
+// newCheckpointAllowListMockClient returns a client whose mock routes by URL
+// path: segment lookups get a segment, everything else (e.g. instance
+// credential creation) gets an ID payload.
+func newCheckpointAllowListMockClient(t *testing.T, service *alkira.ServiceCheckpoint) *alkira.AlkiraClient {
+	return createMockAlkiraClient(t, func(w http.ResponseWriter, req *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		segment := alkira.Segment{Id: json.Number("1"), Name: "test-segment"}
+
+		switch {
+		// Lookup by name returns a list; lookup by ID returns one object.
+		case strings.Contains(req.URL.Path, "segments") && req.URL.Query().Get("name") != "":
+			json.NewEncoder(w).Encode([]alkira.Segment{segment})
+		case strings.Contains(req.URL.Path, "segments"):
+			json.NewEncoder(w).Encode(segment)
+		case service != nil && strings.Contains(req.URL.Path, "chkp-fw-services"):
+			json.NewEncoder(w).Encode(service)
+		default:
+			w.Write([]byte(`{"id": "credential-123"}`))
+		}
+	})
+}
+
+func TestAlkiraServiceCheckpointAllowListSchema(t *testing.T) {
+	resourceSchema := resourceAlkiraCheckpoint().Schema
+
+	t.Run("field exists and is Optional TypeSet of String", func(t *testing.T) {
+		field, ok := resourceSchema["allow_list"]
+		require.True(t, ok, "allow_list must be present in schema")
+		assert.Equal(t, schema.TypeSet, field.Type)
+		assert.True(t, field.Optional)
+		assert.False(t, field.Required)
+
+		elem, ok := field.Elem.(*schema.Schema)
+		require.True(t, ok, "allow_list Elem must be a *schema.Schema")
+		assert.Equal(t, schema.TypeString, elem.Type)
+		assert.NotNil(t, elem.ValidateFunc, "allow_list elements must be validated")
+	})
+}
+
+func TestAlkiraServiceCheckpointAllowListValidator(t *testing.T) {
+	validate := resourceAlkiraCheckpoint().Schema["allow_list"].Elem.(*schema.Schema).ValidateFunc
+
+	valid := []string{"10.0.0.0/24", "192.168.1.0/24", "10.0.0.5", "10.0.0.5/32"}
+	for _, v := range valid {
+		_, errs := validate(v, "allow_list")
+		assert.Emptyf(t, errs, "expected %q to be accepted (IPv4 CIDR or IPv4 IP)", v)
+	}
+
+	invalid := []string{"not-an-ip", "10.0.0.0/33", "999.0.0.1", "2001:db8::/32", "::1", "::ffff:1.2.3.4", "10.0.0.5/24"}
+	for _, v := range invalid {
+		_, errs := validate(v, "allow_list")
+		assert.NotEmptyf(t, errs, "expected %q to be rejected", v)
+	}
+}
+
+func TestAlkiraServiceCheckpointAllowListExpand(t *testing.T) {
+	tests := []struct {
+		name     string
+		elements []interface{}
+		expected []string
+	}{
+		{
+			name:     "populated set",
+			elements: []interface{}{"10.0.0.0/24", "10.0.0.5"},
+			expected: []string{"10.0.0.0/24", "10.0.0.5"},
+		},
+		{
+			name:     "duplicates collapse",
+			elements: []interface{}{"10.0.0.0/24", "10.0.0.5", "10.0.0.0/24"},
+			expected: []string{"10.0.0.0/24", "10.0.0.5"},
+		},
+		{
+			name:     "empty set produces no entries",
+			elements: []interface{}{},
+			expected: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := convertTypeSetToStringList(schema.NewSet(schema.HashString, tt.elements))
+			assert.ElementsMatch(t, tt.expected, got)
+		})
+	}
+}
+
+// TestAlkiraServiceCheckpointAllowListGenerateRequest drives the real
+// generateCheckpointRequest path to confirm allow_list lands on the request
+// payload via the Set helper, and that an absent allow_list is omitted.
+func TestAlkiraServiceCheckpointAllowListGenerateRequest(t *testing.T) {
+	mockClient := newCheckpointAllowListMockClient(t, nil)
+
+	// generateCheckpointRequest requires at least one instance and resolves
+	// the segment by ID.
+	instance := []interface{}{
+		map[string]interface{}{
+			"name":    "checkpoint-instance-1",
+			"sic_key": "test-sic-key",
+		},
+	}
+
+	tests := []struct {
+		name      string
+		allowList interface{}
+		expected  []string
+	}{
+		{
+			name:      "populated allow_list",
+			allowList: []interface{}{"10.0.0.0/24", "10.0.0.5"},
+			expected:  []string{"10.0.0.0/24", "10.0.0.5"},
+		},
+		{
+			name:      "allow_list absent",
+			allowList: nil,
+			expected:  nil,
+		},
+		{
+			name:      "allow_list explicitly empty",
+			allowList: []interface{}{},
+			expected:  nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			raw := map[string]interface{}{
+				"instance":   instance,
+				"segment_id": "1",
+			}
+			if tt.allowList != nil {
+				raw["allow_list"] = tt.allowList
+			}
+
+			r := resourceAlkiraCheckpoint()
+			d := schema.TestResourceDataRaw(t, r.Schema, raw)
+
+			service, err := generateCheckpointRequest(d, mockClient)
+			require.NoError(t, err, "generateCheckpointRequest should not return error")
+			assert.ElementsMatch(t, tt.expected, service.AllowList)
+		})
+	}
+}
+
+// TestAlkiraServiceCheckpointAllowListRead confirms resourceCheckpointRead
+// populates allow_list from the API response with no resulting diff.
+func TestAlkiraServiceCheckpointAllowListRead(t *testing.T) {
+	allowList := []string{"10.0.0.0/24", "10.0.0.5"}
+
+	// resourceCheckpointRead requires exactly one segment on the response.
+	client := newCheckpointAllowListMockClient(t, &alkira.ServiceCheckpoint{
+		Id:        json.Number("1"),
+		Name:      "test-checkpoint-service",
+		AllowList: allowList,
+		Segments:  []string{"test-segment"},
+	})
+
+	r := resourceAlkiraCheckpoint()
+	d := r.TestResourceData()
+	d.SetId("1")
+
+	// Assert on the full diagnostics: a failed GET surfaces as a *Warning*
+	// here, which HasError() would not catch.
+	diags := resourceCheckpointRead(context.Background(), d, client)
+	require.Empty(t, diags, "resourceCheckpointRead should return no diagnostics")
+
+	got := convertTypeSetToStringList(d.Get("allow_list").(*schema.Set))
+	assert.ElementsMatch(t, allowList, got, "allow_list should round-trip from the API response")
+}

--- a/docs/resources/service_checkpoint.md
+++ b/docs/resources/service_checkpoint.md
@@ -78,6 +78,7 @@ resource "alkira_service_checkpoint" "test" {
 
 ### Optional
 
+- `allow_list` (Set of String) Management-access allow-list of IPv4 CIDRs or IP addresses. When set, only these sources can reach the management interface of the service instances.
 - `auto_scale` (String) Indicate if `auto_scale` should be enabled for your checkpoint firewall. `ON` and `OFF` are accepted values. `OFF` is the default if field is omitted
 - `billing_tag_ids` (Set of Number) Billing tags to be associated with the resource. (see resource `alkira_billing_tag`).
 - `description` (String) The description of the checkpoint service.


### PR DESCRIPTION
## Summary

Adds an optional `allow_list` attribute to `alkira_service_checkpoint`, whitelisting source IPs/CIDRs that may reach the firewall's management surface. Part of AK-70969, following the same shape as the five merged connector resources, #758 (`alkira_service_pan`) and #759 (`alkira_service_fortinet`).

`ServiceCheckpoint.AllowList` (`json:"allowList,omitempty"`) from AK-71036 is already vendored, so no re-vendor is needed here.

## Changes

- **`alkira/resource_alkira_service_checkpoint.go`** — `allow_list` schema attribute (`TypeSet`, `Optional`, String elem with per-element validation); `d.Set("allow_list", checkpoint.AllowList)` in `resourceCheckpointRead`.
- **`alkira/resource_alkira_service_checkpoint_helper.go`** — `AllowList: convertTypeSetToStringList(...)` in `generateCheckpointRequest` (Set path, not `convertTypeListToStringList`, which would panic on a Set).
- **`alkira/resource_alkira_service_checkpoint_test.go`** — table-driven unit tests (below).
- **`docs/resources/service_checkpoint.md`** — new attribute line.

**No type-gate.** Check Point FW is single-mode and not sub-scoped, so unlike Cisco cat8k there is no `CAT8000V`-style gate to add. The resource's existing `CustomizeDiff` closure is unchanged.

## Two deviations from the ticket — please review

Both are identical to #758 and #759, so one decision covers all three.

**1. Validator is `validateIPv4CidrOrIP`, not `validation.IsCIDR`.**

The ticket says to use `validation.IsCIDR` "matching the Cisco cat8k allow_list already on dev" — but cat8k on `dev` actually uses `validateIPv4CidrOrIP`, and that helper was hoisted into `alkira/helper.go` in d59a526d precisely so the sibling tickets could share it. All five merged siblings use it.

It is also closer to the backend contract, which is IPv4-only and requires the network address:

| input | `validateIPv4CidrOrIP` | `validation.IsCIDR` |
|---|---|---|
| `10.0.0.5` (bare IP) | accepted | **rejected** |
| `2001:db8::/32` | rejected | **accepted** |
| `10.0.0.5/24` (host bits set) | rejected | **accepted** |

**2. The doc change is the single generated line, not a full `tfplugindocs` run.**

`make doc` regenerates the entire docs tree: ~80 unrelated files rewritten plus deletion of two release-notes guides. I kept only the `allow_list` line, matching the sibling PRs, and verified it by re-running `make doc` and diffing — byte-identical to the generator's output for this attribute.

## Testing

Table-driven unit tests using testify + `schema.TestResourceDataRaw` / `schema.NewSet`, no live backend:

- `TestAlkiraServiceCheckpointAllowListSchema` — asserts `TypeSet`, `Optional`, String `Elem` carrying a `ValidateFunc`.
- `TestAlkiraServiceCheckpointAllowListValidator` — accepts IPv4 CIDRs and bare IPv4; rejects malformed, out-of-range, IPv6, IPv4-mapped-IPv6, and host-bits-set CIDRs.
- `TestAlkiraServiceCheckpointAllowListExpand` — populated set, duplicate collapsing, and empty set (no panic, no entries).
- `TestAlkiraServiceCheckpointAllowListGenerateRequest` — drives the real `generateCheckpointRequest` path and asserts `AllowList` on the resulting `ServiceCheckpoint`, across populated / absent / explicitly-empty.
- `TestAlkiraServiceCheckpointAllowListRead` — `resourceCheckpointRead` against a mock client round-trips `allow_list` from the API response.

### Note on the read test — worth a look

Two traps here that are easy to get wrong, and both are why the pre-existing `TestCheckpointRead` in this file is `t.Skip`-ped ("mock server response format doesn't match API client expectations"):

1. **`resourceCheckpointRead` reports a failed GET as a `diag.Warning`, not an error.** A test asserting `require.False(diags.HasError())` therefore passes even when nothing was fetched and every `d.Set` was skipped. This test asserts the diagnostics are *empty* instead, which is what caught the second problem.
2. **Segment lookup by name unmarshals into `[]alkira.Segment`, but lookup by ID unmarshals into a single object.** The mock routes on the `name=` query parameter and returns the right shape for each. It also returns exactly one segment, since `resourceCheckpointRead` hard-fails on any other count.

The mock additionally serves instance-credential creation, so `generateCheckpointRequest` runs without a live backend.

Verified locally:

- `go build ./...` — clean
- `go vet ./alkira/` — clean
- `gofmt -l alkira/` — no output
- `go test ./alkira/ -count=1` — **full package suite passes** (105s), no regressions

`golangci-lint` is not installed on this machine, so the repo lint target was not run — CI will cover it (it passed on #758 and #759).

## Pre-existing docs drift (out of scope, now seen on all three)

Regenerating showed `docs/resources/service_checkpoint.md` on `dev` also documents `management_server` as `Block Set, Min: 1` when the schema now says `Block List, Min: 1, Max: 1`. That is the third instance of stale docs in this family — `service_pan.md` is missing `routing_type`/`scm_enabled`/`scm_folder`, `service_fortinet.md` is missing `alkira_admin_password`. Worth one docs-sync ticket covering all three.

🤖 Generated with [Claude Code](https://claude.com/claude-code)