### PR TITLE
Set direction in alkira_policy_nat_rule Read

### DIFF
--- a/alkira/resource_alkira_policy_nat_rule.go
+++ b/alkira/resource_alkira_policy_nat_rule.go
@@ -329,6 +329,12 @@ func resourcePolicyNatRuleRead(ctx context.Context, d *schema.ResourceData, m in
 	d.Set("enabled", rule.Enabled)
 	d.Set("category", rule.Category)
 
+	// "direction" is sent on create and update and returned by the API, so it
+	// must be read back here. "terraform import" populates state from Read
+	// alone, and a field left unset lands as null and shows up as a spurious
+	// diff on the next plan.
+	d.Set("direction", rule.Direction)
+
 	setNatRuleActionOptions(rule.Action, d)
 	setNatRuleMatch(rule.Match, d)
 

--- a/alkira/resource_alkira_policy_nat_rule_test.go
+++ b/alkira/resource_alkira_policy_nat_rule_test.go
@@ -1,0 +1,85 @@
+package alkira
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/alkiranet/alkira-client-go/alkira"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// readNatRule drives the real Read function against a mock API returning the
+// given rule and hands back the resulting resource data.
+func readNatRule(t *testing.T, rule *alkira.NatPolicyRule) *schema.ResourceData {
+	t.Helper()
+
+	client := serveMockServer(t, rule, http.StatusOK)
+
+	d := resourceAlkiraPolicyNatRule().TestResourceData()
+	d.SetId("123")
+
+	diags := resourcePolicyNatRuleRead(context.Background(), d, client)
+	require.False(t, diags.HasError(), "Read should succeed: %v", diags)
+
+	return d
+}
+
+// Read must persist "direction". The field is sent on create and update but
+// was never read back, so "terraform import alkira_policy_nat_rule" left it
+// null in state and the next plan showed a spurious
+// "+ direction = INBOUND".
+func TestPolicyNatRuleReadSetsDirection(t *testing.T) {
+	newRule := func(direction string) *alkira.NatPolicyRule {
+		return &alkira.NatPolicyRule{
+			Name:        "nat-rule-1",
+			Description: "nat rule under test",
+			Enabled:     true,
+			Category:    "DEFAULT",
+			Direction:   direction,
+			Match: alkira.NatRuleMatch{
+				SourcePrefixes: []string{"10.0.0.0/8"},
+				DestPrefixes:   []string{"192.168.0.0/16"},
+				Protocol:       "any",
+			},
+		}
+	}
+
+	t.Run("INBOUND is written to state", func(t *testing.T) {
+		d := readNatRule(t, newRule("INBOUND"))
+
+		assert.Equal(t, "INBOUND", d.Get("direction"),
+			"Read must persist direction, otherwise import leaves it null")
+	})
+
+	t.Run("OUTBOUND is written to state", func(t *testing.T) {
+		d := readNatRule(t, newRule("OUTBOUND"))
+
+		assert.Equal(t, "OUTBOUND", d.Get("direction"))
+	})
+
+	t.Run("direction omitted by the API stays empty", func(t *testing.T) {
+		d := readNatRule(t, newRule(""))
+
+		assert.Equal(t, "", d.Get("direction"),
+			"an API response without direction must not invent a value")
+	})
+
+	t.Run("the other fields Read owns are unaffected", func(t *testing.T) {
+		rule := newRule("INBOUND")
+
+		d := readNatRule(t, rule)
+
+		assert.Equal(t, rule.Name, d.Get("name"))
+		assert.Equal(t, rule.Description, d.Get("description"))
+		assert.Equal(t, rule.Enabled, d.Get("enabled"))
+		assert.Equal(t, rule.Category, d.Get("category"))
+
+		match := d.Get("match").(*schema.Set).List()
+		require.Len(t, match, 1)
+		matchMap := match[0].(map[string]interface{})
+		assert.Equal(t, "any", matchMap["protocol"])
+	})
+}


### PR DESCRIPTION
This PR proposes setting `direction` in the `alkira_policy_nat_rule` Read function, so that `terraform import` and drift detection stop dropping the field. We include this PR work along with a full history of your repo at https://eastagiletracker.com/projects/284. You can sign in with your GitHub ID to claim ownership of the project.

## The defect

`alkira_policy_nat_rule` sends `direction` on create and update — `generatePolicyNatRuleRequest()` reads `d.Get("direction")` — and the API returns it on GET as `NatPolicyRule.Direction`. But `resourcePolicyNatRuleRead()` sets `name`, `description`, `enabled` and `category` and then goes straight to `setNatRuleActionOptions()` / `setNatRuleMatch()`, never writing `direction` back to state.

The resource declares an importer whose `StateContext` is `importWithReadValidation(resourcePolicyNatRuleRead)`, and `docs/resources/policy_nat_rule.md` documents both the `direction` attribute and `terraform import alkira_policy_nat_rule.basic <nat_rule_id>`. Since import populates state from Read alone, `direction` lands null and the next `terraform plan` shows a spurious in-place update. The same gap makes an out-of-band change to `direction` invisible to `plan`, because Read never refreshes the value that would reveal the drift.

This is the same defect class you have been working through elsewhere — `global_tenant_id` in the Versa SD-WAN connector Read (#556), `pan_credential_name` in the PAN service Read (#567), and `inbound_connector_type` in the internet application Read (#763, currently open). `alkira_policy_nat_rule` is an instance that has not been fixed yet.

## Reproducing it on current `main`

The regression test in this PR drives the real `resourcePolicyNatRuleRead()` against your existing `serveMockServer()` helper, returning a rule whose API response carries `"direction":"INBOUND"`. On `main` at `7f84847`, before the fix:

```
$ go test ./alkira/ -run TestPolicyNatRuleReadSetsDirection
--- FAIL: TestPolicyNatRuleReadSetsDirection (0.01s)
    --- FAIL: TestPolicyNatRuleReadSetsDirection/INBOUND_is_written_to_state
            Error:    Not equal:
                      expected: "INBOUND"
                      actual  : ""
            Messages: Read must persist direction, otherwise import leaves it null
    --- FAIL: TestPolicyNatRuleReadSetsDirection/OUTBOUND_is_written_to_state
FAIL
```

## The change

One line in `resourcePolicyNatRuleRead()`, alongside the fields it already sets:

```go
d.Set("direction", rule.Direction)
```

The new test covers `INBOUND`, `OUTBOUND`, the case where the API omits `direction` (it must stay empty rather than acquire an invented value), and asserts that `name`, `description`, `enabled`, `category` and `match` are unaffected. Reverting only the `d.Set` line turns the `INBOUND` and `OUTBOUND` cases red while those two control cases stay green, so the test is pinned to the behaviour and not to the shape of the code.

## Verification

Baseline first: `go build ./...`, `go vet ./alkira/...` and `go test ./alkira/...` were run on an unmodified checkout of `7f84847`, and the suite passed in 105.6s. After the change the same three commands pass, with the suite at 105.3s and the four new subtests green — no new failures against the baseline. `golangci-lint run --new-from-rev` reports `0 issues` with your `.golangci.yml`. Nothing else in the tree was reformatted.

The change is additive and backward compatible: it fills a state field that was previously left null, and touches no schema, no request payload and no API call.

## How this was managed

This work was tracked on a board imported from this repository's own issues and pull requests — 765 stories and 6 labels — with the fix carried by [this story](https://eastagiletracker.com/projects/284/stories/177374) on the [board](https://eastagiletracker.com/projects/284).

![board](https://raw.githubusercontent.com/eastagiletracker/terraform-provider-alkira/agile-board-assets/board.png)

If you'd rather not receive contributions like this, reply `no-more-prs` on this pull request and we won't open any further ones on your repositories.

---

**Lawrence W. Sinclair**
CEO / East Agile
[linkedin.com/in/lwsinclair/](https://linkedin.com/in/lwsinclair/)
[eastagile.com](https://eastagile.com)
