### PR TITLE
[CLONE-67] AK-71599 - document 20/30/40/50LARGE for GCP Interconnect size

### DIFF
--- a/alkira/resource_alkira_connector_gcp_interconnect.go
+++ b/alkira/resource_alkira_connector_gcp_interconnect.go
@@ -42,7 +42,8 @@ func resourceAlkiraConnectorGcpInterconnect() *schema.Resource {
 			},
 			"size": {
 				Description: "The size of the connector, one of `SMALL`, " +
-					"`MEDIUM`, `LARGE`, `2LARGE`, `5LARGE` or `10LARGE`.",
+					"`MEDIUM`, `LARGE`, `2LARGE`, `5LARGE`, `10LARGE`, `20LARGE`, " +
+					"`30LARGE`, `40LARGE` or `50LARGE`.",
 				Type:     schema.TypeString,
 				Required: true,
 			},

--- a/docs/resources/connector_gcp_interconnect.md
+++ b/docs/resources/connector_gcp_interconnect.md
@@ -126,7 +126,7 @@ resource "alkira_connector_gcp_interconnect" "example_gcp_interconnect_2" {
 - `instances` (Block List, Min: 1) A list of instances of the InterConnect (see [below for nested schema](#nestedblock--instances))
 - `loopback_prefixes` (Set of String) A list of prefixes that should be associated with the connector. Eg :["10.30.0.0/24"]
 - `name` (String) The name of the connector.
-- `size` (String) The size of the connector, one of `SMALL`, `MEDIUM`, `LARGE`, `2LARGE`, `5LARGE` or `10LARGE`.
+- `size` (String) The size of the connector, one of `SMALL`, `MEDIUM`, `LARGE`, `2LARGE`, `5LARGE`, `10LARGE`, `20LARGE`, `30LARGE`, `40LARGE` or `50LARGE`.
 - `tunnel_protocol` (String) The tunnel protocol used by the connector.Can be one of `GRE`, `IPSEC`, `VXLAN`, or `VXLAN_GPE`.
 
 ### Optional


### PR DESCRIPTION
Cherry-pick of PR #755 for REL 67 release.

**Original Issue:** AK-71449
**Clone for REL 67:** AK-71599
**Parent story:** AK-71444

## Summary
Updates the GCP Interconnect `size` description and the generated resource doc to list all ten sizes.

## Changes
- `alkira/resource_alkira_connector_gcp_interconnect.go` — `size` `Description`
- `docs/resources/connector_gcp_interconnect.md` — regenerated

## Documentation only
`size` is a plain `schema.TypeString` with **no `ValidateFunc`** — sizes are validated server-side. No schema change, no `ForceNew` change, no state migration. A new size already applies on older provider releases because nothing client-side rejects it, so this carries no functional risk and no ordering dependency on the other clones.

## Verification on this branch
- Cherry-pick applied cleanly, no conflicts
- `go build ./...` clean
- Description and generated doc agree

## Original PR
#755

## Cherry-picked Commit(s)
- 5a8b1aa8