### PR TITLE
AK-72272: stop exposing production portal credentials to pre-review PR builds

### DIFF
--- a/.github/workflows/acceptance-preprod.yml
+++ b/.github/workflows/acceptance-preprod.yml
@@ -2,11 +2,10 @@ name: acceptance-test-preprod
 
 on:
   workflow_dispatch:
-  pull_request:
-    branches:
-      - main
-      - dev
-      - 'release/*'
+  # NOTE: deliberately no `pull_request:` trigger. This workflow exports live
+  # preprod portal credentials at workflow scope and then builds and runs the
+  # checked-out code, so a `pull_request` run would hand those secrets to
+  # unreviewed code. Use `workflow_dispatch` to run acceptance on a branch.
   push:
     branches:
       - main

--- a/.github/workflows/acceptance-prod.yml
+++ b/.github/workflows/acceptance-prod.yml
@@ -2,11 +2,10 @@ name: acceptance-test-prod
 
 on:
   workflow_dispatch:
-  pull_request:
-    branches:
-      - main
-      - dev
-      - 'release/*'
+  # NOTE: deliberately no `pull_request:` trigger. This workflow exports live
+  # production portal credentials at workflow scope and then builds and runs
+  # the checked-out code, so a `pull_request` run would hand those secrets to
+  # unreviewed code. Use `workflow_dispatch` to run acceptance on a branch.
   push:
     branches:
       - main


### PR DESCRIPTION
Story: AK-73369
Closes AK-72272

## What was wrong

`.github/workflows/acceptance-prod.yml` and `.github/workflows/acceptance-preprod.yml` both:

1. triggered on `pull_request` to `main`, `dev` and `release/*`,
2. exported `ALKIRA_PORTAL` / `ALKIRA_USERNAME` / `ALKIRA_PASSWORD` from the `PROD_TERRAFORM_*` and `PREPROD_TERRAFORM_*` secrets at **workflow** scope, with no `environment:` gate, then
3. ran `make` and `terraform apply --auto-approve` on the PR's **own checked-out code**.

So any pull request could read those live portal credentials — a one-line change to the Makefile is enough to print or exfiltrate them — and could mutate the production tenant, all before a reviewer saw the diff.

**Accurate scoping for review:** GitHub does not expose secrets to `pull_request` runs from forks, so this was never an anonymous-internet issue; the actor had to already have push access to open a branch PR. It is an insider / compromised-account exposure of live production credentials, plus an availability risk from unreviewed provider code applying against prod. That is why it is still worth closing.

## What changed

Removed the `pull_request:` trigger block from both workflows. `push:` to `main`/`dev`/`release/*` and `workflow_dispatch:` are unchanged, so:

- acceptance still runs on every merge to a protected branch (code that has been reviewed), and
- anyone who wants acceptance coverage on a branch can still get it via `workflow_dispatch`, as a deliberate act.

Nothing else in the workflows was touched.

## Backward compatibility

Backward-compatible. CI configuration only — no provider code, no schema, no state, no product behaviour.

Verified rather than assumed: neither `main` nor any repository ruleset requires an acceptance-test status check (`gh api repos/alkiranet/terraform-provider-alkira/rules/branches/main` returns `[]`, and there is no branch-protection object on `main`), so removing the trigger cannot leave a PR blocked waiting on a check that will never report.

## Deliberately not done here

- **No protected `environment:` added.** If the team does want acceptance on every PR, the idiomatic GitHub control is a protected `environment:` with required reviewers on the job, which holds the run until a human approves before secrets are injected. That is a repo-settings change as well as a workflow change, so it belongs in a follow-up rather than being half-implemented here. Either approach is fine; please do not add a bespoke gate.
- **Secrets left at workflow scope.** Scoping the `env:` block to the apply/destroy steps so the build step never sees them is worth doing, but each of these workflows has exactly one job, so it buys little today and would enlarge this diff.
- **Credentials not rotated.** These prod/preprod portal credentials have been reachable from every PR build for as long as the trigger has existed. Treat them as exposed and rotate them separately — this PR does not do that, and merging it does not make an already-leaked credential safe.
- **No move to a short-lived scoped API key.** The provider already prefers `api_key` and deprecates `password`; CI has not followed. Separate ticket.

## Release

CI-only, no user-visible provider change, but flagging it for the `review-terraform-release-notes` go/no-go anyway since it changes what runs before a release is cut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)